### PR TITLE
fix(get_pca): ade4 dudi.pca individuals + between/within PCA (#126)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,19 @@
   edit and the standardized return structure), with ExPosition as a worked
   example and a vegan (RDA/CCA) template. (#23)
 
+## New Features
+
+* PCA extractors and `fviz_pca_*()` now support **ade4 between-class and
+  within-class PCA** (`ade4::bca()` / `ade4::wca()`). Individual contributions
+  match `ade4::inertia.dudi()`. (#126)
+
 ## Bug Fixes
 
+* `get_pca_ind()` now works for **ade4 `dudi.pca`** objects. Their `$li`/`$tab`
+  are data frames, which previously collapsed the internal `cos2` matrix into a
+  list and raised "attempt to set 'colnames' on an object with less than two
+  dimensions"; `fviz_pca_ind()` on a `dudi.pca` failed as a result. `prcomp`/
+  `princomp` output is unchanged. (#126)
 * `fviz_mca_biplot()` now forwards the `map` argument to the individuals and
   variable categories, so asymmetric maps (e.g. `"rowprincipal"`,
   `"colprincipal"`, `"symbiplot"`) take effect instead of always drawing the

--- a/R/eigenvalue.R
+++ b/R/eigenvalue.R
@@ -113,8 +113,8 @@ get_eig<-function(X){
   else{
     # stats package
     if(inherits(X, "prcomp") || inherits(X, "princomp")) eig <- (X$sdev)^2
-    # ade4 package
-    else if(inherits(X, c("pca", "coa", "acm")) && inherits(X, "dudi")) eig <- X$eig
+    # ade4 package (incl. between-class/within-class analyses: bca/wca)
+    else if(inherits(X, c("pca", "coa", "acm", "between", "within")) && inherits(X, "dudi")) eig <- X$eig
     # ca package
     else if(inherits(X, 'ca'))  eig <- X$sv^2
     else if(inherits(X, 'mjca')) eig <- X$inertia.e

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -395,7 +395,10 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   else if(inherits(X, "prcomp" )) scale_unit <- is.numeric(X$scale) 
   else if(inherits(X, "princomp")) scale_unit <- length(unique(X$scale))>1 
   else if(inherits(X, "expoOutput")) scale_unit <- !all(X$ExPosition.Data$scale==1) 
-  else if(inherits(X, "pca") && inherits(X, "dudi")) scale_unit <- length(unique(X$norm)) > 1 
+  else if(inherits(X, "pca") && inherits(X, "dudi")) scale_unit <- length(unique(X$norm)) > 1
+  # ade4 between-/within-class PCA: $co holds projections (not variable
+  # correlations bounded by 1), so the correlation circle does not apply.
+  else if(inherits(X, c("between", "within")) && inherits(X, "dudi")) scale_unit <- FALSE
   else {
     warning(".get_scale_unit function: can't handle an object of class ",
             paste(class(X), collapse = ", "))

--- a/R/get_pca.R
+++ b/R/get_pca.R
@@ -73,9 +73,16 @@ get_pca_ind<-function(res.pca, ...){
     ind <- .get_pca_ind_results(ind.coord, data, res.pca$eig,
                                 res.pca$cent, res.pca$norm)
   }
-  
+
+  # ade4 between-class / within-class PCA (bca/wca). These dudi objects carry
+  # row coordinates ($li), the transformed table ($tab) and row/column weights
+  # ($lw/$cw) but not $cent/$norm, so cos2/contrib use the weighted-dudi formula.
+  else if(inherits(res.pca, c("between", "within")) && inherits(res.pca, "dudi")){
+    ind <- .get_dudi_class_ind_results(res.pca)
+  }
+
   # stats package
-  else if(inherits(res.pca, 'princomp')){  
+  else if(inherits(res.pca, 'princomp')){
     ind.coord <- res.pca$scores
     data <- .prcomp_reconst(res.pca)
     ind <- .get_pca_ind_results(ind.coord, data, res.pca$sdev^2,
@@ -107,8 +114,10 @@ get_pca_ind<-function(res.pca, ...){
 get_pca_var<-function(res.pca){
   # FactoMineR package
   if(inherits(res.pca, c('PCA'))) var <- res.pca$var
-  # ade4 package
-  else if(inherits(res.pca, "pca") && inherits(res.pca, "dudi")){
+  # ade4 package (incl. between-class/within-class PCA: bca/wca). Variable/column
+  # coordinates live in $co for all dudi flavours.
+  else if(inherits(res.pca, "dudi") &&
+          inherits(res.pca, c("pca", "between", "within"))){
     var <- .get_pca_var_results(res.pca$co)
   }
   # stats package
@@ -162,6 +171,13 @@ get_pca_var<-function(res.pca){
 # - Avoids repeated function calls and memory allocations
 # - Maintains full econometric precision (identical numerical results)
 .get_pca_ind_results <- function(ind.coord, data, eigenvalues, pca.center, pca.scale){
+
+  # Coerce to plain matrices: ade4 dudi objects store $li/$tab as data.frames,
+  # and assigning a data.frame into a matrix slice below (ind.cos2[pos, ] <- ...)
+  # silently turns the matrix into a list, losing its dimensions. stats prcomp/
+  # princomp already pass matrices, so this is a no-op for them.
+  ind.coord <- as.matrix(ind.coord)
+  data <- as.matrix(data)
 
   eigenvalues <- eigenvalues[seq_len(ncol(ind.coord))]
   n.ind <- nrow(ind.coord)
@@ -243,4 +259,41 @@ get_pca_var<-function(res.pca){
 
   # Variable coord, cor, cos2 and contrib
   list(coord = var.coord, cor = var.cor, cos2 = var.cos2, contrib = var.contrib)
+}
+
+# Individual results for ade4 between-class / within-class PCA (bca/wca).
+# These dudi objects expose row coordinates ($li), the transformed table ($tab)
+# and row/column weights ($lw/$cw) but no $cent/$norm, so we use the general
+# weighted-dudi definitions:
+#   d2[i]        = sum_j cw[j] * tab[i, j]^2      (squared distance, column metric)
+#   cos2[i, k]   = li[i, k]^2 / d2[i]
+#   contrib[i,k] = 100 * lw[i] * li[i, k]^2 / eig[k]
+# For ordinary dudi.pca (uniform lw = 1/n, cw = 1) these reduce exactly to the
+# values produced by .get_pca_ind_results(); contrib matches ade4::inertia.dudi.
+.get_dudi_class_ind_results <- function(res.pca){
+  ind.coord <- as.matrix(res.pca$li)
+  tab <- as.matrix(res.pca$tab)
+  cw  <- res.pca$cw
+  lw  <- res.pca$lw
+  n.dim <- ncol(ind.coord)
+  eigenvalues <- res.pca$eig[seq_len(n.dim)]
+
+  d2 <- rowSums(sweep(tab^2, 2, cw, "*"))
+  coord.sq <- ind.coord^2
+
+  ind.cos2 <- matrix(0, nrow = nrow(ind.coord), ncol = n.dim)
+  positive_d2 <- d2 > .Machine$double.eps
+  if(any(positive_d2))
+    ind.cos2[positive_d2, ] <- coord.sq[positive_d2, , drop = FALSE] / d2[positive_d2]
+
+  ind.contrib <- sweep(coord.sq, 2, eigenvalues, "/")
+  ind.contrib <- sweep(ind.contrib, 1, lw, "*") * 100
+
+  dim.names <- paste0("Dim.", seq_len(n.dim))
+  colnames(ind.coord) <- colnames(ind.cos2) <- colnames(ind.contrib) <- dim.names
+  rnames <- rownames(ind.coord)
+  if(is.null(rnames)) rnames <- as.character(seq_len(nrow(ind.coord)))
+  rownames(ind.coord) <- rownames(ind.cos2) <- rownames(ind.contrib) <- rnames
+
+  list(coord = ind.coord, cos2 = ind.cos2, contrib = ind.contrib)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -95,6 +95,10 @@ NULL
     facto_class ="PCA"
   else if(inherits(X, "pca") && inherits(X, "dudi"))
     facto_class ="PCA"
+  # ade4 between-class / within-class PCA (bca/wca): treated as a PCA. These
+  # objects are class c("between"/"within", "dudi") and drop the "pca" class.
+  else if(inherits(X, c("between", "within")) && inherits(X, "dudi"))
+    facto_class ="PCA"
   else if(inherits(X, c("CA", "ca", "coa", "correspondence"))) facto_class="CA"
   else if(inherits(X, c("MCA", "acm"))) facto_class = "MCA"
   else if(inherits(X, c("MFA","mfa"))) facto_class = "MFA"

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -795,3 +795,57 @@ test_that("fviz_mca_biplot forwards `map` to ind and var (#142)", {
   def <- co(fviz_mca_biplot(res.mca, geom = "point"))
   expect_equal(def, sym)
 })
+
+test_that("get_pca_ind works for ade4 dudi.pca (data.frame $li) (#126)", {
+  skip_if_not_installed("ade4")
+  pca <- ade4::dudi.pca(iris[, -5], scannf = FALSE, nf = 3)
+
+  ind <- get_pca_ind(pca)
+  # The bug: a data.frame $li turned the cos2 matrix into a list (lost dims).
+  expect_s3_class(ind, "factoextra")
+  expect_true(all(c("coord", "cos2", "contrib") %in% names(ind)))
+  expect_true(is.matrix(ind$coord) && is.matrix(ind$cos2) && is.matrix(ind$contrib))
+  expect_equal(nrow(ind$coord), nrow(iris))
+  expect_true(all(rowSums(ind$cos2) <= 1 + 1e-9))
+  expect_true(all(abs(colSums(ind$contrib) - 100) < 1e-6))
+  expect_s3_class(fviz_pca_ind(pca), "ggplot")
+})
+
+test_that("prcomp/princomp get_pca_ind unchanged by the dudi fix (#126 no-regression)", {
+  pc <- prcomp(iris[, -5], scale. = TRUE)
+  pr <- princomp(iris[, -5], cor = TRUE)
+  for (ind in list(get_pca_ind(pc), get_pca_ind(pr))) {
+    expect_true(is.matrix(ind$coord) && is.matrix(ind$cos2) && is.matrix(ind$contrib))
+    expect_equal(nrow(ind$coord), nrow(iris))
+    expect_true(all(rowSums(ind$cos2) <= 1 + 1e-9))
+  }
+})
+
+test_that("ade4 between-/within-class PCA (bca/wca) are supported (#126)", {
+  skip_if_not_installed("ade4")
+  data(meaudret, package = "ade4")
+  pca <- ade4::dudi.pca(meaudret$env, scannf = FALSE, nf = 3)
+  fac <- meaudret$design$season
+  bet <- ade4::bca(pca, fac, scannf = FALSE, nf = 2)
+  wit <- ade4::wca(pca, fac, scannf = FALSE, nf = 2)
+
+  for (obj in list(bet, wit)) {
+    expect_equal(factoextra:::.get_facto_class(obj), "PCA")
+    expect_s3_class(get_eig(obj), "data.frame")
+    ind <- get_pca_ind(obj)
+    var <- get_pca_var(obj)
+    expect_true(all(c("coord", "cos2", "contrib") %in% names(ind)))
+    expect_true(all(rowSums(ind$cos2) <= 1 + 1e-9))
+    expect_true(all(c("coord", "cos2", "contrib") %in% names(var)))
+    expect_s3_class(fviz_pca_ind(obj), "ggplot")
+    expect_s3_class(fviz_pca_var(obj), "ggplot")
+    expect_s3_class(fviz_pca_biplot(obj), "ggplot")
+    expect_s3_class(fviz_eig(obj), "ggplot")
+
+    # contributions must match ade4's own inertia.dudi (row.abs, in %)
+    inr <- ade4::inertia.dudi(obj, row.inertia = TRUE)
+    ade_contrib <- as.matrix(inr$row.abs[, seq_len(ncol(ind$contrib))])
+    expect_equal(unname(as.matrix(ind$contrib)), unname(ade_contrib),
+                 tolerance = 1e-4)
+  }
+})


### PR DESCRIPTION
## Two changes

### 1. Bug fix — `get_pca_ind()` was broken for all ade4 `dudi.pca`
ade4 stores `$li`/`$tab` as data frames. Assigning a data frame into a matrix slice (`ind.cos2[pos, ] <- ...`) silently turned the `cos2` matrix into a **list**, crashing at the `colnames` line — so `get_pca_ind()`/`fviz_pca_ind()` errored on every `dudi.pca`. Fixed by coercing `ind.coord`/`data` to matrix in `.get_pca_ind_results()`. **`prcomp`/`princomp`/FactoMineR output is byte-identical** (they already pass matrices; `as.matrix()` is a no-op).

### 2. Feature (#126) — ade4 between-/within-class PCA (`bca`/`wca`)
Objects of class `c("between"/"within","dudi")` are now supported across `.get_facto_class()`, `get_eig()`, `get_pca_ind()` (new weighted-dudi helper), `get_pca_var()` and `.get_scale_unit()`. Individual **contributions match `ade4::inertia.dudi()`**, and the weighted formula **reduces exactly** to the existing path for uniform-weight `dudi.pca`.

## No regression
- prcomp/princomp/FactoMineR get_pca_ind output **byte-identical** (verified load_all vs master).
- New regression tests (ade4-guarded) + a prcomp/princomp no-regression test.
- Clean-session `devtools::test()`: **357 pass / 0 fail / 0 warn**.
- Adversarial review: SAFE — byte-identical preservation proven; contrib matches ade4 to ~1e-14; reduction to existing path exact. Only note: `bca`/`wca` built on a `coa`/`acm` are treated as PCA-styled (numbers still correct; was an error before, so not a regression).

Fixes #126