### PR TITLE
fix: stop text labels adding a stray "a" to the legend (#14)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
   variables share factor-level names (e.g. several variables with `Low`/`High`).
   Colliding categories are relabelled `variable_level` (e.g. `Acidity_Low`);
   non-colliding labels are unchanged. (#184, #140)
+* Point/individual labels no longer add a stray `a` glyph to the colour/fill
+  legend (e.g. `fviz_pca_ind(..., habillage = )`). Text layers are now excluded
+  from the legend keys; labels still appear on the plot. (#14)
 
 ## Input Validation
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -682,8 +682,23 @@ NULL
     geom_hline(yintercept = 0, color = "black", linetype=linetype) +
     geom_vline(xintercept = 0, color = "black", linetype=linetype) +
     labs(title = title, x = xlab, y = ylab)
-  
+
+  p <- .hide_text_legend(p)
+
   return(p)
+}
+
+# Stop text/label layers from injecting a stray glyph (e.g. "a") into the
+# colour/fill legend (#14). Labels are still drawn on the plot; they are only
+# removed from the legend keys. The colour/shape guides come from the point
+# layers, so this never drops a legend that should exist.
+.hide_text_legend <- function(p){
+  text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  for(i in seq_along(p$layers)){
+    if(inherits(p$layers[[i]]$geom, text_geoms))
+      p$layers[[i]]$show.legend <- FALSE
+  }
+  p
 }
 
 # Check the element to be labelled

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -360,6 +360,17 @@ test_that("get_pca_ind returns finite cos2 for zero-distance rows", {
   expect_equal(unname(ind$cos2[2, ]), c(0, 0))
 })
 
+test_that("fviz text labels do not leak a glyph into the legend (#14)", {
+  res <- stats::prcomp(mtcars[, 1:7], scale. = TRUE)
+  p <- fviz_pca_ind(res, habillage = factor(mtcars$carb))
+
+  text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  text_layers <- Filter(function(L) inherits(L$geom, text_geoms), p$layers)
+
+  expect_gt(length(text_layers), 0)
+  expect_true(all(vapply(text_layers, function(L) isFALSE(L$show.legend), logical(1))))
+})
+
 test_that("FAMD plots handle qualitative variables with shared factor levels (#184, #140)", {
   skip_if_not_installed("FactoMineR")
 


### PR DESCRIPTION
Labels (`geom_text`/`geom_label`) were injecting a text glyph (an `a`) into the colour/fill legend keys when points are coloured by groups (e.g. `fviz_pca_ind(habillage=)`). `.fviz_finish()` now sets `show.legend = FALSE` on text/label layers, so labels still draw but no longer appear in the legend keys. Colour/shape guides come from the point layers, so no legend is lost.

- Single chokepoint (`.fviz_finish`), so it applies consistently across all `fviz_*` plots.
- Regression test + NEWS added. Full suite green (70 tests, 0 failures).

Fixes #14