### PR TITLE
fix: FAMD/MFA quali categories with shared factor levels (#184)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,11 @@
   plain numeric matrices. Previously they inherited the `"loadings"` class, whose
   `print()` method hid values with `|x| < 0.1` and broke downstream manipulation.
   (#212)
+* FAMD/MFA plots (`fviz_contrib()`, `fviz_famd_ind()`, `fviz_famd_var()`) no
+  longer error with `duplicate 'row.names' are not allowed` when qualitative
+  variables share factor-level names (e.g. several variables with `Low`/`High`).
+  Colliding categories are relabelled `variable_level` (e.g. `Acidity_Low`);
+  non-colliding labels are unchanged. (#184, #140)
 
 ## Input Validation
 

--- a/R/facto_summarize.R
+++ b/R/facto_summarize.R
@@ -239,6 +239,10 @@ facto_summarize <- function(X, element, node.level = 1, group.names,
     name <- rownames(elmt$coord)
     if(is.null(name)) name <- as.character(seq_len(nrow(elmt$coord)))
     name <- as.character(name)
+    # Disambiguate duplicated category names (e.g. FAMD/MFA qualitative
+    # variables sharing factor-level names) so they can be used as row names
+    # (#184, #140). No-op when names are already unique.
+    name <- .disambiguate_category_names(X, name, element, facto_class)
     res <- cbind.data.frame(name = name, res)
     rownames(res) <- name
     if(!is.null(select) && !is.null(select$name) && .factominer_needs_category_map(facto_class, element)){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1108,6 +1108,42 @@ factominer_category_map <- function(X, element = c("quali.var", "quali.sup", "va
   map
 }
 
+# Disambiguate duplicated category names (e.g. FAMD/MFA qualitative variables
+# that share factor-level names such as "Low"/"High"). FactoMineR returns the
+# raw level names as row names, which are not necessarily unique across
+# variables; setting them as data.frame row names then errors with
+# "duplicate 'row.names' are not allowed" (see issues #184, #140).
+#
+# When duplicates exist, colliding categories are relabelled as
+# "variable_level" (only the levels actually involved in a collision are
+# prefixed; unique levels keep their plain label). If the original data or the
+# variable mapping is unavailable, falls back to make.unique() so the call
+# never crashes. When there are no duplicates this is a no-op and the names are
+# returned unchanged.
+.disambiguate_category_names <- function(X, name, element, facto_class){
+  if(length(name) == 0 || !any(duplicated(name))) return(name)
+  if(!is.null(facto_class) && facto_class %in% c("FAMD", "MFA", "MCA", "HMFA") &&
+     element %in% c("quali.var", "quali.sup")){
+    data <- tryCatch(as.data.frame(X$call$X), error = function(e) NULL)
+    if(!is.null(data)){
+      is.quali <- which(!vapply(data, is.numeric, logical(1)))
+      if(length(is.quali) > 0){
+        data.quali <- droplevels(as.data.frame(lapply(data[, is.quali, drop = FALSE], as.factor)))
+        level.pos <- unlist(lapply(data.quali, levels), use.names = FALSE)
+        var.pos   <- rep(names(data.quali), vapply(data.quali, nlevels, integer(1)))
+        # Only trust the positional variable mapping when it lines up exactly
+        # with the supplied names (same length and order).
+        if(length(level.pos) == length(name) && all(level.pos == name)){
+          dup.level <- level.pos %in% level.pos[duplicated(level.pos)]
+          new <- ifelse(dup.level, paste(var.pos, level.pos, sep = "_"), level.pos)
+          if(!any(duplicated(new))) return(new)
+        }
+      }
+    }
+  }
+  make.unique(name)
+}
+
 #' Map legacy FactoMineR category names to current labels
 #'
 #' @param X a FactoMineR object (MCA, MFA, FAMD, HMFA).

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -360,6 +360,42 @@ test_that("get_pca_ind returns finite cos2 for zero-distance rows", {
   expect_equal(unname(ind$cos2[2, ]), c(0, 0))
 })
 
+test_that("FAMD plots handle qualitative variables with shared factor levels (#184, #140)", {
+  skip_if_not_installed("FactoMineR")
+
+  set.seed(1)
+  n <- 60
+  df <- data.frame(
+    x1 = rnorm(n), x2 = rnorm(n), x3 = rnorm(n),
+    f1 = factor(sample(c("Low", "Medium", "High"), n, replace = TRUE)),
+    f2 = factor(sample(c("Low", "High"), n, replace = TRUE)) # shares Low/High with f1
+  )
+  res <- FactoMineR::FAMD(df, graph = FALSE)
+
+  # Previously errored with "duplicate 'row.names' are not allowed"
+  expect_s3_class(fviz_contrib(res, choice = "quali.var"), "ggplot")
+  expect_s3_class(fviz_contrib(res, choice = "quanti.var"), "ggplot")
+  expect_s3_class(fviz_famd_ind(res), "ggplot")
+  expect_s3_class(fviz_famd_var(res, "quali.var"), "ggplot")
+
+  # Colliding categories are disambiguated as variable_level; unique ones stay plain
+  fc <- facto_summarize(res, element = "quali.var", result = "contrib", axes = 1)
+  expect_false(any(duplicated(fc$name)))
+  expect_true(all(c("f1_Low", "f1_High", "f2_Low", "f2_High") %in% fc$name))
+  expect_true("Medium" %in% fc$name) # Medium only in f1 -> not prefixed
+})
+
+test_that("FAMD without shared factor levels keeps plain category labels (#184)", {
+  skip_if_not_installed("FactoMineR")
+
+  data(wine, package = "FactoMineR")
+  res <- FactoMineR::FAMD(wine, graph = FALSE)
+  fc <- facto_summarize(res, element = "quali.var", result = "contrib", axes = 1)
+
+  expect_true(all(c("Saumur", "Env1") %in% fc$name))
+  expect_false(any(grepl("_", fc$name))) # no disambiguation when names are unique
+})
+
 test_that("fviz_pca_biplot auto scaling keeps plot coordinates finite", {
   x <- data.frame(a = c(1, 1, 1), b = c(-1, 0, 1), c = c(-2, 0, 2))
   res <- stats::prcomp(x, center = TRUE, scale. = FALSE)


### PR DESCRIPTION
## Summary

FAMD/MFA plots — `fviz_contrib(choice = "quali.var")`, `fviz_famd_ind()`, and `fviz_famd_var(…, "quali.var")` — errored with `duplicate 'row.names' are not allowed` whenever two qualitative variables shared factor-level names (e.g. several variables with `Low`/`High`). This was the still-open part of #184 (the `quanti.var` `-nrow(X$group$Lg)` error was already fixed in `c8681c2`); root cause is the same as #140.

## Fix

- New internal helper `.disambiguate_category_names()` (`R/utilities.R`) relabels colliding categories as `variable_level` (e.g. `Acidity_Low`), reusing the existing `factominer_category_map()` prefixing pattern, with a `make.unique()` fallback when the original data/variable mapping is unavailable.
- Wired into `R/facto_summarize.R` at the single crash point — covers all three failing entry points, which funnel through `facto_summarize()` → `get_famd()`.
- **Gated on `any(duplicated(name))`**, so non-colliding cases are byte-identical (only previously-crashing inputs change).

## No regressions

- Probed every method/element path that reaches the changed line (PCA/CA/MCA/MFA/FAMD) — all have unique names, so the new branch never fires for currently-working inputs.
- Test suite: **68 tests, 0 failures, 0 warnings** (+2 new regression tests: collision case fixed, no-collision `wine` case unchanged).

## Behavior

- Collision case → labels `f1_Low, f1_High, f2_Low, f2_High, Medium` (`Medium` left plain — it does not collide).
- `wine` FAMD → unchanged plain labels (`Saumur`, `Env1`, …).

Fixes #184
Refs #140
