### PR TITLE
Fix fviz_dend linewidth handling in ggplot output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: factoextra
 Type: Package
 Title: Extract and Visualize the Results of Multivariate Data Analyses
 Version: 2.0.0.999
-Date: 2026-03-02
+Date: 2026-03-09
 Authors@R: c(
     person("Alboukadel", "Kassambara", role = c("aut", "cre"), email = "alboukadel.kassambara@gmail.com",
            comment = c(ORCID = "0009-0002-9136-0791")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # factoextra 2.0.0.999
 
 * (development version)
+* `fviz_dend()`: `lwd` now controls ggplot branch thickness correctly and no
+  longer triggers a spurious linewidth legend. (#200)
 
 # factoextra 2.0.0
 

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -22,7 +22,8 @@
 #'   labels. Used only when type = "rectangle".
 #' @param repel logical value. Use repel = TRUE to avoid label overplotting when
 #'   type = "phylogenic".
-#' @param lwd a numeric value specifying branches and rectangle line width.
+#' @param lwd a numeric value specifying dendrogram branch and rectangle line
+#'   width.
 #' @param type type of plot. Allowed values are one of "rectangle", "triangle", 
 #'   "circular", "phylogenic".
 #' @param phylo_layout the layout to be used for phylogenic trees. Default value
@@ -60,6 +61,9 @@
 #' 
 #' # Default plot
 #' fviz_dend(res.hc)
+#'
+#' # Increase branch and rectangle line widths
+#' fviz_dend(res.hc, lwd = 2)
 #' 
 #' # Cut the tree
 #' fviz_dend(res.hc, cex = 0.5, k = 4, color_labels_by_k = TRUE)

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -322,8 +322,8 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
                  colour = .data[["col"]], linetype = .data[["lty"]], linewidth = .data[["lwd"]]), lineend = "square") +
       # FIX: ggplot2 3.3.4+ deprecation - use "none" instead of FALSE for guides()
       # See: https://github.com/kassambara/factoextra/issues/179
-      guides(linetype = "none", col = "none") + #scale_colour_identity() +
-      scale_size_identity() + scale_linetype_identity()
+      guides(linetype = "none", col = "none", linewidth = "none") + #scale_colour_identity() +
+      scale_linewidth_identity() + scale_linetype_identity()
     if(is.null(palette)) p <- p + scale_colour_identity()
   }
   if (nodes) {

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -62,7 +62,8 @@ labels. Used only when type = "rectangle".}
 \item{repel}{logical value. Use repel = TRUE to avoid label overplotting when
 type = "phylogenic".}
 
-\item{lwd}{a numeric value specifying branches and rectangle line width.}
+\item{lwd}{a numeric value specifying dendrogram branch and rectangle line
+width.}
 
 \item{type}{type of plot. Allowed values are one of "rectangle", "triangle", 
 "circular", "phylogenic".}
@@ -120,6 +121,9 @@ res.hc <- hclust(dist(df))
 
 # Default plot
 fviz_dend(res.hc)
+
+# Increase branch and rectangle line widths
+fviz_dend(res.hc, lwd = 2)
 
 # Cut the tree
 fviz_dend(res.hc, cex = 0.5, k = 4, color_labels_by_k = TRUE)

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -42,6 +42,38 @@ test_that("fviz_dend supports rectangular dendrogram layout", {
   expect_s3_class(p, "ggplot")
 })
 
+test_that("fviz_dend applies lwd to branch segments without adding a linewidth guide", {
+  hc <- hclust(dist(scale(USArrests)))
+
+  p_default <- fviz_dend(hc)
+  p_custom <- fviz_dend(hc, lwd = 2)
+
+  default_layers <- ggplot2::ggplot_build(p_default)
+  custom_layers <- ggplot2::ggplot_build(p_custom)
+  legend_labels <- function(plot) {
+    gt <- ggplot2::ggplotGrob(plot)
+    idx <- which(gt$layout$name == "guide-box-right")
+    if(length(idx) == 0) return(character(0))
+    legend <- gt$grobs[[idx[1]]]$grobs[[1]]
+    extract_labels <- function(grob) {
+      out <- character()
+      if(inherits(grob, "text")) out <- c(out, grob$label)
+      if(!is.null(grob$children)) {
+        for(child in grob$children) out <- c(out, extract_labels(child))
+      }
+      if(!is.null(grob$grobs)) {
+        for(child in grob$grobs) out <- c(out, extract_labels(child))
+      }
+      out
+    }
+    unique(Filter(nzchar, extract_labels(legend)))
+  }
+
+  expect_equal(unique(default_layers$data[[1]]$linewidth), 0.7)
+  expect_equal(unique(custom_layers$data[[1]]$linewidth), 2)
+  expect_false("lwd" %in% legend_labels(p_custom))
+})
+
 test_that("fviz_pca_biplot supports form and covariance scaling modes", {
   res.pca <- stats::prcomp(iris[, 1:4], scale. = TRUE)
   p_form <- fviz_pca_biplot(res.pca, biplot.type = "form")


### PR DESCRIPTION
## Summary
- fix `fviz_dend()` ggplot branch rendering so mapped `lwd` values are applied through `scale_linewidth_identity()`
- suppress the spurious linewidth legend introduced by the `linewidth` aesthetic mapping
- document the fix in `NEWS.md`, refresh the `fviz_dend()` parameter text and examples, regenerate `man/fviz_dend.Rd`, and update the package date in `DESCRIPTION`

## Problem
Issue #200 reports two regressions in the ggplot path of `fviz_dend()`:
- `lwd = 2` did not actually make dendrogram branches thicker
- mapping branch width to `linewidth` introduced an unwanted linewidth legend

The root cause was that `.ggplot_dend()` mapped `linewidth = .data[["lwd"]]` but still used `scale_size_identity()`, so ggplot2 ignored the intended identity mapping for line widths. The code also hid `linetype` and `colour` guides but not `linewidth`.

## Validation
I reproduced the issue locally with the example from #200:

```r
library(factoextra)
data(USArrests)
df <- scale(USArrests)
res.hc <- hclust(dist(df))
fviz_dend(res.hc)
fviz_dend(res.hc, lwd = 2)
```

Before the fix, both plots built the branch layer at the same rendered linewidth. After the fix, the default plot builds at `0.7` and `lwd = 2` builds at `2`, while the linewidth legend no longer appears.

## Checks
- `Rscript -e "devtools::run_examples(run_donttest = TRUE, document = FALSE, fresh = TRUE)"`
- `R CMD check factoextra_2.0.0.999.tar.gz`
- `R CMD check --as-cran factoextra_2.0.0.999.tar.gz`

`R CMD check` completed with `Status: OK`.

`--as-cran` completed with 2 incoming NOTES from the local environment:
- `Days since last update: 6`
- `unable to verify current time`

Fixes #200.