### PR TITLE
Update fviz_dend docs 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,4 +79,4 @@ Collate:
     'multishapes.R'
     'poison.R'
     'zzz.R'
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -23,7 +23,7 @@
 #' @param repel logical value. Use repel = TRUE to avoid label overplotting when
 #'   type = "phylogenic".
 #' @param lwd a numeric value specifying branches and rectangle line width.
-#' @param type type of plot. Allowed values are one of "rectangle", "triangle", 
+#' @param type type of plot. Allowed values are one of "rectangle",  
 #'   "circular", "phylogenic".
 #' @param phylo_layout the layout to be used for phylogenic trees. Default value
 #'   is "layout.auto". Allowed values include: 

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -64,7 +64,7 @@ type = "phylogenic".}
 
 \item{lwd}{a numeric value specifying branches and rectangle line width.}
 
-\item{type}{type of plot. Allowed values are one of "rectangle", "triangle", 
+\item{type}{type of plot. Allowed values are one of "rectangle",
 "circular", "phylogenic".}
 
 \item{phylo_layout}{the layout to be used for phylogenic trees. Default value


### PR DESCRIPTION
Hi,

Awesome package. This PR updates docs to remove reference to `triangle` as a dendrogram method since triangle is not a valid method.

Cheers,

Nelson 