### PR TITLE
fix: validate MCA supplementary, axes, and eigenvalue inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   `quali.sup`, including the related overlay, print, and category-name
   compatibility paths. Regression coverage and examples were expanded
   accordingly. (#202, @erdeyl)
+* `get_mca_var()` now reports missing quantitative supplementary MCA variables
+  cleanly, `facto_summarize()` and related plotting helpers now validate axis
+  indices consistently, and `fviz_eig()` now validates `ncp` before plotting.
+  (@erdeyl)
 
 # factoextra 2.0.0
 

--- a/R/eigenvalue.R
+++ b/R/eigenvalue.R
@@ -148,7 +148,15 @@ fviz_eig<-function(X, choice=c("variance", "eigenvalue"), geom=c("bar", "line"),
                   parallel.lty = "dashed", parallel.iter = 100,
                   parallel.seed = NULL, ...)
 {
-  
+  if(!is.numeric(ncp) || length(ncp) != 1L || is.na(ncp) ||
+     !is.finite(ncp) || ncp %% 1 != 0 ||
+     ncp < 1 || ncp > .Machine$integer.max)
+    stop(
+      "ncp must be a single positive integer value in [1, ",
+      .Machine$integer.max, "]."
+    )
+  ncp <- as.integer(ncp)
+
   eig <- get_eigenvalue(X)
   eig <-eig[seq_len(min(ncp, nrow(eig))), , drop=FALSE]
   

--- a/R/facto_summarize.R
+++ b/R/facto_summarize.R
@@ -132,10 +132,7 @@ facto_summarize <- function(X, element, node.level = 1, group.names,
     ndim <- ncol(elmt[[1]])
   else
     ndim <- ncol(elmt$coord)
-  if(max(axes) > ndim)
-    stop("The value of the argument axes is incorrect. ",
-         "The number of axes in the data is: ", ncol(elmt$coord), 
-         ". Please try again with axes between 1 - ", ncol(elmt$coord))
+  axes <- .validate_axis_indices(axes, ndim = ndim)
   
   # Summarize the result
   res = NULL

--- a/R/get_mca.R
+++ b/R/get_mca.R
@@ -69,6 +69,8 @@ get_mca_var <- function(res.mca, element = c( "var", "mca.cor", "quanti.sup")){
   element_desc <- "variables"
   # FactoMineR package
   if(inherits(res.mca, c("MCA"))) {
+    if(choice == "quanti.sup" && is.null(res.mca$quanti.sup))
+      stop("There are no quantitative supplementary variables in this MCA.")
     vars <- switch(choice,
                    var = res.mca$var,
                    mca.cor = list(coord = res.mca$var$eta2),
@@ -173,5 +175,4 @@ get_mca_ind <- function(res.mca){
   attr(ind, "element") <- "individuals"
   return(ind)
 }
-
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -763,9 +763,25 @@ NULL
   return_val
 }
 
+# Check axis values
+.validate_axis_indices <- function(axes, ndim = NULL){
+  if(!is.numeric(axes) || length(axes) == 0L || anyNA(axes) || any(!is.finite(axes)) ||
+     any(axes %% 1 != 0) || any(axes < 1))
+    stop("The value of the argument axes is incorrect. axes should contain positive integers.")
+
+  axes <- as.integer(axes)
+  if(!is.null(ndim) && max(axes) > ndim)
+    stop("The value of the argument axes is incorrect. ",
+         "The number of axes in the data is: ", ndim,
+         ". Please try again with axes between 1 - ", ndim)
+
+  axes
+}
+
 # Check axis lengths
 .check_axes <- function(axes, .length){
-  if(length(axes) != .length) stop("axes should be of length ", 2)
+  axes <- .validate_axis_indices(axes)
+  if(length(axes) != .length) stop("axes should be of length ", .length)
 }
 
 # Add individual groups column

--- a/tests/testthat/test-input-validation.R
+++ b/tests/testthat/test-input-validation.R
@@ -40,3 +40,69 @@ test_that("get_clust_tendency validates numeric data and n", {
   x_na <- matrix(c(1, 2, NA, NA), ncol = 2)
   expect_error(get_clust_tendency(x_na, n = 1, graph = FALSE), "at least two complete rows")
 })
+
+test_that("MCA quanti.sup workflows error cleanly when absent", {
+  skip_if_not_installed("FactoMineR")
+
+  data(poison, package = "FactoMineR")
+  res.mca <- FactoMineR::MCA(poison[, 5:15], graph = FALSE)
+
+  expect_error(
+    get_mca_var(res.mca, "quanti.sup"),
+    "There are no quantitative supplementary variables in this MCA"
+  )
+  expect_error(
+    facto_summarize(res.mca, "quanti.sup", axes = 1:2),
+    "There are no quantitative supplementary variables in this MCA"
+  )
+  expect_error(
+    fviz(res.mca, "quanti.sup"),
+    "There are no quantitative supplementary variables in this MCA"
+  )
+})
+
+test_that("axes validation rejects invalid axis indices", {
+  res.pca <- stats::prcomp(iris[, 1:4], scale. = TRUE)
+
+  expect_error(
+    facto_summarize(res.pca, "var", axes = c(1, NA)),
+    "The value of the argument axes is incorrect"
+  )
+  expect_error(
+    facto_summarize(res.pca, "var", axes = 0),
+    "The value of the argument axes is incorrect"
+  )
+  expect_error(
+    facto_summarize(res.pca, "var", axes = c(1, 1.5)),
+    "The value of the argument axes is incorrect"
+  )
+  expect_error(
+    fviz_cos2(res.pca, choice = "var", axes = c(1, NA)),
+    "The value of the argument axes is incorrect"
+  )
+  expect_error(
+    fviz_contrib(res.pca, choice = "var", axes = c(1, 0)),
+    "The value of the argument axes is incorrect"
+  )
+  expect_error(
+    fviz_ellipses(res.pca, habillage = iris$Species, axes = c(1, 1.5)),
+    "The value of the argument axes is incorrect"
+  )
+})
+
+test_that("fviz_eig validates ncp", {
+  res.pca <- stats::prcomp(iris[, 1:4], scale. = TRUE)
+
+  expect_error(
+    fviz_eig(res.pca, ncp = NA),
+    "ncp must be a single positive integer value in"
+  )
+  expect_error(
+    fviz_eig(res.pca, ncp = -1),
+    "ncp must be a single positive integer value in"
+  )
+  expect_error(
+    fviz_eig(res.pca, ncp = 1.5),
+    "ncp must be a single positive integer value in"
+  )
+})


### PR DESCRIPTION
## Summary
- error cleanly when MCA results have no quantitative supplementary variables
- validate axis indices consistently across summarization and plotting helpers
- validate \ in \ before plotting

## Validation
- R -q -e "devtools::test('/Users/erdeylaszlo/Library/CloudStorage/GoogleDrive-erdeyl@erdey.info/Saját meghajtó/Codex/factoextra')"
- R -q -e "devtools::check('/Users/erdeylaszlo/Library/CloudStorage/GoogleDrive-erdeyl@erdey.info/Saját meghajtó/Codex/factoextra', document = FALSE, error_on = 'never', cran = FALSE, vignettes = FALSE, manual = FALSE)"