### PR TITLE
feat(eclust): support hkmeans as a FUNcluster (#78)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,9 @@
 
 ## New Features
 
+* `eclust()` gains `"hkmeans"` as a `FUNcluster` option, so hierarchical k-means
+  can be run through the same enhanced-clustering interface (with gap-statistic
+  `k` selection, silhouette info, and plotting). (#78)
 * `eclust()` now accepts a precomputed dissimilarity matrix (an object of class
   `"dist"`) as `x` for hierarchical clustering (`"hclust"`, `"agnes"`,
   `"diana"`), so custom distances such as Bray-Curtis

--- a/R/eclust.R
+++ b/R/eclust.R
@@ -14,8 +14,8 @@ NULL
 #'   supplied directly; in that case \code{hc_metric} is ignored and \code{k}
 #'   must be specified. This allows custom distances such as Bray-Curtis
 #'   (e.g. \code{vegan::vegdist(df, "bray")}).
-#' @param FUNcluster a clustering function including "kmeans", "pam", "clara", 
-#'   "fanny", "hclust", "agnes" and "diana". Abbreviation is allowed.
+#' @param FUNcluster a clustering function including "kmeans", "pam", "clara",
+#'   "fanny", "hkmeans", "hclust", "agnes" and "diana". Abbreviation is allowed.
 #' @param k the number of clusters to be generated. If NULL, the gap statistic
 #'   is used to estimate the appropriate number of clusters. For hierarchical
 #'   clustering, this automatic selection may return \code{k = 1}. In the case
@@ -88,7 +88,7 @@ NULL
 #' @name eclust
 #' @rdname eclust
 #' @export
-eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust", "agnes", "diana"),
+eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust", "agnes", "diana", "hkmeans"),
                    k = NULL, k.max = 10, stand = FALSE,
                    graph = TRUE,
                    hc_metric = "euclidean", hc_method = "ward.D2",
@@ -119,7 +119,7 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   }
   # Define the type of clustering
   FUNcluster <- match.arg(FUNcluster)
-  if(is_dist && FUNcluster %in% c("kmeans", "pam", "clara", "fanny"))
+  if(is_dist && FUNcluster %in% c("kmeans", "pam", "clara", "fanny", "hkmeans"))
     stop("A distance matrix (class 'dist') is supported only for hierarchical clustering ",
          "(FUNcluster = 'hclust', 'agnes', or 'diana'). For '", FUNcluster,
          "', supply the raw data, or use hcut() for precomputed distances.")
@@ -128,6 +128,7 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
                  pam = cluster::pam,
                  clara = cluster::clara,
                  fanny = cluster::fanny,
+                 hkmeans = hkmeans,
                  diana = hcut,
                  agnes = hcut,
                  hclust = hcut
@@ -141,7 +142,7 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
   # Partitioning clustering
   # ++++++++++++++++++++++++++++++
   clust <- list()
-  if(FUNcluster %in% c("kmeans", "pam", "clara", "fanny")){
+  if(FUNcluster %in% c("kmeans", "pam", "clara", "fanny", "hkmeans")){
     # Number of cluster
     if(is.null(k)) {
       gap <- .gap_stat(x, fun_clust, k.max = k.max, nboot = nboot,

--- a/man/eclust.Rd
+++ b/man/eclust.Rd
@@ -6,7 +6,8 @@
 \usage{
 eclust(
   x,
-  FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust", "agnes", "diana"),
+  FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust", "agnes", "diana",
+    "hkmeans"),
   k = NULL,
   k.max = 10,
   stand = FALSE,
@@ -28,8 +29,8 @@ supplied directly; in that case \code{hc_metric} is ignored and \code{k}
 must be specified. This allows custom distances such as Bray-Curtis
 (e.g. \code{vegan::vegdist(df, "bray")}).}
 
-\item{FUNcluster}{a clustering function including "kmeans", "pam", "clara", 
-"fanny", "hclust", "agnes" and "diana". Abbreviation is allowed.}
+\item{FUNcluster}{a clustering function including "kmeans", "pam", "clara",
+"fanny", "hkmeans", "hclust", "agnes" and "diana". Abbreviation is allowed.}
 
 \item{k}{the number of clusters to be generated. If NULL, the gap statistic
 is used to estimate the appropriate number of clusters. For hierarchical

--- a/tests/testthat/test-clustering-smoke.R
+++ b/tests/testthat/test-clustering-smoke.R
@@ -52,3 +52,21 @@ test_that("eclust() hierarchical clustering on raw data is unchanged (#182 no-re
   ref <- stats::hclust(get_dist(iris[, 1:4], method = "manhattan"), method = "ward.D2")
   expect_equal(res$height, ref$height)
 })
+
+test_that("eclust() supports hkmeans as a FUNcluster (#78)", {
+  df <- scale(iris[, 1:4])
+
+  set.seed(1)
+  res <- eclust(df, "hkmeans", k = 3, graph = FALSE)
+  expect_s3_class(res, "eclust")
+  expect_s3_class(res, "hkmeans")
+  expect_length(res$cluster, nrow(df))
+  expect_false(is.null(res$silinfo))
+  # delegates to hkmeans() unchanged
+  set.seed(1)
+  expect_equal(unname(res$cluster), unname(hkmeans(df, 3)$cluster))
+
+  # a distance matrix is rejected for hkmeans (needs raw data), like kmeans
+  expect_error(eclust(get_dist(df), "hkmeans", k = 3, graph = FALSE),
+               "hierarchical clustering")
+})


### PR DESCRIPTION
Adds `"hkmeans"` to `eclust()`'s `FUNcluster` options, routed through the partitioning branch (gap-stat `k` selection, silhouette info, plotting) via `hkmeans()`.

**No regression:** purely additive — existing `FUNcluster` values hit unchanged code paths (verified `eclust(df, "kmeans", k=3)` == `stats::kmeans`). hkmeans fixed-`k`, gap-stat auto-`k`, and abbreviation all verified; a `dist` input is rejected for hkmeans like the other partitioning methods. Suite green (72 tests, +1).

Fixes #78