### PR TITLE
feat(fviz): add arrow.linetype for variable arrows (#73)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,9 @@
 
 ## New Features
 
+* `fviz_pca_var()` / `fviz_pca_biplot()` (and other arrow plots) gain an
+  `arrow.linetype` argument to set the variable-arrow line type (e.g. `"dashed"`).
+  Default `"solid"` reproduces the previous appearance. (#73)
 * `eclust()` gains `"hkmeans"` as a `FUNcluster` option, so hierarchical k-means
   can be run through the same enhanced-clustering interface (with gap-statistic
   `k` selection, silhouette info, and plotting). (#78)

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -21,6 +21,8 @@ NULL
 #'@param pointsize the size of points
 #'@param pointshape the shape of points
 #'@param arrowsize the size of arrows. Controls the thickness of arrows.
+#'@param arrow.linetype linetype of the variable arrows (e.g. "solid",
+#'  "dashed", "dotted"). Default is "solid".
 #'@param title the title of the graph
 #'@param repel a boolean, whether to use ggrepel to avoid overplotting text
 #'  labels or not. The old \code{jitter} argument is kept for backward
@@ -126,9 +128,10 @@ NULL
 #'  }
 #'@export
 fviz <- function(X, element, axes = c(1, 2), geom = "auto",
-                          label = "all", invisible="none", labelsize=4, 
+                          label = "all", invisible="none", labelsize=4,
                           pointsize = 1.5, pointshape = 19, arrowsize = 0.5,
-                          habillage="none", addEllipses=FALSE, ellipse.level = 0.95, 
+                          arrow.linetype = "solid",
+                          habillage="none", addEllipses=FALSE, ellipse.level = 0.95,
                           ellipse.type = "norm", ellipse.alpha = 0.1, mean.point = TRUE,
                           color = "black", fill = "white", alpha = 1, gradient.cols = NULL,
                           col.row.sup = "darkblue", col.col.sup="darkred",
@@ -274,7 +277,8 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   if(is.null(extra_args$legend)) p <- p + theme(legend.position = "right" )
   # Add arrows
   if("arrow" %in% geom && !hide[[element]])
-    p <- p + .arrows(data = df, color = color, alpha = alpha, linewidth = arrowsize)
+    p <- p + .arrows(data = df, color = color, alpha = alpha, linewidth = arrowsize,
+                     linetype = arrow.linetype)
   # Add correlation circle if PCA & element = "var" & scale = TRUE
   if(facto.class == "PCA" && element == "var"){
     if(.get_scale_unit(X) && is.null(extra_args$scale.)) 
@@ -381,13 +385,14 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
 # Add arrow to the plot
 # FIX: ggplot2 3.4.0+ deprecation - size replaced with linewidth for geom_segment
 .arrows <- function(data, color = "black", alpha = 1, linewidth = 0.5,
-                    origin = 0, xend = "x", yend = "y"){
+                    linetype = "solid", origin = 0, xend = "x", yend = "y"){
   origin <- rep(origin, nrow(data))
   dd <- cbind.data.frame(data, xstart = origin, ystart = origin)
   ggpubr::geom_exec(geom_segment, data = dd,
                     x = "xstart", y = "ystart", xend = xend, yend = yend,
                     arrow = grid::arrow(length = grid::unit(0.2, 'cm')),
-                    color = color, alpha = alpha, linewidth = linewidth)
+                    color = color, alpha = alpha, linewidth = linewidth,
+                    linetype = linetype)
 }
 
 

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -15,6 +15,7 @@ fviz(
   pointsize = 1.5,
   pointshape = 19,
   arrowsize = 0.5,
+  arrow.linetype = "solid",
   habillage = "none",
   addEllipses = FALSE,
   ellipse.level = 0.95,
@@ -75,6 +76,9 @@ Default value is "none". Allowed values are the combination of c("ind",
 \item{pointshape}{the shape of points}
 
 \item{arrowsize}{the size of arrows. Controls the thickness of arrows.}
+
+\item{arrow.linetype}{linetype of the variable arrows (e.g. "solid",
+"dashed", "dotted"). Default is "solid".}
 
 \item{habillage}{an optional factor variable for coloring the observations by 
 groups. Default value is "none". If X is a PCA object from FactoMineR 

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -506,3 +506,20 @@ test_that("fviz_eig validates parallel.iter for parallel analysis", {
     "parallel.iter must be a single positive integer value in"
   )
 })
+
+test_that("arrow.linetype controls variable-arrow linetype; default unchanged (#73)", {
+  skip_if_not_installed("FactoMineR")
+  res <- FactoMineR::PCA(decathlon2[1:23, 1:10], graph = FALSE)
+
+  arrow_lt <- function(p) {
+    seg <- Filter(function(l) inherits(l$geom, "GeomSegment") &&
+                    !is.null(l$geom_params$arrow), p$layers)
+    if (!length(seg)) return(NA_character_)
+    lt <- seg[[1]]$aes_params$linetype
+    if (is.null(lt)) "solid" else as.character(lt)
+  }
+
+  expect_equal(arrow_lt(fviz_pca_var(res)), "solid")                       # default
+  expect_equal(arrow_lt(fviz_pca_var(res, arrow.linetype = "dashed")), "dashed")
+  expect_equal(arrow_lt(fviz_pca_biplot(res, arrow.linetype = "dotted")), "dotted")
+})


### PR DESCRIPTION
New optional `arrow.linetype` argument (default `"solid"`) sets the line type of variable arrows, threaded through `fviz()` to the internal `.arrows()` helper.

**No regression:** default `"solid"` == previous implicit behavior (verified the default arrow layer is still solid; only changes when a non-default value is passed). Works in `fviz_pca_var()` and `fviz_pca_biplot()`. Suite green (73 tests).

Fixes #73