### PR TITLE
Fix `Condition has length > 1` error in fviz_dend

### DIFF
--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -503,7 +503,7 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   df <- data.frame(xmin = unlist(xleft), ymin = unlist(ybottom), xmax = unlist(xright), ymax = unlist(ytop), stringsAsFactors = TRUE)
   
   color <- k_colors
-  if(color == "cluster") color <- "default"
+  if(length(color) == 1L && color == "cluster") color <- "default"
   if(ggpubr:::.is_col_palette(color)) color <- ggpubr:::.get_pal(color, k = k)
   else if(length(color) > 1 & length(color) < k){
     color <- rep(color, k)[1:k]


### PR DESCRIPTION
## Description
There is an issue with `fviz_dend` when using `rect_border` with more than one color.


## Example
```
library(factoextra)

model = hclust(dist(USArrests))
factoextra::fviz_dend(model, horiz = FALSE, k = 2L, rect_fill = TRUE,
                      rect = TRUE, rect_border = c("red", "blue"))

# Error in if (color == "cluster") color <- "default" : 
#  the condition has length > 1
```

## Fix
I simply check length of `color` to make sure it's not a vector.