### PR TITLE
feat: eclust() accepts precomputed dist for hierarchical clustering (#182)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,12 @@
 
 ## New Features
 
+* `eclust()` now accepts a precomputed dissimilarity matrix (an object of class
+  `"dist"`) as `x` for hierarchical clustering (`"hclust"`, `"agnes"`,
+  `"diana"`), so custom distances such as Bray-Curtis
+  (e.g. `vegan::vegdist(df, "bray")`) can be used. In that case `hc_metric` is
+  ignored and `k` must be supplied. Previously a `"dist"` input was silently
+  recomputed as a Euclidean distance. (#182)
 * `get_famd()`, `get_mfa()`, `facto_summarize()`, `fviz_famd_*()`, and
   `fviz_mfa_*()` now support supplementary qualitative variable categories
   via `quali.sup`, including overlay, print, and category-name compatibility

--- a/R/eclust.R
+++ b/R/eclust.R
@@ -8,7 +8,12 @@ NULL
 #'   \code{k = 1}; in that case \code{eclust()} returns a one-cluster result
 #'   without silhouette information. Read more:
 #'  \href{https://www.datanovia.com/en/blog/cluster-analysis-in-r-simplified-and-enhanced/}{Visual enhancement of clustering analysis}.
-#' @param x numeric vector, data matrix or data frame
+#' @param x numeric vector, data matrix or data frame. For hierarchical
+#'   clustering (\code{FUNcluster} = "hclust", "agnes" or "diana"), a
+#'   precomputed dissimilarity matrix (an object of class \code{"dist"}) may be
+#'   supplied directly; in that case \code{hc_metric} is ignored and \code{k}
+#'   must be specified. This allows custom distances such as Bray-Curtis
+#'   (e.g. \code{vegan::vegdist(df, "bray")}).
 #' @param FUNcluster a clustering function including "kmeans", "pam", "clara", 
 #'   "fanny", "hclust", "agnes" and "diana". Abbreviation is allowed.
 #' @param k the number of clusters to be generated. If NULL, the gap statistic
@@ -29,9 +34,9 @@ NULL
 #'   calculating dissimilarities between observations. Allowed values are those 
 #'   accepted by the function dist() [including "euclidean", "manhattan", 
 #'   "maximum", "canberra", "binary", "minkowski"] and correlation based 
-#'   distance measures ["pearson", "spearman" or "kendall"]. Used only when 
-#'   FUNcluster is a hierarchical clustering function such as one of "hclust", 
-#'   "agnes" or "diana".
+#'   distance measures ["pearson", "spearman" or "kendall"]. Used only when
+#'   FUNcluster is a hierarchical clustering function such as one of "hclust",
+#'   "agnes" or "diana". Ignored when \code{x} is already a \code{"dist"} object.
 #' @param hc_method the agglomeration method to be used (?hclust): "ward.D", 
 #'   "ward.D2", "single", "complete", "average", ...
 #' @param gap_maxSE a list containing the parameters (method and SE.factor) for 
@@ -102,13 +107,22 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   }, add = TRUE)
   set.seed(seed)
   data <- x
+  # A precomputed distance matrix (class "dist") may be passed as x for
+  # hierarchical clustering (mirrors hcut()); hc_metric is then ignored (#182).
+  is_dist <- inherits(x, "dist")
   if(stand) {
+    if(is_dist)
+      stop("'stand = TRUE' is not supported when 'x' is a distance matrix (class 'dist').")
     x <- scale(x)
     if(anyNA(x))
       stop("Scaling produced NA values. Check for constant columns or non-finite values.")
   }
   # Define the type of clustering
   FUNcluster <- match.arg(FUNcluster)
