### PR TITLE
docs: remove README reference to internal clean_lock_files helper

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -148,8 +148,8 @@ fviz_famd_var(res.famd, "quali.sup")
 get_mfa(res.mfa, "quali.sup")
 fviz_mfa_var(res.mfa, "quali.sup")
 
-# New helper: remove stale package lock directories
-clean_lock_files()
+# If installation leaves stale 00LOCK-* directories in your library,
+# remove those directories manually before reinstalling.
 
 # Hopkins statistic uses corrected formula (Wright 2022)
 # Set this option to silence the one-time warning

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ fviz_famd_var(res.famd, "quali.sup")
 get_mfa(res.mfa, "quali.sup")
 fviz_mfa_var(res.mfa, "quali.sup")
 
-# New helper: remove stale package lock directories
-clean_lock_files()
+# If installation leaves stale 00LOCK-* directories in your library,
+# remove those directories manually before reinstalling.
 
 # Hopkins statistic uses corrected formula (Wright 2022)
 # Set this option to silence the one-time warning


### PR DESCRIPTION
## Summary
- remove the README example that suggests calling the internal `clean_lock_files()` helper
- replace it with neutral manual guidance about clearing stale `00LOCK-*` directories
- regenerate `README.md` from `README.Rmd`

## Validation
- rg -n "clean_lock_files" README.Rmd README.md
- R -q -e "library(factoextra); cat('NAMESPACE_EXPORTED=', 'clean_lock_files' %in% getNamespaceExports('factoextra'), '; ATTACHED=', exists('clean_lock_files', inherits = TRUE), '\\n', sep = '')"
