### PR TITLE
fix(fviz): alpha.var/alpha.ind also fade text labels (#130)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@
   recycled to `k`. (#154, #168)
 * `fviz_dend()` no longer leaks its leaf-label text layer into the legend
   (the stray `a`/`cex` key), matching the scatter-plot cleanup. (#14)
+* `alpha.var`/`alpha.ind` (and `alpha`) now also fade the variable/individual text
+  labels, not just the points and arrows, in `fviz_pca_*()` and the other biplots.
+  Only a numeric `alpha < 1` is affected; the default (`alpha = 1`) is unchanged. (#130)
 * Point/individual labels no longer add a stray `a` glyph to the colour/fill
   legend (e.g. `fviz_pca_ind(..., habillage = )`). Text layers are now excluded
   from the legend keys; labels still appear on the plot. (#14)

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -252,8 +252,12 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   
   label <- NULL
   if(lab[[element]] && "text" %in% geom && !hide[[element]]) label <- "name"
-  
-  p <- ggplot() 
+
+  # Layers already present (when chaining via ggp, e.g. biplots) so we only
+  # restyle the text labels added for THIS element below (#130).
+  n_layers_before <- if(is.null(ggp)) 0L else length(ggp$layers)
+
+  p <- ggplot()
   if(hide[[element]]) {
     # FIX: ggplot2 3.0.0+ deprecation - aes_string() replaced with aes() + .data pronoun
     # See: https://github.com/kassambara/factoextra/issues/190
@@ -269,7 +273,21 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
                          main = title, ggtheme = ggtheme, ggp = ggp, font.family = font.family, ...)
   if(alpha %in% c("cos2","contrib", "coord", "x", "y"))
     p <- p + scale_alpha(limits = range(df.all[, alpha]))
-  
+
+  # Apply a numeric alpha to this element's text labels too, not just its
+  # points/arrows, so e.g. alpha.var fades the variable names as well (#130).
+  # Gated on a numeric alpha < 1, so the default (alpha = 1) and metric-mapped
+  # alpha ("cos2"/"contrib"/...) paths are byte-identical. Only restyles labels
+  # added for this element (index > n_layers_before), preserving other layers
+  # when chaining via ggp (e.g. biplots).
+  if(is.numeric(alpha) && length(alpha) == 1 && !is.na(alpha) && alpha < 1){
+    .text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+    for(i in seq_along(p$layers)){
+      if(i > n_layers_before && inherits(p$layers[[i]]$geom, .text_geoms))
+        p$layers[[i]]$aes_params$alpha <- alpha
+    }
+  }
+
   if(!is.null(gradient.cols))
     p <- p + ggpubr::gradient_color(gradient.cols)
     

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -648,3 +648,25 @@ test_that("fviz_dend labels_font sets leaf-label font face; default unchanged (#
 
   expect_s3_class(fviz_dend(hc, k = 3, rect = TRUE, labels_font = "italic"), "ggplot")
 })
+
+test_that("alpha.var/alpha.ind fade text labels too; default unchanged (#130)", {
+  res <- prcomp(iris[1:20, -5], scale. = TRUE)
+  text_alpha <- function(p) {
+    L <- Filter(function(l) inherits(l$geom, c("GeomText", "GeomTextRepel")), p$layers)
+    vapply(L, function(l) { a <- l$aes_params$alpha; if (is.null(a)) NA_real_ else a }, numeric(1))
+  }
+
+  # labels now fade together with arrows/points
+  expect_true(all(text_alpha(fviz_pca_var(res, alpha.var = 0.3)) == 0.3))
+  expect_true(all(text_alpha(fviz_pca_ind(res, alpha.ind = 0.3)) == 0.3))
+
+  # NO-REGRESSION: default (alpha = 1) keeps labels opaque
+  expect_true(all(text_alpha(fviz_pca_var(res)) == 1))
+  expect_true(all(text_alpha(fviz_pca_ind(res)) == 1))
+  # metric-mapped alpha does not fade labels to a constant
+  expect_true(all(text_alpha(fviz_pca_var(res, alpha.var = "contrib")) == 1))
+
+  # biplot: alpha.var fades variable labels but leaves individual labels opaque
+  ta <- text_alpha(fviz_pca_biplot(res, alpha.var = 0.3, label = "all"))
+  expect_true(0.3 %in% ta && 1 %in% ta)
+})


### PR DESCRIPTION
A numeric `alpha` faded points/arrows but not the text labels, so e.g. `alpha.var = 0.3` left variable names fully opaque. `fviz()` now applies a numeric `alpha < 1` to the element's text-label layer too.

**No regression (gated):** only a numeric `alpha < 1` is affected — default `alpha = 1` and metric-mapped alpha (`"cos2"`/`"contrib"`/…) are **byte-identical** (verified default text alpha stays 1 across PCA/CA/MCA/FAMD). Only the current element's labels are restyled (index > pre-existing layers), so in biplots `alpha.var` fades variable labels while individual labels stay opaque (verified `1,0.3`). Regression + no-regression tests; suite green (81 tests).

Fixes #130