### PR TITLE
chore: gitignore gh-aw runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 Rplots.pdf
 .claude/skills/
 .vscode/
+.github/aw/logs/


### PR DESCRIPTION
Ignore `.github/aw/logs/` produced by local `gh aw run`/`audit`.