### PR TITLE
feat(fviz): add.circle to control the correlation circle (#88)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,10 @@
 
 * `fviz_dend()` now renders the `sub` argument as a plot subtitle. `sub`
   defaults to `NULL` (no subtitle, as before); set it to a string to add one. (#54)
+* `fviz_pca_var()`/`fviz_pca_biplot()` (via `fviz()`) gain an `add.circle` argument to
+  force (`TRUE`) or suppress (`FALSE`) the variable correlation circle. Default `NULL`
+  keeps the previous automatic behavior (shown only for unit-variance PCA). Useful when
+  scaling manually and fitting `prcomp(scale = FALSE)`. (#88)
 * `fviz_pca_var()` / `fviz_pca_biplot()` (and other arrow plots) gain an
   `arrow.linetype` argument to set the variable-arrow line type (e.g. `"dashed"`).
   Default `"solid"` reproduces the previous appearance. (#73)

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -58,6 +58,12 @@ NULL
 #'@param col.circle a color for the correlation circle. Used only when X is a 
 #'  PCA output.
 #'@param circlesize the size of the variable correlation circle.
+#'@param add.circle logical or NULL controlling the variable correlation circle.
+#'  Default NULL shows it only when meaningful: for PCA variables on
+#'  unit-variance (scaled) data, and for quantitative variables of
+#'  MCA/MFA/HMFA/FAMD. Use \code{add.circle = TRUE} to force the circle (e.g. a
+#'  \code{prcomp(scale = FALSE)} fit on data you scaled manually) or
+#'  \code{add.circle = FALSE} to suppress it.
 #'@param axes.linetype linetype of x and y axes.
 #'@param color color to be used for the specified geometries (point, text). Can 
 #'  be a continuous variable or a factor variable. Possible values include also 
@@ -137,7 +143,8 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
                           col.row.sup = "darkblue", col.col.sup="darkred",
                           select = list(name = NULL, cos2 = NULL, contrib = NULL),
                           title = NULL, axes.linetype = "dashed",
-                          repel = FALSE, col.circle ="grey70", circlesize = 0.5, ggtheme = theme_minimal(),
+                          repel = FALSE, col.circle ="grey70", circlesize = 0.5, add.circle = NULL,
+                          ggtheme = theme_minimal(),
                           ggp = NULL, font.family = "",
                            ...)
   {
@@ -297,13 +304,19 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   if("arrow" %in% geom && !hide[[element]])
     p <- p + .arrows(data = df, color = color, alpha = alpha, linewidth = arrowsize,
                      linetype = arrow.linetype)
-  # Add correlation circle if PCA & element = "var" & scale = TRUE
+  # Add correlation circle. By default (add.circle = NULL) the circle is shown
+  # only when it is meaningful: for PCA variables on unit-variance (scaled) data,
+  # and for quanti variables of MCA/MFA/HMFA/FAMD. add.circle = TRUE/FALSE forces
+  # or suppresses it (e.g. force it for a prcomp(scale = FALSE) on data the user
+  # scaled manually). (#88)
+  .want_circle <- function(default) if(is.null(add.circle)) isTRUE(default) else isTRUE(add.circle)
   if(facto.class == "PCA" && element == "var"){
-    if(.get_scale_unit(X) && is.null(extra_args$scale.)) 
+    if(.want_circle(.get_scale_unit(X) && is.null(extra_args$scale.)))
       p <- .add_corr_circle(p, color = col.circle, size = circlesize)
   }
   else if(facto.class %in% c("MCA", "MFA", "HMFA", "FAMD") && element %in% c("quanti.sup", "quanti.var", "partial.axes")){
-      p <- .add_corr_circle(p, color = col.circle, size = circlesize)
+      if(.want_circle(TRUE))
+        p <- .add_corr_circle(p, color = col.circle, size = circlesize)
   }
   # Faceting when multiple variables are used to color individuals
   # (e.g., habillage = 1:2, or data.frame)

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -34,6 +34,7 @@ fviz(
   repel = FALSE,
   col.circle = "grey70",
   circlesize = 0.5,
+  add.circle = NULL,
   ggtheme = theme_minimal(),
   ggp = NULL,
   font.family = "",
@@ -158,6 +159,13 @@ compatibility and is converted to \code{repel = TRUE} with a deprecation warning
 PCA output.}
 
 \item{circlesize}{the size of the variable correlation circle.}
+
+\item{add.circle}{logical or NULL controlling the variable correlation circle.
+Default NULL shows it only when meaningful: for PCA variables on
+unit-variance (scaled) data, and for quantitative variables of
+MCA/MFA/HMFA/FAMD. Use \code{add.circle = TRUE} to force the circle (e.g. a
+\code{prcomp(scale = FALSE)} fit on data you scaled manually) or
+\code{add.circle = FALSE} to suppress it.}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -698,3 +698,21 @@ test_that("fviz_mclust_bic optimal-cluster line uses factor position (#116)", {
   m_std <- Mclust(iris[, -5], verbose = FALSE)
   expect_equal(vline_x(fviz_mclust_bic(m_std)), m_std$G)
 })
+
+test_that("fviz_pca add.circle forces/suppresses the correlation circle (#88)", {
+  has_circle <- function(p) {
+    any(vapply(p$layers, function(l) inherits(l$geom, c("GeomPath", "GeomCircle")),
+               logical(1)))
+  }
+  sc <- prcomp(iris[, -5], scale. = TRUE)
+  un <- prcomp(iris[, -5], scale. = FALSE)
+
+  # NO-REGRESSION: default (NULL) keeps the auto behavior
+  expect_true(has_circle(fviz_pca_var(sc)))   # scaled -> circle
+  expect_false(has_circle(fviz_pca_var(un)))  # unscaled -> no circle
+
+  # opt-in: force on a manually-scaled (scale = FALSE) fit, or suppress
+  expect_true(has_circle(fviz_pca_var(un, add.circle = TRUE)))
+  expect_false(has_circle(fviz_pca_var(sc, add.circle = FALSE)))
+  expect_true(has_circle(fviz_pca_biplot(un, add.circle = TRUE)))
+})


### PR DESCRIPTION
New `add.circle` argument on `fviz()` (→ `fviz_pca_var()`/`fviz_pca_biplot()` via `...`): `NULL` (default) = current automatic behavior; `TRUE` forces the variable correlation circle (e.g. a `prcomp(scale = FALSE)` fit on manually-scaled data); `FALSE` suppresses it.

**No regression:** default `NULL` is byte-identical for both the PCA-var and MCA/MFA branches (verified; `.get_scale_unit()` is length-1 logical for all backends). **Adversarially reviewed** (no blockers) and verified in a clean `R --vanilla` session. Regression + no-regression tests; suite green (83).

Fixes #88