### PR TITLE
fix(fviz): clearer error for wrong-length col/fill vector (#139)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,10 @@
   user's `data=` was overwritten by the object's empty data slot, erroring with "'data'
   must be of vector type, was NULL"). The clusters come from the object; `data=` is used
   only for the 2-D layout. A clear message is shown if no data is available. (#128)
+* Clearer error when a `col`/`fill` vector passed to a `fviz_*` plot has the wrong length
+  (e.g. colouring variables in `fviz_pca_var()` by an observation-level group): the message
+  now explains the length must match the elements plotted (individuals for `fviz_*_ind()`,
+  variables for `fviz_*_var()`) or be a metric. (#139)
 * Point/individual labels no longer add a stray `a` glyph to the colour/fill
   legend (e.g. `fviz_pca_ind(..., habillage = )`). Text layers are now excluded
   from the legend keys; labels still appear on the plot. (#14)

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -208,8 +208,10 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   }
   # Augment data if color is a continuous variable or a factor variable
   if(length(color) > 1){
-    if(nrow(df) != length(color)) stop("The length of color variable",
-                                    "should be the same as the number of rows in the data.")
+    if(nrow(df) != length(color)) stop(
+      "The length of the `color` variable must equal the number of elements being ",
+      "plotted (individuals for fviz_*_ind(), variables for fviz_*_var()), or be a ",
+      "single value or a metric such as \"cos2\"/\"contrib\".", call. = FALSE)
     .col.name <- "Col."
     df[[.col.name]] <- color
     if(missing(pointshape) && .is_grouping_var(color)) pointshape <- .col.name
@@ -217,8 +219,10 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   }
   # Augment data if fill is a continuous variable or a factor variable
   if(length(fill) > 1){
-    if(nrow(df) != length(fill)) stop("The length of fill variable",
-                                       "should be the same as the number of rows in the data.")
+    if(nrow(df) != length(fill)) stop(
+      "The length of the `fill` variable must equal the number of elements being ",
+      "plotted (individuals for fviz_*_ind(), variables for fviz_*_var()), or be a ",
+      "single value or a metric such as \"cos2\"/\"contrib\".", call. = FALSE)
     .col.name <- "Fill."
     df[[.col.name]] <- fill
     fill <- .col.name

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -750,3 +750,18 @@ test_that("fviz_cluster plots diss-based pam/fanny when data is supplied (#128)"
   # NO-REGRESSION: pam fitted on raw data (object$data present) is unchanged
   expect_s3_class(fviz_cluster(cluster::pam(df, k = 4), geom = "point"), "ggplot")
 })
+
+test_that("fviz colour/fill length-mismatch gives a clear message; valid usage works (#139)", {
+  res <- prcomp(iris[, -5], scale. = TRUE)   # 150 individuals, 4 variables
+
+  # colouring VARIABLES by an observation-level group (length 150 != 4 variables)
+  expect_error(fviz_pca_var(res, col.var = iris$Species),
+               "number of elements being plotted")
+  expect_error(fviz_pca_ind(res, fill.ind = c("a", "b")),
+               "number of elements being plotted")
+
+  # valid usages still work (no behavior change)
+  expect_s3_class(fviz_pca_var(res, col.var = "contrib"), "ggplot")
+  expect_s3_class(fviz_pca_var(res, col.var = factor(c("a", "a", "b", "b"))), "ggplot")
+  expect_s3_class(fviz_pca_ind(res, col.ind = iris$Species), "ggplot")
+})


### PR DESCRIPTION
Colouring **variables** in `fviz_pca_var(col.var=)` by an observation-level group (length = #individuals) correctly errors, but the message was confusing (run-together `variableshould` typo + ambiguous "number of rows in the data"). Reworded both color/fill messages to say the length must match the elements plotted (individuals for `fviz_*_ind()`, variables for `fviz_*_var()`) or be a metric.

**Message-only:** validation guards unchanged → identical behavior for all inputs (verified). Independent adversarial review found no issues; clean-session green; regression test added (clear error fires + valid usages work). Not a code-behavior bug — see #139 (reply explains the conceptual point).

Refs #139