### PR TITLE
feat(fviz_dend): labels_font for italic/bold leaf labels (#121)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,9 @@
   `method = "silhouette"`/`"wss"`, passing it to dissimilarity-capable `FUNcluster`s
   (e.g. `cluster::pam`, `factoextra::hcut`). Non-diss methods (kmeans/clara) and
   `method = "gap_stat"` raise a clear error instead of mis-clustering. (#90)
+* `fviz_dend()` gains a `labels_font` argument ("plain"/"bold"/"italic"/"bold.italic")
+  to set the leaf-label font face, e.g. italic species names. Default "plain" leaves
+  labels unchanged. (#121)
 * `fviz_dend()` gains a `match_coord_colors` argument (default `FALSE`). When `TRUE`,
   cluster colours are remapped from left-to-right leaf order to cluster-label order,
   so a dendrogram's colours match `fviz_cluster()`/`fviz_silhouette()` for the same

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -22,6 +22,9 @@
 #'   remapped to cluster-label order so they match \code{\link{fviz_cluster}()}
 #'   and \code{\link{fviz_silhouette}()} for the same clustering.
 #' @param label_cols a vector containing the colors for labels.
+#' @param labels_font font face for the leaf labels of "rectangle"/"circular"
+#'   dendrograms. One of "plain" (default), "bold", "italic" or "bold.italic".
+#'   Default "plain" leaves labels unchanged.
 #' @param labels_track_height a positive numeric value for adjusting the room for the 
 #'   labels. Used only when type = "rectangle".
 #' @param repel logical value. Use repel = TRUE to avoid label overplotting when
@@ -107,7 +110,7 @@
 #' @export
 fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  show_labels = TRUE, color_labels_by_k = TRUE,
                       match_coord_colors = FALSE,
-                      label_cols = NULL,  labels_track_height = NULL, repel = FALSE, lwd = 0.7,
+                      label_cols = NULL, labels_font = "plain", labels_track_height = NULL, repel = FALSE, lwd = 0.7,
                       type = c("rectangle",  "circular", "phylogenic"),
                       phylo_layout = "layout.auto",
                       rect = FALSE, rect_border = "gray", rect_lty = 2, rect_fill = FALSE, lower_rect,
@@ -193,7 +196,7 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   if(rectangle || circular){
     p <- .ggplot_dend(dend, type = "rectangle", offset_labels = offset_labels, nodes = FALSE,
                       ggtheme = ggtheme, horiz = horiz, circular = circular, palette = palette,
-                      labels = show_labels, label_cols = label_cols, 
+                      labels = show_labels, label_cols = label_cols, labels_font = labels_font,
                       labels_track_height = labels_track_height, ...)
     if(!circular) p <- p + labs(title = main, subtitle = sub, x = xlab, y = ylab)
   }
@@ -328,7 +331,7 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
 .ggplot_dend <- function (dend, segments = TRUE, labels = TRUE, nodes = TRUE, 
                         horiz = FALSE, ggtheme = theme_classic(), 
                         offset_labels = 0, circular = FALSE, type = "rectangle",
-                        palette = NULL, label_cols = NULL, labels_track_height = 1,
+                        palette = NULL, label_cols = NULL, labels_font = "plain", labels_track_height = 1,
                         ...) {
   
   gdend <- dendextend::as.ggdend(dend, type = type)
@@ -386,6 +389,10 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
     p <- p + ggpubr::geom_exec(geom_text, data = data$labels,
                                x = "x", y = "y", label = "label", color = label_cols, size = "cex",
                                 angle = "angle", hjust = "hjust", vjust = "vjust")
+    # Apply a single font face to all leaf labels (e.g. "italic") as a fixed
+    # layer parameter. Only when non-default, so the "plain" path is untouched (#121).
+    if(!identical(labels_font, "plain"))
+      p$layers[[length(p$layers)]]$aes_params$fontface <- labels_font
   }
   p <- ggpubr::ggpar(p, ggtheme = ggtheme, palette = palette, ...) + theme(axis.line = element_blank())
   if (horiz && !circular) {

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -14,6 +14,7 @@ fviz_dend(
   color_labels_by_k = TRUE,
   match_coord_colors = FALSE,
   label_cols = NULL,
+  labels_font = "plain",
   labels_track_height = NULL,
   repel = FALSE,
   lwd = 0.7,
@@ -61,6 +62,10 @@ remapped to cluster-label order so they match \code{\link{fviz_cluster}()}
 and \code{\link{fviz_silhouette}()} for the same clustering.}
 
 \item{label_cols}{a vector containing the colors for labels.}
+
+\item{labels_font}{font face for the leaf labels of "rectangle"/"circular"
+dendrograms. One of "plain" (default), "bold", "italic" or "bold.italic".
+Default "plain" leaves labels unchanged.}
 
 \item{labels_track_height}{a positive numeric value for adjusting the room for the 
 labels. Used only when type = "rectangle".}

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -630,3 +630,21 @@ test_that("fviz_dend match_coord_colors aligns colours to cluster labels (#103)"
     dendextend::get_leaves_branches_col(attr(fviz_dend(hc, k = k, match_coord_colors = FALSE), "dendrogram"))
   )
 })
+
+test_that("fviz_dend labels_font sets leaf-label font face; default unchanged (#121)", {
+  hc <- hclust(dist(scale(USArrests[1:20, ])), "ward.D2")
+  text_layer <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))[1]
+    p$layers[[i]]
+  }
+
+  # opt-in font face applies to the leaf-label layer
+  expect_equal(text_layer(fviz_dend(hc, k = 3, labels_font = "italic"))$aes_params$fontface, "italic")
+  expect_equal(text_layer(fviz_dend(hc, k = 3, labels_font = "bold.italic"))$aes_params$fontface, "bold.italic")
+
+  # NO-REGRESSION: default (and explicit "plain") leave the layer untouched
+  expect_null(text_layer(fviz_dend(hc, k = 3))$aes_params$fontface)
+  expect_null(text_layer(fviz_dend(hc, k = 3, labels_font = "plain"))$aes_params$fontface)
+
+  expect_s3_class(fviz_dend(hc, k = 3, rect = TRUE, labels_font = "italic"), "ggplot")
+})


### PR DESCRIPTION
Adds opt-in `labels_font` ("plain"/"bold"/"italic"/"bold.italic") to style `fviz_dend()` leaf labels (e.g. italic species names) for rectangle/circular dendrograms.

**No regression:** applied as a fixed layer parameter **only when non-default**, so `"plain"` (the default) never touches the label layer — verified the text layer has no `fontface` aes_param by default (byte-identical). No mapped aesthetic → no stray scale/legend. Regression + no-regression tests added; suite green (80 tests).

Fixes #121