### PR TITLE
Added formal error handling for partition objects without data

### DIFF
--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -133,7 +133,11 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
   
   
   # object from cluster package
-  if(inherits(object, c("partition", "hkmeans", "eclust"))) data <- object$data
+  if(inherits(object, c("partition", "hkmeans", "eclust")) & !is.null(object$data)) data <- object$data
+  # Object from partition and is missing data (E.g. distance matrix was used in the original calculation)
+  else if(inherits(object, "partition")){
+    if(is.null(data)) stop("data is required for plotting partition clusters")
+  }
   # Object from kmeans (stats package)
   else if((inherits(object, "kmeans") & !inherits(object, "eclust"))| inherits(object, "dbscan")){
     if(is.null(data)) stop("data is required for plotting kmeans/dbscan clusters")


### PR DESCRIPTION
I added an error message for users who pass partition class objects into `fviz_cluster` without a data component. This can occur when a user employs one of the cluster functions (e.g. `pam`) with a distance matrix pre-calculated rather than using the original data matrix. 

Here's a sample use case.

```
library(cluster)
library(factoextra)

dat = pam(iris[,-5], 3)
dis = pam(dist(iris[,-5]), 3)

fviz_cluster(dat)

fviz_cluster(dis)

dis2 = dis
dis2$data = iris[,-5]
fviz_cluster(dis2)
```