### PR TITLE
fix(fviz_dend): rect=TRUE error with tied merge heights (#154, #168)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@
   variables share factor-level names (e.g. several variables with `Low`/`High`).
   Colliding categories are relabelled `variable_level` (e.g. `Acidity_Low`);
   non-colliding labels are unchanged. (#184, #140)
+* `fviz_dend(rect = TRUE)` no longer errors ("Aesthetics must be either length 1
+  or the same as the data") for dendrograms with tied merge heights; the cluster
+  rectangles now always match `k`, and `rect_border`/`rect_fill` colour vectors are
+  recycled to `k`. (#154, #168)
 * `fviz_dend()` no longer leaks its leaf-label text layer into the legend
   (the stray `a`/`cex` key), matching the scatter-plot cleanup. (#14)
 * Point/individual labels no longer add a stray `a` glyph to the colour/fill

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -505,19 +505,24 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   m <- c(0, cumsum(clustab))
   which <- 1L:k
   
+  # Collapse height lookups to a single value: tied merge heights can make
+  # `names(tree_heights) == k` match more than one entry, which would make
+  # ytop (and thus the rectangle data frame) longer than k rows and break the
+  # geom_rect aesthetics. Well-behaved dendrograms match exactly one (#154, #168).
+  k_height <- tree_heights[names(tree_heights) == k]
+  k_height <- if (length(k_height) == 0) 0 else max(k_height)
+  next_k_height <- tree_heights[names(tree_heights) == k + 1]
+  if (length(next_k_height) == 0) {
+    next_k_height <- 0
+    prop_k_height <- 1
+  } else next_k_height <- max(next_k_height)
+
   xleft <- ybottom <- xright <- ytop <- list()
   for (n in seq_along(which)) {
-    next_k_height <- tree_heights[names(tree_heights) == k + 1]
-    if (length(next_k_height) == 0) {
-      next_k_height <- 0
-      prop_k_height <- 1
-    }
-    
     xleft[[n]] = m[which[n]] + 0.66
     ybottom[[n]] = lower_rect
     xright[[n]] = m[which[n] + 1] + 0.33
-    ytop[[n]] <- tree_heights[names(tree_heights) == k] * 
-      prop_k_height + next_k_height * (1 - prop_k_height)
+    ytop[[n]] <- k_height * prop_k_height + next_k_height * (1 - prop_k_height)
   }
   
   df <- data.frame(xmin = unlist(xleft), ymin = unlist(ybottom), xmax = unlist(xright), ymax = unlist(ytop))
@@ -528,8 +533,9 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   # See: https://github.com/kassambara/factoextra/issues/163, #180
   if(length(color) == 1 && color == "cluster") color <- "default"
   if(.is_color_palette(color)) color <- ggpubr::get_palette(color, k = k)
-  else if(length(color) > 1 && length(color) < k){
-    color <- rep(color, k)[1:k]
+  else if(length(color) > 1 && length(color) != k){
+    # recycle/trim a multi-colour vector to exactly k (one per rectangle)
+    color <- rep_len(color, k)
   }
   if(rect_fill){
     fill <- color

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -562,3 +562,29 @@ test_that("fviz_dend keeps leaf labels out of the legend (#14 sibling)", {
     expect_true(all(vapply(txt, function(L) isFALSE(L$show.legend), logical(1))))
   }
 })
+
+test_that("fviz_dend rectangles match k even with tied heights (#154, #168)", {
+  nrects <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomRect"), logical(1)))[1]
+    nrow(ggplot2::ggplot_build(p)$data[[i]])
+  }
+
+  # seed 234: binary/ward.D2 dendrogram whose heights_per_k has duplicate names
+  # (k = 2 matches >1 height) -> used to make the rect data frame longer than k,
+  # erroring with "Aesthetics must be either length 1 or the same as the data".
+  set.seed(234)
+  m <- matrix(sample(0:1, 16 * 4, replace = TRUE), ncol = 4)
+  rownames(m) <- paste0("o", seq_len(nrow(m)))
+  hc <- hclust(dist(m), method = "ward.D2")
+
+  expect_equal(nrects(fviz_dend(hc, k = 2, rect = TRUE, rect_fill = TRUE,
+                                rect_border = c("red", "blue"))), 2)
+  expect_equal(nrects(fviz_dend(hc, k = 4, rect = TRUE,
+                                rect_border = ggpubr::get_palette("jco", 4))), 4)
+  # more colours than rectangles are recycled/trimmed, not errored
+  expect_equal(nrects(fviz_dend(hc, k = 3, rect = TRUE, rect_border = rainbow(6))), 3)
+
+  # NO-REGRESSION: well-behaved dendrogram still yields exactly k rectangles
+  hc2 <- hclust(dist(scale(USArrests)), method = "ward.D2")
+  for (k in 2:5) expect_equal(nrects(fviz_dend(hc2, k = k, rect = TRUE)), k)
+})


### PR DESCRIPTION
`.rect_dendrogram` matched `tree_heights[names == k]`, which returns >1 value when merge heights tie (duplicate `heights_per_k` names). That made the rectangle data frame longer than `k`, so `geom_rect` errored *at render time* with "Aesthetics must be either length 1 or the same as the data". Height lookups are now collapsed to a single value; rect count always equals `k`; colour vectors recycled to `k`.

**No default-output change:** for well-behaved dendrograms the match was already length-1 (`max()` is a no-op); verified rect counts unchanged on USArrests `k = 2..5`. Pure error-fix. Regression test uses a deterministic tied-height dendrogram (seed 234). Suite green (77 tests).

Fixes #154
Fixes #168