### PR TITLE
test: drop undeclared withr from #116 test (CI fix)

### DIFF
--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -674,8 +674,10 @@ test_that("alpha.var/alpha.ind fade text labels too; default unchanged (#130)", 
 test_that("fviz_mclust_bic optimal-cluster line uses factor position (#116)", {
   skip_if_not_installed("mclust")
   # mclust::Mclust() calls mclustBIC() by name, which requires mclust to be
-  # ATTACHED (not just namespaced); attach it for this test only.
-  withr::local_package("mclust")
+  # ATTACHED (not just namespaced). Attach it (mclust is in Suggests) and detach
+  # on exit to keep the search path clean.
+  suppressPackageStartupMessages(library(mclust))
+  on.exit(detach("package:mclust", unload = FALSE), add = TRUE)
   vline_x <- function(p) {
     L <- Filter(function(l) inherits(l$geom, "GeomVline"), p$layers)
     if (!length(L)) return(NA_real_)


### PR DESCRIPTION
Follow-up to the #116 test fix. `withr::local_package()` triggered an "unstated dependencies in 'tests'" WARNING (withr isn't declared), which CI fails on (`error_on=warning`). Replaced with `library(mclust)` (mclust already in Suggests) + `on.exit(detach())`. Verified in clean `R --vanilla`: tests pass, search path clean, no undeclared-import warning.