### PR TITLE
Change condition behavior. Var/ind through select.var/select.ind must…

### DIFF
--- a/R/fviz.R
+++ b/R/fviz.R
@@ -74,7 +74,7 @@ NULL
 #'  values("x") or y values("y"). To use this, make sure that habillage ="none".
 #'@param col.col.sup,col.row.sup colors for the supplementary column and row 
 #'  points, respectively.
-#'@param select a selection of individuals/variables to be drawn. Allowed values
+#'@param select a selection of individuals/variables to be drawn (must match at least one of the conditions). Allowed values
 #'  are NULL or a list containing the arguments name, cos2 or contrib: \itemize{
 #'  \item name: is a character vector containing individuals/variables to be 
 #'  drawn \item cos2: if cos2 is in [0, 1], ex: 0.6, then individuals/variables 

--- a/R/fviz_ca.R
+++ b/R/fviz_ca.R
@@ -50,7 +50,7 @@ NULL
 #'  points, respectively.
 #'@param repel a boolean, whether to use ggrepel to avoid overplotting text 
 #'  labels or not.
-#'@param select.col,select.row a selection of columns/rows to be drawn. Allowed 
+#'@param select.col,select.row a selection of columns/rows to be drawn (must match at least one of the conditions). Allowed 
 #'  values are NULL or a list containing the arguments name, cos2 or contrib: 
 #'  \itemize{ \item name is a character vector containing column/row names to be
 #'  drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, then columns/rows with a 

--- a/R/fviz_famd.R
+++ b/R/fviz_famd.R
@@ -44,7 +44,7 @@ NULL
 #' @param select.ind,select.var a selection of individuals and variables to be 
 #'   drawn. Allowed values are NULL or a list containing the arguments name, 
 #'   cos2 or contrib: \itemize{ \item name is a character vector containing 
-#'   individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
+#'   individuals/variables to be drawn (must match at least one of the conditions). \item cos2 if cos2 is in [0, 1], ex: 0.6,
 #'   then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5,
 #'   then the top 5 individuals/variables with the highest cos2 are drawn. \item
 #'   contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 

--- a/R/fviz_hmfa.R
+++ b/R/fviz_hmfa.R
@@ -43,7 +43,7 @@ NULL
 #'@param select.ind,select.var a selection of individuals and variables to be 
 #'  drawn. Allowed values are NULL or a list containing the arguments name, cos2
 #'  or contrib: \itemize{ \item name is a character vector containing 
-#'  individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, 
+#'  individuals/variables to be drawn (must match at least one of the conditions). \item cos2 if cos2 is in [0, 1], ex: 0.6, 
 #'  then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
 #'  then the top 5 individuals/variables with the highest cos2 are drawn. \item 
 #'  contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 

--- a/R/fviz_mca.R
+++ b/R/fviz_mca.R
@@ -58,7 +58,7 @@ NULL
 #'  dimensions; ii) "var.cat" for variable categories and iii) "quanti.sup" for
 #'  the supplementary quantitative variables.
 #'@param title the title of the graph
-#'@param select.ind,select.var a selection of individuals/variables to be drawn.
+#'@param select.ind,select.var a selection of individuals/variables to be drawn (must match at least one of the conditions).
 #'  Allowed values are NULL or a list containing the arguments name, cos2 or 
 #'  contrib: \itemize{ \item name is a character vector containing 
 #'  individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, 

--- a/R/fviz_mfa.R
+++ b/R/fviz_mfa.R
@@ -48,7 +48,7 @@ NULL
 #'  Default is "black".
 #'@param title the title of the graph
 #'@param select.ind,select.var,select.axes a selection of individuals/partial 
-#'  individuals/ variables/groups/axes to be drawn. Allowed values are NULL or a
+#'  individuals/ variables/groups/axes to be drawn (must match at least one of the conditions). Allowed values are NULL or a
 #'  list containing the arguments name, cos2 or contrib: \itemize{ \item name is
 #'  a character vector containing individuals/variables to be drawn \item cos2 
 #'  if cos2 is in [0, 1], ex: 0.6, then individuals/variables with a cos2 > 0.6 

--- a/R/fviz_pca.R
+++ b/R/fviz_pca.R
@@ -73,7 +73,7 @@
 #' @param select.ind,select.var a selection of individuals/variables to be 
 #'   drawn. Allowed values are NULL or a list containing the arguments name, 
 #'   cos2 or contrib: \itemize{ \item name: is a character vector containing 
-#'   individuals/variables to be drawn \item cos2: if cos2 is in [0, 1], ex: 
+#'   individuals/variables to be drawn (must match at least one of the conditions). \item cos2: if cos2 is in [0, 1], ex: 
 #'   0.6, then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, 
 #'   ex: 5, then the top 5 individuals/variables with the highest cos2 are 
 #'   drawn. \item contrib: if contrib > 1, ex: 5,  then the top 5 

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -107,7 +107,7 @@ values include brewer and ggsci color palettes.}
 \item{col.col.sup, col.row.sup}{colors for the supplementary column and row 
 points, respectively.}
 
