### PR TITLE
fix(fviz_mca_biplot): forward map argument to ind and var (#142)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Bug Fixes
 
+* `fviz_mca_biplot()` now forwards the `map` argument to the individuals and
+  variable categories, so asymmetric maps (e.g. `"rowprincipal"`,
+  `"colprincipal"`, `"symbiplot"`) take effect instead of always drawing the
+  symmetric map. (#142)
 * `fviz_dend()`: `lwd` now controls ggplot branch thickness correctly and no
   longer triggers a spurious linewidth legend. (#200, @erdeyl)
 * `fviz_nbclust()` computes the `k = 1` WSS baseline internally, so helpers

--- a/R/fviz_mca.R
+++ b/R/fviz_mca.R
@@ -266,14 +266,14 @@ fviz_mca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
   if(arrows[1]==TRUE) geom2 <- setdiff(unique(c(geom2, "arrow")), "point")
   p <- fviz_mca_ind(X,  axes = axes, geom = geom2, repel = repel,
                     label = label, invisible=invisible, habillage = habillage,
-                    addEllipses = addEllipses, palette = palette,  ...)
-    
+                    addEllipses = addEllipses, palette = palette, map = map, ...)
+
   # Variable
   geom2 <- geom.var
   if(arrows[2]==TRUE) geom2 <- setdiff(unique(c(geom2, "arrow")), "point")
   # Add variables
-  p <- fviz_mca_var(X, axes = axes, geom =  geom2, repel = repel, 
-                    label = label, invisible = invisible, ggp = p, ...)
+  p <- fviz_mca_var(X, axes = axes, geom =  geom2, repel = repel,
+                    label = label, invisible = invisible, ggp = p, map = map, ...)
   
   p+labs(title=title)
 }

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -778,3 +778,20 @@ test_that("fviz_cluster keeps point labels out of the legend (#14 sibling)", {
     expect_true(all(vapply(txt, function(l) isFALSE(l$show.legend), logical(1))))
   }
 })
+
+test_that("fviz_mca_biplot forwards `map` to ind and var (#142)", {
+  skip_if_not_installed("FactoMineR")
+  data(poison, package = "factoextra")
+  res.mca <- FactoMineR::MCA(poison[, 5:15], graph = FALSE)
+  co <- function(p) ggplot2::ggplot_build(p)$data[[1]][, c("x", "y")]
+
+  sym <- co(fviz_mca_biplot(res.mca, map = "symmetric", geom = "point"))
+  col <- co(fviz_mca_biplot(res.mca, map = "colprincipal", geom = "point"))
+
+  # The bug: `map` was dropped, so every map produced identical coordinates.
+  expect_false(isTRUE(all.equal(sym, col)))
+
+  # No behavior change for the default symmetric map.
+  def <- co(fviz_mca_biplot(res.mca, geom = "point"))
+  expect_equal(def, sym)
+})


### PR DESCRIPTION
## Problem
`fviz_mca_biplot()` declares a `map` argument (default `"symmetric"`) but never forwarded it to `fviz_mca_ind()`/`fviz_mca_var()`. As a result, every `map=` value (`"rowprincipal"`, `"colprincipal"`, `"symbiplot"`, …) produced the **same** symmetric biplot. Reported in #142.

## Fix
Forward `map = map` in the two internal calls, mirroring `fviz_ca_biplot()` (which already does this). Both `fviz_mca_ind()` and `fviz_mca_var()` already accept and honor `map` (via `fviz()` → `.scale_ca()`).

## No regression
- Default `map="symmetric"` is a no-op in `.scale_ca()` → biplot output is byte-identical to before.
- New regression test asserts (i) `colprincipal` ≠ `symmetric` in the biplot and (ii) default == symmetric.
- Full suite green (324 pass / 0 fail) in clean-session `devtools::test()`.
- Adversarial review: no double-passing/partial-matching risk (`map` is a named formal, never lands in `...`); all 8 map values flow without error.

Fixes #142