### PR TITLE
fix(fviz_dend): remove stray legend glyph from dendrograms (#14 sibling)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
   variables share factor-level names (e.g. several variables with `Low`/`High`).
   Colliding categories are relabelled `variable_level` (e.g. `Acidity_Low`);
   non-colliding labels are unchanged. (#184, #140)
+* `fviz_dend()` no longer leaks its leaf-label text layer into the legend
+  (the stray `a`/`cex` key), matching the scatter-plot cleanup. (#14)
 * Point/individual labels no longer add a stray `a` glyph to the colour/fill
   legend (e.g. `fviz_pca_ind(..., habillage = )`). Text layers are now excluded
   from the legend keys; labels still appear on the plot. (#14)

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -199,6 +199,10 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
                               lower_rect = lower_rect)
   }
   
+  # Keep the leaf-label text layer out of the legend (no stray "a" glyph),
+  # mirroring the scatter-plot cleanup in .fviz_finish() (#14).
+  p <- .hide_text_legend(p)
+
   attr(p, "dendrogram") <- dend
   structure(p, class = c(class(p), "fviz_dend"))
   return(p)

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -553,3 +553,12 @@ test_that("fviz_nbclust accepts a precomputed dist for diss-capable methods (#90
   expect_s3_class(fviz_nbclust(df, stats::kmeans, method = "silhouette"), "ggplot")
   expect_s3_class(fviz_nbclust(df, cluster::pam, method = "silhouette", diss = d), "ggplot")
 })
+
+test_that("fviz_dend keeps leaf labels out of the legend (#14 sibling)", {
+  hc <- hclust(dist(scale(USArrests[1:20, ])), method = "ward.D2")
+  text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  for (p in list(fviz_dend(hc), fviz_dend(hc, k = 3, cex = 0.5))) {
+    txt <- Filter(function(L) inherits(L$geom, text_geoms), p$layers)
+    expect_true(all(vapply(txt, function(L) isFALSE(L$show.legend), logical(1))))
+  }
+})


### PR DESCRIPTION
`fviz_dend()` bypasses `.fviz_finish()`, so its leaf-label text layer leaked into the legend as a stray `a`/`cex` key. Applies the same `.hide_text_legend()` cleanup before returning.

**No regression:** labels still draw; dendrogram colours come from dendextend (not a ggplot scale), so no legitimate legend is dropped. Verified across default/k/sub/phylogenic variants. Suite green (76 tests).

Refs #14