### PR TITLE
fix: validate scaled distance and cluster workflows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   `quali.sup`, including the related overlay, print, and category-name
   compatibility paths. Regression coverage and examples were expanded
   accordingly. (#202, @erdeyl)
+* `get_dist()`, `hcut()`, `fviz_dist()`, and `fviz_cluster()` now reject
+  invalid standardized data and non-finite distance matrices with package-level
+  validation errors instead of leaking low-level clustering or plotting
+  failures. (@erdeyl)
 
 # factoextra 2.0.0
 

--- a/R/dist.R
+++ b/R/dist.R
@@ -34,7 +34,11 @@ NULL
 #' @export
 get_dist <- function(x, method = "euclidean",  stand = FALSE, ...){
   
-  if(stand) x <- scale(x)
+  if(stand) {
+    x <- scale(x)
+    if(anyNA(x))
+      stop("Scaling produced NA values. Check for constant columns or non-finite values.")
+  }
   if(method %in% c("pearson", "spearman", "kendall")){
     res.cor <- stats::cor(t(x),  method = method)
     res.dist <- stats::as.dist(1 - res.cor, ...)
@@ -42,6 +46,11 @@ get_dist <- function(x, method = "euclidean",  stand = FALSE, ...){
   else res.dist <- stats::dist(x, method = method, ...)
   
   res.dist
+}
+
+.check_dist_finite <- function(dist.obj){
+  if(anyNA(dist.obj) || any(!is.finite(unclass(dist.obj))))
+    stop("The distance matrix contains NA/NaN/Inf values. Check for constant columns or non-finite values.")
 }
 
 
@@ -60,6 +69,7 @@ fviz_dist<- function(dist.obj, order = TRUE, show_labels = TRUE, lab_size = NULL
   
   if(!inherits(dist.obj, "dist"))
     stop("An object of class dist is required.")
+  .check_dist_finite(dist.obj)
   
   if(order){
   res.hc <- stats::hclust(dist.obj, method = "ward.D2")

--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -200,7 +200,11 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
   # Choose variables
   if(!is.null(choose.vars))
     data <- data[, choose.vars, drop = FALSE]
-  if(stand) data <- scale(data)
+  if(stand) {
+    data <- scale(data)
+    if(anyNA(data))
+      stop("Scaling produced NA values. Check for constant columns or non-finite values.")
+  }
   cluster <- as.factor(object$cluster)
   
   pca_performed <- FALSE

--- a/R/hcut.R
+++ b/R/hcut.R
@@ -70,6 +70,8 @@ hcut <- function(x, k = 2, isdiss = inherits(x, "dist"),
     stop("k must be a single integer >= 2")
   if(isdiss && !inherits(x, "dist"))
     stop("When isdiss = TRUE, x must be an object of class dist")
+  if(isdiss)
+    .check_dist_finite(x)
   if(stand && !inherits(x, "dist")) {
     x <- scale(x)
     if(anyNA(x))

--- a/tests/testthat/test-input-validation.R
+++ b/tests/testthat/test-input-validation.R
@@ -15,9 +15,19 @@ test_that("hcut validates k and scaled inputs", {
 
 test_that("hcut requires dist input when isdiss is TRUE", {
   x <- iris[, 1:4]
+  bad_dist <- stats::as.dist(matrix(c(
+    0, NA, 1,
+    NA, 0, 2,
+    1, 2, 0
+  ), nrow = 3, byrow = TRUE))
+
   expect_error(
     hcut(x, k = 2, isdiss = TRUE),
     "must be an object of class dist"
+  )
+  expect_error(
+    hcut(bad_dist, k = 2, isdiss = TRUE),
+    "distance matrix contains NA/NaN/Inf values"
   )
 })
 
@@ -39,4 +49,38 @@ test_that("get_clust_tendency validates numeric data and n", {
 
   x_na <- matrix(c(1, 2, NA, NA), ncol = 2)
   expect_error(get_clust_tendency(x_na, n = 1, graph = FALSE), "at least two complete rows")
+})
+
+test_that("get_dist validates scaled inputs and fviz_dist validates dist values", {
+  x_const <- data.frame(a = 1:10, b = rep(1, 10))
+  bad_dist <- stats::as.dist(matrix(c(
+    0, NA, 1,
+    NA, 0, 2,
+    1, 2, 0
+  ), nrow = 3, byrow = TRUE))
+
+  expect_error(
+    get_dist(x_const, method = "pearson", stand = TRUE),
+    "Scaling produced NA values"
+  )
+  expect_error(
+    fviz_dist(bad_dist),
+    "distance matrix contains NA/NaN/Inf values"
+  )
+})
+
+test_that("fviz_cluster validates scaled plotting data", {
+  degenerate_2d <- data.frame(a = 1:10, b = rep(1, 10))
+  degenerate_3d <- data.frame(a = 1:10, b = rep(1, 10), c = rep(2, 10))
+  cluster_obj_2d <- list(data = degenerate_2d, cluster = rep(1:2, each = 5))
+  cluster_obj_3d <- list(data = degenerate_3d, cluster = rep(1:2, each = 5))
+
+  expect_error(
+    fviz_cluster(cluster_obj_2d, stand = TRUE),
+    "Scaling produced NA values"
+  )
+  expect_error(
+    fviz_cluster(cluster_obj_3d, stand = TRUE),
+    "Scaling produced NA values"
+  )
 })


### PR DESCRIPTION
## Summary
- reject invalid standardized inputs in get_dist() and fviz_cluster()
- validate non-finite dist objects at the hcut()/fviz_dist() boundary
- add regression coverage for the remaining distance and cluster validation paths

## Testing
- R -q -e "devtools::test(\"/Users/erdeylaszlo/Library/CloudStorage/GoogleDrive-erdeyl@erdey.info/Saját meghajtó/Codex/factoextra\", filter = \"input-validation|clustering-smoke|visual-smoke\")"
- R -q -e "devtools::check(\"/Users/erdeylaszlo/Library/CloudStorage/GoogleDrive-erdeyl@erdey.info/Saját meghajtó/Codex/factoextra\", document = FALSE, error_on = \"never\", cran = FALSE, vignettes = FALSE, manual = FALSE)"