### PR TITLE
chore: gitignore local .claude/skills/ dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 CLAUDE.md
 docs/
 Rplots.pdf
+.claude/skills/


### PR DESCRIPTION
Keeps the local issue-fixing skill folder (triage tracker + workflow notes) out of version control. `.claude/` is already excluded from the package build via `.Rbuildignore`, so this only affects git.