+  if(is_dist && FUNcluster %in% c("kmeans", "pam", "clara", "fanny"))
+    stop("A distance matrix (class 'dist') is supported only for hierarchical clustering ",
+         "(FUNcluster = 'hclust', 'agnes', or 'diana'). For '", FUNcluster,
+         "', supply the raw data, or use hcut() for precomputed distances.")
   fun_clust <- switch(FUNcluster,
                  kmeans = stats::kmeans,
                  pam = cluster::pam,
@@ -151,8 +165,12 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   # Hierarchical clustering
   # ++++++++++++++++++++++++++++++++
   else if(FUNcluster %in% c("hclust", "agnes", "diana")){
-    
-    res.dist <- get_dist(x, method = hc_metric)
+
+    # Use a precomputed distance directly; otherwise compute it from the data.
+    res.dist <- if(is_dist) x else get_dist(x, method = hc_metric)
+    if(auto_k && is_dist)
+      stop("When 'x' is a distance matrix, the number of clusters 'k' must be specified: ",
+           "the gap statistic requires the original data and cannot be computed from a 'dist'.")
     # Number of cluster
     if(auto_k) {
       gap <- .gap_stat(x, fun_clust, k.max = k.max, nboot = nboot,

--- a/man/eclust.Rd
+++ b/man/eclust.Rd
@@ -21,7 +21,12 @@ eclust(
 )
 }
 \arguments{
-\item{x}{numeric vector, data matrix or data frame}
+\item{x}{numeric vector, data matrix or data frame. For hierarchical
+clustering (\code{FUNcluster} = "hclust", "agnes" or "diana"), a
+precomputed dissimilarity matrix (an object of class \code{"dist"}) may be
+supplied directly; in that case \code{hc_metric} is ignored and \code{k}
+must be specified. This allows custom distances such as Bray-Curtis
+(e.g. \code{vegan::vegdist(df, "bray")}).}
 
 \item{FUNcluster}{a clustering function including "kmeans", "pam", "clara", 
 "fanny", "hclust", "agnes" and "diana". Abbreviation is allowed.}
@@ -48,9 +53,9 @@ error.}
 calculating dissimilarities between observations. Allowed values are those 
 accepted by the function dist() [including "euclidean", "manhattan", 
 "maximum", "canberra", "binary", "minkowski"] and correlation based 
-distance measures ["pearson", "spearman" or "kendall"]. Used only when 
-FUNcluster is a hierarchical clustering function such as one of "hclust", 
-"agnes" or "diana".}
+distance measures ["pearson", "spearman" or "kendall"]. Used only when
+FUNcluster is a hierarchical clustering function such as one of "hclust",
+"agnes" or "diana". Ignored when \code{x} is already a \code{"dist"} object.}
 
 \item{hc_method}{the agglomeration method to be used (?hclust): "ward.D", 
 "ward.D2", "single", "complete", "average", ...}

--- a/tests/testthat/test-clustering-smoke.R
+++ b/tests/testthat/test-clustering-smoke.R
@@ -17,3 +17,38 @@ test_that("Hopkins tendency returns statistic and optional plot", {
   expect_false(is.null(res$hopkins_stat))
   expect_null(res$plot)
 })
+
+test_that("eclust() accepts a precomputed dist for hierarchical clustering (#182)", {
+  set.seed(1)
+  df <- matrix(rpois(20 * 6, 5), nrow = 20)
+  rownames(df) <- paste0("s", seq_len(nrow(df)))
+
+  # Bray-Curtis dissimilarity, computed locally (no extra dependency)
+  braycurtis <- function(m) {
+    n <- nrow(m)
+    d <- matrix(0, n, n)
+    for (i in seq_len(n)) for (j in seq_len(n)) {
+      d[i, j] <- sum(abs(m[i, ] - m[j, ])) / sum(m[i, ] + m[j, ])
+    }
+    stats::as.dist(d)
+  }
+  bc <- braycurtis(df)
+
+  res <- eclust(bc, "hclust", k = 3, graph = FALSE)
+  expect_s3_class(res, "eclust")
+  # The supplied distance is honored, not recomputed as Euclidean
+  expect_equal(res$height, stats::hclust(bc, method = "ward.D2")$height)
+
+  # Auto-k cannot run on a bare dist (gap statistic needs the original data)
+  expect_error(eclust(bc, "hclust", graph = FALSE), "number of clusters 'k'")
+  # Partitioning methods that need raw data reject a dist clearly
+  expect_error(eclust(bc, "kmeans", k = 3, graph = FALSE), "hierarchical clustering")
+  # Scaling a dissimilarity is rejected
+  expect_error(eclust(bc, "hclust", k = 3, stand = TRUE, graph = FALSE), "stand = TRUE")
+})
+
+test_that("eclust() hierarchical clustering on raw data is unchanged (#182 no-regression)", {
+  res <- eclust(iris[, 1:4], "hclust", hc_metric = "manhattan", k = 3, graph = FALSE)
+  ref <- stats::hclust(get_dist(iris[, 1:4], method = "manhattan"), method = "ward.D2")
+  expect_equal(res$height, ref$height)
+})


### PR DESCRIPTION
## Summary

Addresses #182 (Bray-Curtis distance). Rather than hard-coding ecology-specific metrics (which would need a `vegan`/`ade4` dependency and invite endless follow-on metric requests), this generalizes `eclust()` to accept a **precomputed dissimilarity matrix** (`class "dist"`) for hierarchical clustering — matching what `hcut()` already does. Users can then supply *any* custom distance, including Bray-Curtis via `vegan::vegdist(df, "bray")`.

It also fixes a latent correctness trap: previously, passing a `dist` to `eclust()` silently **recomputed Euclidean** distances (verified: wrong merge heights).

## Changes (`R/eclust.R`)

- Hierarchical branch (`"hclust"`/`"agnes"`/`"diana"`): `res.dist <- if (inherits(x, "dist")) x else get_dist(x, hc_metric)` — the supplied dist is used directly.
- Guards with clear errors (all gated on `inherits(x, "dist")`):
  - auto-`k` (`k = NULL`) + `dist` → error (gap statistic needs the original data, can't run on a bare dist).
  - partitioning methods (`kmeans`/`pam`/`clara`/`fanny`) + `dist` → error (need raw data; point to `hcut()`).
  - `stand = TRUE` + `dist` → error (can't scale a dissimilarity).
- Docs updated (`@param x`, `@param hc_metric`).

## No regressions

- All new behavior is gated on `inherits(x, "dist")`, so raw matrix/data.frame input is byte-identical. No existing code/tests passed a `dist` to `eclust()`.
- Verified `eclust(iris[,1:4], "hclust", hc_metric="manhattan", k=3)` heights unchanged.
- Test suite: **70 tests, 0 failures, 0 warnings** (+2 new: dist honored + raw-data no-regression).

## Behavior

```r
# now works — custom distance honored (heights == hclust(bc))
eclust(vegan::vegdist(df, "bray"), "hclust", k = 3)

# hcut() already supported this and continues to:
hcut(vegan::vegdist(df, "bray"), k = 3, hc_method = "average")
```

Fixes #182
