### PR TITLE
fix(fviz_cluster): plot diss-based pam/fanny via data= (#128)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,11 @@
 * `alpha.var`/`alpha.ind` (and `alpha`) now also fade the variable/individual text
   labels, not just the points and arrows, in `fviz_pca_*()` and the other biplots.
   Only a numeric `alpha < 1` is affected; the default (`alpha = 1`) is unchanged. (#130)
+* `fviz_cluster()` now plots `pam()`/`fanny()` results fitted on a dissimilarity
+  matrix (`diss = TRUE`) when the original data is passed via `data=` (previously the
+  user's `data=` was overwritten by the object's empty data slot, erroring with "'data'
+  must be of vector type, was NULL"). The clusters come from the object; `data=` is used
+  only for the 2-D layout. A clear message is shown if no data is available. (#128)
 * Point/individual labels no longer add a stray `a` glyph to the colour/fill
   legend (e.g. `fviz_pca_ind(..., habillage = )`). Text layers are now excluded
   from the legend keys; labels still appear on the plot. (#14)

--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -168,7 +168,31 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
   
   
   # object from cluster package
-  if(inherits(object, c("partition", "hkmeans", "eclust"))) data <- object$data
+  if(inherits(object, c("partition", "hkmeans", "eclust"))){
+    # Use the object's own data when present; otherwise keep the user-supplied
+    # `data=`. pam()/fanny() fitted on a dissimilarity matrix store no
+    # coordinates (object$data is NULL), so the original data is needed for the
+    # 2-D layout; the cluster assignments still come from the object (#128).
+    if(!is.null(object$data)) data <- object$data
+    else if(!is.null(data)){
+      # Align the object's clustering to the supplied data's rows by name, so
+      # points are not silently mis-coloured if `data` is ordered differently
+      # from the dissimilarity. Error on a genuine set mismatch.
+      cl <- object$clustering
+      if(!is.null(cl) && !is.null(names(cl)) && !is.null(rownames(data))){
+        if(!setequal(names(cl), rownames(data)))
+          stop("The row names of `data` do not match the observations used to ",
+               "build the clustering. Pass the same data used for the ",
+               "dissimilarity matrix.", call. = FALSE)
+        object$clustering <- cl[rownames(data)]
+      }
+    }
+    if(is.null(data))
+      stop("This clustering has no stored data (e.g. pam()/fanny() on a ",
+           "dissimilarity matrix). Supply the original data via 'data=' - it is ",
+           "used only for the 2-D layout; the cluster assignments come from the object.",
+           call. = FALSE)
+  }
   # Object from kmeans (stats package)
   else if((inherits(object, "kmeans") && !inherits(object, "eclust")) || inherits(object, "dbscan")){
     if(is.null(data)) stop("data is required for plotting kmeans/dbscan clusters")

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -716,3 +716,37 @@ test_that("fviz_pca add.circle forces/suppresses the correlation circle (#88)", 
   expect_false(has_circle(fviz_pca_var(sc, add.circle = FALSE)))
   expect_true(has_circle(fviz_pca_biplot(un, add.circle = TRUE)))
 })
+
+test_that("fviz_cluster plots diss-based pam/fanny when data is supplied (#128)", {
+  skip_if_not_installed("cluster")
+  df <- scale(USArrests)
+  d  <- get_dist(df, method = "euclidean")
+
+  pr <- cluster::pam(d, k = 4, diss = TRUE)
+  p  <- fviz_cluster(pr, data = df, geom = "point")
+  expect_s3_class(p, "ggplot")
+  # cluster assignments come from the (dissimilarity-based) object, aligned per
+  # observation by name (not recomputed from data=)
+  pt_cluster <- function(p) {
+    setNames(as.integer(as.character(p$data$cluster)), rownames(p$data))
+  }
+  expect_equal(pt_cluster(p)[names(pr$clustering)], pr$clustering)
+
+  fa <- cluster::fanny(d, k = 3, diss = TRUE)
+  expect_s3_class(fviz_cluster(fa, data = df, geom = "point"), "ggplot")
+
+  # data= in a DIFFERENT row order than the dissimilarity must still colour each
+  # point with its own cluster (aligned by row name), not silently mis-mapped
+  dfs <- df[sample(nrow(df)), ]
+  ps  <- fviz_cluster(pr, data = dfs, geom = "point")
+  expect_equal(pt_cluster(ps)[names(pr$clustering)], pr$clustering)
+
+  # data= for different observations (row names don't match) -> clear error
+  expect_error(fviz_cluster(pr, data = scale(mtcars[, 1:4])), "do not match")
+
+  # no data available -> clear, actionable error (not the cryptic NULL one)
+  expect_error(fviz_cluster(pr), "dissimilarity matrix")
+
+  # NO-REGRESSION: pam fitted on raw data (object$data present) is unchanged
+  expect_s3_class(fviz_cluster(cluster::pam(df, k = 4), geom = "point"), "ggplot")
+})


### PR DESCRIPTION
`fviz_cluster()` did `data <- object$data` for partition objects, which is NULL for `pam()`/`fanny()` fitted with `diss=TRUE` and **overwrote the user's `data=`** → `'data' must be of vector type, was NULL`. Now the object's data is used only when present; otherwise `data=` is kept (used only for the 2-D layout — clusters come from the object). Clear error when no data is available.

The object's clustering is **aligned to `data`'s row names**, so points aren't silently mis-coloured if `data=` is in a different order than the dissimilarity (an adversarial reviewer's shuffle test was 33/50 wrong before — now correct); a set mismatch errors clearly.

**No regression:** raw-data pam/clara/fanny/hkmeans/eclust unchanged (verified all object types, clean `R --vanilla`). **Two independent adversarial reviews** (no blockers; the flagged mis-order hazard is fixed). Regression + no-regression tests (shuffle, wrong-data); suite green (84).

Fixes #128