### PR TITLE
fix(fviz_cluster): remove stray legend glyph (#14 sibling)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,8 @@
   when the model's cluster counts don't start at 1 (e.g. a restricted `G` range or a
   noise/outlier model). It previously used the numeric `G` as a position on the discrete
   x-axis; standard `G = 1:k` models are unaffected. (#116)
+* `fviz_cluster()` no longer leaks its point-label text layer into the legend (the stray
+  `a` key), matching the scatter and dendrogram plots. (#14)
 * `fviz_dend()` no longer leaks its leaf-label text layer into the legend
   (the stray `a`/`cex` key), matching the scatter-plot cleanup. (#14)
 * `alpha.var`/`alpha.ind` (and `alpha`) now also fade the variable/individual text

--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -337,6 +337,9 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
     p <- .add_outliers(p, outliers_data, outliers_labs, outlier.color, outlier.shape,
                   outlier.pointsize, outlier.labelsize/3, geom, repel = repel)
 
+  # Keep the point labels out of the legend (no stray "a" glyph); the cluster
+  # colour/shape legend comes from the point layer. Mirrors .fviz_finish() (#14).
+  p <- .hide_text_legend(p)
   p
 }
 
@@ -364,6 +367,6 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
                          aes(x = .data[["x"]], y = .data[["y"]], label = .data[["name"]]),
                          size = labelsize, vjust = -0.7, color = outlier.color)
   }
-    
+
   return(p)
 }

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -765,3 +765,16 @@ test_that("fviz colour/fill length-mismatch gives a clear message; valid usage w
   expect_s3_class(fviz_pca_var(res, col.var = factor(c("a", "a", "b", "b"))), "ggplot")
   expect_s3_class(fviz_pca_ind(res, col.ind = iris$Species), "ggplot")
 })
+
+test_that("fviz_cluster keeps point labels out of the legend (#14 sibling)", {
+  set.seed(1)
+  dat <- scale(matrix(rnorm(30 * 4), nrow = 30)); rownames(dat) <- paste0("s", 1:30)
+  km <- kmeans(dat, centers = 8)
+  text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  for (p in list(fviz_cluster(list(data = dat, cluster = km$cluster)),
+                 fviz_cluster(km, data = dat))) {
+    txt <- Filter(function(l) inherits(l$geom, text_geoms), p$layers)
+    expect_gt(length(txt), 0)
+    expect_true(all(vapply(txt, function(l) isFALSE(l$show.legend), logical(1))))
+  }
+})


### PR DESCRIPTION
`fviz_cluster()` builds via `ggscatter` (bypassing `.fviz_finish()`), so its point-label text layer leaked into the legend as a stray `a` (same class as #14 scatter / #224 dendrogram). Applies `.hide_text_legend()` before returning.

**No regression:** labels still draw; the cluster colour/shape legend (from the point layer) is unaffected — an independent adversarial review verified this across kmeans/list/eclust/hcut/pam/hkmeans/dbscan/Mclust/HCPC, and `geom="point"` is a no-op. Both dev + clean `R --vanilla` suites green (86). Found while verifying #155.

Refs #14