### PR TITLE
Bug fix for deprecated ggplot guides in fviz_dend()

### DIFF
--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -329,14 +329,14 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
     p <- p + geom_segment(data = data$segments,
       aes_string(x = "x", y = "y", xend = "xend", yend = "yend", 
                  colour = "col", linetype = "lty", size = "lwd"), lineend = "square") +
-      guides(linetype = FALSE, col = FALSE) + #scale_colour_identity() + 
+      guides(linetype = "none", col = "none") + #scale_colour_identity() + 
       scale_size_identity() + scale_linetype_identity()
     if(is.null(palette)) p <- p + scale_colour_identity()
   }
   if (nodes) {
     p <- p + geom_point(data = data$nodes, 
       aes_string(x = "x", y = "y", colour = "col", shape = "pch", size = "cex")) + 
-      guides(shape = FALSE, col = FALSE, size = FALSE) + 
+      guides(shape = "none", col = "none", size = "none") + 
       scale_shape_identity()
   }
   if (labels) {


### PR DESCRIPTION
updates to ggplot have deprecated how the guides are set in `fviz_dend()`  , have updated the function to the new approach which removes the warning message given to users. 

hopefully this helps new R users not feel like they did something wrong when following a tutorial and don't understand the warning.