### PR TITLE
fix(fviz_mclust_bic): optimal-cluster line off-by on restricted/outlier models (#116)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,10 @@
   or the same as the data") for dendrograms with tied merge heights; the cluster
   rectangles now always match `k`, and `rect_border`/`rect_fill` colour vectors are
   recycled to `k`. (#154, #168)
+* `fviz_mclust_bic()`: the red "optimal clusters" line now lands on the correct cluster
+  when the model's cluster counts don't start at 1 (e.g. a restricted `G` range or a
+  noise/outlier model). It previously used the numeric `G` as a position on the discrete
+  x-axis; standard `G = 1:k` models are unaffected. (#116)
 * `fviz_dend()` no longer leaks its leaf-label text layer into the legend
   (the stray `a`/`cex` key), matching the scatter-plot cleanup. (#14)
 * `alpha.var`/`alpha.ind` (and `alpha`) now also fade the variable/individual text

--- a/R/fviz_mclust.R
+++ b/R/fviz_mclust.R
@@ -98,11 +98,18 @@ fviz_mclust_bic <- function(object, model.names = NULL, shape = 19, color = "mod
   ggline.opts <- list(data = x, x ="cluster", y = "BIC", group = "model",
                       color = color, shape = shape, palette = palette,
                       main = main, xlab = xlab, ylab = ylab,...)
+  # The x-axis is a discrete factor, so the optimal-cluster line must use the
+  # position of `number_of_cluster` among the cluster levels, not its numeric
+  # value (those differ when the cluster counts don't start at 1, e.g. a
+  # restricted G range or a noise/outlier model). For the standard G = 1:k case
+  # the position equals the value, so this is unchanged. (#116)
+  opt_x <- match(as.character(number_of_cluster), levels(x$cluster))
   p <- do.call(ggpubr::ggline, ggline.opts)+
-    labs(subtitle = paste0("Best model: ", best_model, 
+    labs(subtitle = paste0("Best model: ", best_model,
                            " | Optimal clusters: n = ",  number_of_cluster))+
-    geom_vline(xintercept = number_of_cluster, linetype = 2, color = "red")+
     theme(legend.title = element_blank())
+  if(!is.na(opt_x))
+    p <- p + geom_vline(xintercept = opt_x, linetype = 2, color = "red")
 
   
   if(missing(legend)) p + theme(legend.position = c(0.7, 0.2), legend.direction = "horizontal",

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -670,3 +670,26 @@ test_that("alpha.var/alpha.ind fade text labels too; default unchanged (#130)", 
   ta <- text_alpha(fviz_pca_biplot(res, alpha.var = 0.3, label = "all"))
   expect_true(0.3 %in% ta && 1 %in% ta)
 })
+
+test_that("fviz_mclust_bic optimal-cluster line uses factor position (#116)", {
+  skip_if_not_installed("mclust")
+  vline_x <- function(p) {
+    L <- Filter(function(l) inherits(l$geom, "GeomVline"), p$layers)
+    if (!length(L)) return(NA_real_)
+    L[[1]]$data$xintercept
+  }
+
+  # restricted G range: cluster levels start at 3, so the line must sit at the
+  # *position* of the optimal G, landing on the correctly-labelled tick.
+  set.seed(1)
+  m_restr <- mclust::Mclust(iris[, -5], G = 3:9, verbose = FALSE)
+  p_restr <- fviz_mclust_bic(m_restr)
+  lv <- levels(p_restr$data$cluster)
+  expect_equal(vline_x(p_restr), match(as.character(m_restr$G), lv))
+  expect_equal(lv[vline_x(p_restr)], as.character(m_restr$G))
+
+  # NO-REGRESSION: standard G = 1:9 -> levels start at 1, position == G
+  set.seed(1)
+  m_std <- mclust::Mclust(iris[, -5], verbose = FALSE)
+  expect_equal(vline_x(fviz_mclust_bic(m_std)), m_std$G)
+})


### PR DESCRIPTION
The BIC x-axis is a discrete factor, but the red "optimal clusters" vline used numeric `number_of_cluster` as the intercept — only correct when cluster counts start at 1. For restricted `G` ranges or noise/outlier models the line landed on the wrong cluster. Now maps `G` to its factor position via `match()`.

**No regression:** standard `G = 1:k` → position == value → byte-identical (verified). Only the previously-wrong restricted/outlier case is corrected. Adversarially reviewed by a separate agent (no blockers; noise-model verified). Regression + no-regression tests; suite green (82).

Fixes #116