### PR TITLE
fix(fviz_dend): render the sub argument as subtitle (#54)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
 
 ## New Features
 
+* `fviz_dend()` now renders the `sub` argument as a plot subtitle. `sub`
+  defaults to `NULL` (no subtitle, as before); set it to a string to add one. (#54)
 * `fviz_pca_var()` / `fviz_pca_biplot()` (and other arrow plots) gain an
   `arrow.linetype` argument to set the variable-arrow line type (e.g. `"dashed"`).
   Default `"solid"` reproduces the previous appearance. (#73)

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -43,8 +43,9 @@
 #' @param horiz a logical value. If TRUE, an horizontal dendrogram is drawn.
 #' @param cex size of labels
 #' @param main,xlab,ylab main and axis titles
-#' @param sub Plot subtitle. If NULL, the method used hierarchical clustering is
-#'   shown. To remove the subtitle use sub = "".
+#' @param sub Plot subtitle. Default is NULL (no subtitle). Set to a character
+#'   string to display a subtitle below the title, e.g.
+#'   \code{sub = paste0("Method: ", "ward.D2")}.
 #' @param ggtheme function, ggplot2 theme name. Default value is 
 #'   theme_classic(). Allowed values include ggplot2 official themes: 
 #'   theme_gray(), theme_bw(), theme_minimal(), theme_classic(), theme_void(), 
@@ -146,7 +147,8 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   else stop("Can't handle an object of class ", paste(class(x), collapse =", ") )
   if(is.null(method)) method <- ""
   else if(is.na(method)) method <- ""
-  if(is.null(sub) && method != "") sub = paste0("Method: ", method)
+  # `sub` defaults to NULL (no subtitle), preserving the previous appearance.
+  # When set, it is rendered via labs(subtitle=) below (#54).
   
   if(!is.null(dendextend::labels_cex(dend))) cex <- dendextend::labels_cex(dend)
   dend <- dendextend::set(dend, "labels_cex", cex) 
@@ -180,7 +182,7 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
                       ggtheme = ggtheme, horiz = horiz, circular = circular, palette = palette,
                       labels = show_labels, label_cols = label_cols, 
                       labels_track_height = labels_track_height, ...)
-    if(!circular) p <- p + labs(title = main, x = xlab, y = ylab)
+    if(!circular) p <- p + labs(title = main, subtitle = sub, x = xlab, y = ylab)
   }
   else if(phylogenic){
     p <- .phylogenic_tree(dend, labels = show_labels, label_cols = label_cols,

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -93,8 +93,9 @@ around clusters. Ignored when rect = FALSE.}
 
 \item{main, xlab, ylab}{main and axis titles}
 
-\item{sub}{Plot subtitle. If NULL, the method used hierarchical clustering is
-shown. To remove the subtitle use sub = "".}
+\item{sub}{Plot subtitle. Default is NULL (no subtitle). Set to a character
+string to display a subtitle below the title, e.g.
+\code{sub = paste0("Method: ", "ward.D2")}.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is 
 theme_classic(). Allowed values include ggplot2 official themes: 

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -523,3 +523,13 @@ test_that("arrow.linetype controls variable-arrow linetype; default unchanged (#
   expect_equal(arrow_lt(fviz_pca_var(res, arrow.linetype = "dashed")), "dashed")
   expect_equal(arrow_lt(fviz_pca_biplot(res, arrow.linetype = "dotted")), "dotted")
 })
+
+test_that("fviz_dend renders sub only when set; default has no subtitle (#54)", {
+  hc <- hclust(dist(USArrests[1:15, ]), method = "ward.D2")
+
+  # default: no subtitle (unchanged behavior)
+  expect_null(fviz_dend(hc)$labels$subtitle)
+  # explicit subtitle is rendered
+  expect_equal(fviz_dend(hc, sub = "Method: ward.D2")$labels$subtitle, "Method: ward.D2")
+  expect_s3_class(fviz_dend(hc, k = 3), "ggplot")
+})


### PR DESCRIPTION
`fviz_dend()` accepted `sub` but never passed it to `labs()`, so it had no effect. Now rendered via `labs(subtitle = sub)`.

**No default-output change (gated):** `sub` defaults to `NULL` → `labs(subtitle = NULL)` → no subtitle, identical to current plots (verified). The old auto-generated `"Method: …"` default — which never actually displayed — is dropped in favour of an explicit, opt-in subtitle. Set `sub="..."` to add one. Suite green (74 tests).

Fixes #54