### PR TITLE
fix coordinates in fviz_pca_var()'s circle

### DIFF
--- a/R/fviz.R
+++ b/R/fviz.R
@@ -293,7 +293,8 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   circle <- data.frame(xcircle = cos(theta), ycircle = sin(theta))
   p + 
     geom_path(mapping = aes_string("xcircle", "ycircle"), data = circle, color = color,
-              size = size)
+              size = size) +
+    coord_fixed()
   
 }
 


### PR DESCRIPTION
pca's correlation circles should have fixed coordinates so they don't appear as ellipses.