### PR TITLE
fix(fviz_dend): scale default lower_rect for short trees (#55)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@
   variables share factor-level names (e.g. several variables with `Low`/`High`).
   Colliding categories are relabelled `variable_level` (e.g. `Acidity_Low`);
   non-colliding labels are unchanged. (#184, #140)
+* `fviz_dend(rect = TRUE)`: the default `lower_rect` (rectangle depth) now scales
+  with tree height for short trees (max height < 1, e.g. correlation/gower distances),
+  where the previous fixed -0.5 offset pushed rectangles far below the labels. Taller
+  trees keep the previous default. (#55)
 * `fviz_dend(rect = TRUE)` no longer errors ("Aesthetics must be either length 1
   or the same as the data") for dendrograms with tied merge heights; the cluster
   rectangles now always match `k`, and `rect_border`/`rect_fill` colour vectors are

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -192,7 +192,14 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   # Add rectangle around clusters
   if(circular || phylogenic || is.null(k)) rect <- FALSE
   if(rect_fill && missing(rect_lty)) rect_lty = "blank"
-  if(missing(lower_rect)) lower_rect = -(labels_track_height+0.5)
+  if(missing(lower_rect)) {
+    # The absolute -0.5 offset overwhelms short trees (e.g. correlation/gower
+    # distances with max height < 1), pushing the rectangles far below the
+    # labels. For those, scale the offset to the tree height instead; taller
+    # trees (>= 1) keep the previous default unchanged (#55).
+    lower_rect <- if(max_height < 1) -(labels_track_height + max_height/8)
+                  else -(labels_track_height + 0.5)
+  }
   if(rect){
     p <- p + .rect_dendrogram(dend, k = k, palette = rect_border, rect_fill = rect_fill,
                               rect_lty = rect_lty, linewidth = lwd, 

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -588,3 +588,21 @@ test_that("fviz_dend rectangles match k even with tied heights (#154, #168)", {
   hc2 <- hclust(dist(scale(USArrests)), method = "ward.D2")
   for (k in 2:5) expect_equal(nrects(fviz_dend(hc2, k = k, rect = TRUE)), k)
 })
+
+test_that("fviz_dend lower_rect scales for short trees; tall trees unchanged (#55)", {
+  rect_ymin <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomRect"), logical(1)))[1]
+    min(ggplot2::ggplot_build(p)$data[[i]]$ymin)
+  }
+
+  # short tree (max height < 1): default lower_rect is now height-relative
+  set.seed(7)
+  m <- matrix(rnorm(18 * 3, sd = 0.04), ncol = 3); rownames(m) <- paste0("s", 1:18)
+  hc <- hclust(dist(m), "ward.D2"); mh <- max(hc$height)
+  expect_lt(mh, 1)
+  expect_equal(rect_ymin(fviz_dend(hc, k = 3, rect = TRUE)), -mh / 4)
+
+  # tall tree (max height >= 1): previous default preserved (no regression)
+  hc2 <- hclust(dist(scale(USArrests)), "ward.D2"); mh2 <- max(hc2$height)
+  expect_equal(rect_ymin(fviz_dend(hc2, k = 4, rect = TRUE)), -(mh2 / 8 + 0.5))
+})


### PR DESCRIPTION
**⚠️ Default-output change for short trees — holding for maintainer sign-off (flow c).**

The default `lower_rect` was `-(labels_track_height + 0.5)`; the fixed `0.5` offset dwarfs short trees (max height < 1, e.g. correlation/gower distances), pushing the cluster rectangles far below the labels. For short trees it now scales as `-max_height/4`; **taller trees (>= 1) are unchanged** (verified: USArrests rect ymin identical).

Before/after on a short tree (max height ~0.28) is in the issue thread — old rectangles plunged to ~-0.5 (~1.9× the whole tree height); new ones hug the tree.

Gated on `max_height < 1`, regression test added, suite green (78 tests).

Fixes #55