### PR TITLE
Fix internal k=1 helper regressions in clustering helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * (development version)
 * `fviz_dend()`: `lwd` now controls ggplot branch thickness correctly and no
   longer triggers a spurious linewidth legend. (#200, @erdeyl)
+* `fviz_nbclust()` now computes the `k = 1` WSS baseline internally, and
+  `eclust()` now handles hierarchical auto-selected `k = 1` results without
+  calling `hcut(..., k = 1)`. Direct `hcut()` and `hkmeans()` validation stays
+  unchanged. (#203, @erdeyl)
 * `get_famd()`, `get_mfa()`, `facto_summarize()`, `fviz_famd_*()`, and
   `fviz_mfa_*()` now support supplementary qualitative variable categories via
   `quali.sup`, including the related overlay, print, and category-name

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 * `fviz_nbclust()` now computes the `k = 1` WSS baseline internally, and
   `eclust()` now handles hierarchical auto-selected `k = 1` results without
   calling `hcut(..., k = 1)`. Direct `hcut()` and `hkmeans()` validation stays
-  unchanged. (#203, @erdeyl)
+  unchanged. `fviz_silhouette()` now errors cleanly when silhouette data is
+  unavailable for one-cluster results. (#203, @erdeyl)
 * `get_famd()`, `get_mfa()`, `facto_summarize()`, `fviz_famd_*()`, and
   `fviz_mfa_*()` now support supplementary qualitative variable categories via
   `quali.sup`, including the related overlay, print, and category-name

--- a/R/eclust.R
+++ b/R/eclust.R
@@ -113,6 +113,7 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   else if(ncol(data)< 2) graph = FALSE
       
   gap_stat <- NULL
+  auto_k <- is.null(k)
   # Partitioning clustering
   # ++++++++++++++++++++++++++++++
   clust <- list()
@@ -143,15 +144,22 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
     
     res.dist <- get_dist(x, method = hc_metric)
     # Number of cluster
-    if(is.null(k)) {
+    if(auto_k) {
       gap <- .gap_stat(x, fun_clust, k.max = k.max, nboot = nboot,
                        gap_maxSE = gap_maxSE, verbose = verbose, diss = res.dist)
       k <- gap$k
       gap_stat <- gap$stat
     }
-    res.hc <- hcut(res.dist, k, hc_func = FUNcluster, hc_method = hc_method )
+    if(auto_k && k == 1) {
+      res.hc <- .single_cluster_hcut(res.dist, hc_func = FUNcluster, hc_method = hc_method)
+    } else {
+      res.hc <- hcut(res.dist, k, hc_func = FUNcluster, hc_method = hc_method )
+    }
     clust <- res.hc
-    if(graph) fviz_dend(clust, k)
+    if(graph) {
+      if(k > 1) fviz_dend(clust, k)
+      else fviz_dend(clust)
+    }
   }
   
   clust$nbclust <- k
@@ -159,6 +167,33 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   clust$gap_stat <- gap_stat
   class(clust) <- c(class(clust), "eclust")
   clust
+}
+
+
+# Compute the hierarchical tree for the requested backend
+.compute_hc_tree <- function(diss, hc_func, hc_method){
+  if(hc_func == "hclust") stats::hclust(diss, method = hc_method)
+  else if(hc_func == "agnes") {
+    if(hc_method %in% c("ward.D", "ward.D2")) hc_method <- "ward"
+    cluster::agnes(diss, method = hc_method)
+  }
+  else if(hc_func == "diana") cluster::diana(diss)
+  else stop("Don't support the function ", hc_func)
+}
+
+# Build a one-cluster hierarchical result without relaxing direct hcut validation.
+.single_cluster_hcut <- function(diss, hc_func, hc_method){
+  n_obs <- attr(diss, "Size")
+  if(is.null(n_obs) || !is.numeric(n_obs))
+    stop("Unable to determine number of observations from distance data")
+
+  hc <- .compute_hc_tree(diss, hc_func = hc_func, hc_method = hc_method)
+  hc$cluster <- rep(1L, n_obs)
+  hc$nbclust <- 1L
+  hc$size <- as.vector(table(hc$cluster))
+  hc$data <- diss
+  class(hc) <- c(class(hc), "hcut")
+  hc
 }
 
 
@@ -174,5 +209,4 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   k <- .maxSE(gap, se, method = gap_maxSE$method, SE.factor = gap_maxSE$SE.factor)
   list(stat = gap_stat, k = k)
 }
-
 

--- a/R/fviz_nbclust.R
+++ b/R/fviz_nbclust.R
@@ -134,7 +134,12 @@ fviz_nbclust <- function (x, FUNcluster = NULL, method = c("silhouette", "wss", 
         }
       }
       else if(method == "wss"){
-        for(i in 1:k.max){
+        n_obs <- attr(diss, "Size")
+        if(is.null(n_obs) || !is.numeric(n_obs))
+          stop("Unable to determine the number of observations from diss")
+        # Compute the one-cluster baseline internally so callers may reject k = 1.
+        v[1] <- .get_withinSS(diss, rep(1L, n_obs))
+        for(i in 2:k.max){
           clust <- FUNcluster(x, i, ...)
           v[i] <- .get_withinSS(diss, clust$cluster)
         }

--- a/R/fviz_silhouette.R
+++ b/R/fviz_silhouette.R
@@ -82,6 +82,12 @@
 fviz_silhouette <- function(sil.obj, label = FALSE, print.summary = TRUE, ...){
   
   if(inherits(sil.obj, c("eclust", "hcut", "pam", "clara", "fanny"))){
+    if(is.null(sil.obj$silinfo) || is.null(sil.obj$silinfo$widths)) {
+      stop(
+        "Silhouette information is unavailable for this clustering result. ",
+        "Silhouette plots require at least 2 clusters."
+      )
+    }
     df <- as.data.frame(sil.obj$silinfo$widths)
   }
   else if(inherits(sil.obj, "silhouette"))
@@ -121,4 +127,3 @@ fviz_silhouette <- function(sil.obj, label = FALSE, print.summary = TRUE, ...){
   
   p
 }
-

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -178,6 +178,27 @@ test_that("eclust hierarchical auto-k handles a one-cluster gap selection", {
   }
 })
 
+test_that("fviz_silhouette errors cleanly for one-cluster hierarchical results", {
+  x <- scale(iris[, 1:4])
+  fake_gap <- structure(
+    list(Tab = cbind(gap = c(0.5, 0.4, 0.3), SE.sim = c(0.05, 0.05, 0.05))),
+    class = "clusGap"
+  )
+  testthat::local_mocked_bindings(
+    .gap_stat = function(...) list(stat = fake_gap, k = 1L),
+    .env = environment(eclust)
+  )
+
+  res <- eclust(
+    x, FUNcluster = "hclust", k = NULL, k.max = 3, nboot = 2,
+    verbose = FALSE, graph = FALSE, hc_method = "complete", seed = 1
+  )
+  expect_error(
+    fviz_silhouette(res),
+    "Silhouette information is unavailable"
+  )
+})
+
 test_that("internal jitter and multishape helpers preserve RNG state", {
   set.seed(3030)
   seed_before <- get(".Random.seed", envir = .GlobalEnv)

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -80,6 +80,34 @@ test_that("fviz_nbclust wss path returns ggplot and forwards FUNcluster args", {
   expect_false(anyNA(p$data$y))
 })
 
+test_that("fviz_nbclust wss handles clustering helpers that reject k = 1", {
+  x <- scale(iris[, 1:4])
+
+  p_hcut <- fviz_nbclust(
+    x, FUNcluster = hcut, method = "wss", k.max = 4,
+    hc_method = "complete"
+  )
+  expect_s3_class(p_hcut, "ggplot")
+  expect_equal(nrow(p_hcut$data), 4)
+  expect_false(anyNA(p_hcut$data$y))
+
+  p_hkmeans <- fviz_nbclust(x, FUNcluster = hkmeans, method = "wss", k.max = 4)
+  expect_s3_class(p_hkmeans, "ggplot")
+  expect_equal(nrow(p_hkmeans$data), 4)
+  expect_false(anyNA(p_hkmeans$data$y))
+})
+
+test_that("fviz_nbclust gap_stat continues to support hcut", {
+  set.seed(123)
+  x <- scale(iris[, 1:4])
+  p <- fviz_nbclust(
+    x, FUNcluster = hcut, method = "gap_stat",
+    k.max = 3, nboot = 2, verbose = FALSE,
+    hc_method = "complete"
+  )
+  expect_s3_class(p, "ggplot")
+})
+
 test_that("fviz_nbclust handles matrix Best.nc and preserves numeric cluster order", {
   best_nc <- rbind(
     Number_clusters = c(2, 10, 3, 10),
@@ -125,6 +153,29 @@ test_that("eclust restores RNG state after execution", {
   eclust(scale(USArrests), FUNcluster = "kmeans", k = 2, graph = FALSE)
   seed_after <- get(".Random.seed", envir = .GlobalEnv)
   expect_identical(seed_after, seed_before)
+})
+
+test_that("eclust hierarchical auto-k handles a one-cluster gap selection", {
+  x <- scale(iris[, 1:4])
+  fake_gap <- structure(
+    list(Tab = cbind(gap = c(0.5, 0.4, 0.3), SE.sim = c(0.05, 0.05, 0.05))),
+    class = "clusGap"
+  )
+  testthat::local_mocked_bindings(
+    .gap_stat = function(...) list(stat = fake_gap, k = 1L),
+    .env = environment(eclust)
+  )
+
+  for(fun in c("hclust", "agnes", "diana")) {
+    res <- eclust(
+      x, FUNcluster = fun, k = NULL, k.max = 3, nboot = 2,
+      verbose = FALSE, graph = FALSE, hc_method = "complete", seed = 1
+    )
+    expect_s3_class(res, "eclust")
+    expect_identical(res$nbclust, 1L)
+    expect_true(all(res$cluster == 1L))
+    expect_identical(res$size, nrow(x))
+  }
 })
 
 test_that("internal jitter and multishape helpers preserve RNG state", {


### PR DESCRIPTION
Summary:
- compute the k=1 WSS baseline inside fviz_nbclust() instead of calling clustering helpers with k=1
- handle hierarchical eclust() auto-selected k=1 results without relaxing direct hcut() validation
- add regression coverage for hcut, hkmeans, hierarchical auto-k, and unchanged gap_stat handling
- document the fix in NEWS.md

Fixes #203.

Validation:
- devtools::test(..., filter = regressions|input-validation)
- direct R reproductions for hcut WSS, hkmeans WSS, hcut gap_stat, and hierarchical eclust auto-k