-\item{select}{a selection of individuals/variables to be drawn. Allowed values
+\item{select}{a selection of individuals/variables to be drawn (must match at least one of the conditions). Allowed values
 are NULL or a list containing the arguments name, cos2 or contrib: \itemize{
 \item name: is a character vector containing individuals/variables to be 
 drawn \item cos2: if cos2 is in [0, 1], ex: 0.6, then individuals/variables 

--- a/man/fviz_ca.Rd
+++ b/man/fviz_ca.Rd
@@ -70,7 +70,7 @@ variate from 0 (total transparency) to 1 (no transparency). Default value is
 1. Allowed values include also : "cos2", "contrib", "coord", "x" or "y" as 
 for the arguments col.col and col.row.}
 
-\item{select.col, select.row}{a selection of columns/rows to be drawn. Allowed 
+\item{select.col, select.row}{a selection of columns/rows to be drawn (must match at least one of the conditions). Allowed 
 values are NULL or a list containing the arguments name, cos2 or contrib: 
 \itemize{ \item name is a character vector containing column/row names to be
 drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, then columns/rows with a 

--- a/man/fviz_famd.Rd
+++ b/man/fviz_famd.Rd
@@ -81,7 +81,7 @@ Default is "black".}
 \item{select.ind, select.var}{a selection of individuals and variables to be 
 drawn. Allowed values are NULL or a list containing the arguments name, 
 cos2 or contrib: \itemize{ \item name is a character vector containing 
-individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
+individuals/variables to be drawn (must match at least one of the conditions). \item cos2 if cos2 is in [0, 1], ex: 0.6,
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5,
 then the top 5 individuals/variables with the highest cos2 are drawn. \item
 contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 

--- a/man/fviz_hmfa.Rd
+++ b/man/fviz_hmfa.Rd
@@ -75,7 +75,7 @@ habillage ="none".}
 \item{select.ind, select.var}{a selection of individuals and variables to be 
 drawn. Allowed values are NULL or a list containing the arguments name, cos2
 or contrib: \itemize{ \item name is a character vector containing 
-individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, 
+individuals/variables to be drawn (must match at least one of the conditions). \item cos2 if cos2 is in [0, 1], ex: 0.6, 
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
 then the top 5 individuals/variables with the highest cos2 are drawn. \item 
 contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 

--- a/man/fviz_mca.Rd
+++ b/man/fviz_mca.Rd
@@ -91,7 +91,7 @@ habillage ="none".}
 "symmetric", "rowprincipal", "colprincipal", "symbiplot", "rowgab", 
 "colgab", "rowgreen" and "colgreen". See details}
 
-\item{select.ind, select.var}{a selection of individuals/variables to be drawn.
+\item{select.ind, select.var}{a selection of individuals/variables to be drawn (must match at least one of the conditions).
 Allowed values are NULL or a list containing the arguments name, cos2 or 
 contrib: \itemize{ \item name is a character vector containing 
 individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, 

--- a/man/fviz_mfa.Rd
+++ b/man/fviz_mfa.Rd
@@ -91,7 +91,7 @@ axes}
 Default is "black".}
 
 \item{select.ind, select.var, select.axes}{a selection of individuals/partial 
-individuals/ variables/groups/axes to be drawn. Allowed values are NULL or a
+individuals/ variables/groups/axes to be drawn (must match at least one of the conditions). Allowed values are NULL or a
 list containing the arguments name, cos2 or contrib: \itemize{ \item name is
 a character vector containing individuals/variables to be drawn \item cos2 
 if cos2 is in [0, 1], ex: 0.6, then individuals/variables with a cos2 > 0.6 

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -95,7 +95,7 @@ this, make sure that habillage ="none".}
 \item{select.ind, select.var}{a selection of individuals/variables to be 
 drawn. Allowed values are NULL or a list containing the arguments name, 
 cos2 or contrib: \itemize{ \item name: is a character vector containing 
-individuals/variables to be drawn \item cos2: if cos2 is in [0, 1], ex: 
+individuals/variables to be drawn (must match at least one of the conditions). \item cos2: if cos2 is in [0, 1], ex: 
 0.6, then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, 
 ex: 5, then the top 5 individuals/variables with the highest cos2 are 
 drawn. \item contrib: if contrib > 1, ex: 5,  then the top 5 


### PR DESCRIPTION
Hello,

At the moment we can use `select.var` or `select.ind` with one of the condition `name`, `cos2` or `contrib`.
  
I suggest to modify a bit this behavior. Being able to use several of these conditions for example :  

* select var with cos2>0.8
* select var with name = c("VAR1", "VAR2")

This can be great when we know that `VAR1` & `VAR2` don't have cos2 > 0.8  

(possible to play with all the 3 conditions at the same time)