### PR TITLE
fix(fviz_dend): honor explicit k for HCPC objects (#81)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@
   list and raised "attempt to set 'colnames' on an object with less than two
   dimensions"; `fviz_pca_ind()` on a `dudi.pca` failed as a result. `prcomp`/
   `princomp` output is unchanged. (#126)
+* `fviz_dend()` now honors an explicit `k` for `HCPC` objects (e.g.
+  `fviz_dend(res.hcpc, k = 5)`); previously the user-supplied `k` was silently
+  overwritten by the HCPC cluster count. With `k = NULL` (default) the behavior
+  is unchanged. (#81)
 * `fviz_mca_biplot()` now forwards the `map` argument to the individuals and
   variable categories, so asymmetric maps (e.g. `"rowprincipal"`,
   `"colprincipal"`, `"symbiplot"`) take effect instead of always drawing the

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -129,8 +129,11 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   rectangle <- type == "rectangle"
   
   if(inherits(x, "HCPC")){
-    k <- length(unique(x$data.clust$clust))
-    #k <- x$call$t$nb.clust
+    # Honor an explicit k; default to the number of HCPC clusters when k is
+    # NULL. The previous code always overwrote k, so a user-supplied k (e.g.
+    # fviz_dend(hcpc, k = 5)) was silently ignored and colored at the HCPC
+    # cluster count instead. (#81)
+    if(is.null(k)) k <- length(unique(x$data.clust$clust))
     x <- x$call$t$tree #hclust
   }
     

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -849,3 +849,24 @@ test_that("ade4 between-/within-class PCA (bca/wca) are supported (#126)", {
                  tolerance = 1e-4)
   }
 })
+
+test_that("fviz_dend honors an explicit k for HCPC, defaults to HCPC count (#81)", {
+  skip_if_not_installed("FactoMineR")
+  data(wine, package = "FactoMineR")
+  set.seed(1)
+  fa <- FactoMineR::FAMD(wine[, 1:10], graph = FALSE, ncp = 5)
+  hc <- FactoMineR::HCPC(fa, nb.clust = 7, graph = FALSE)
+
+  n_branch_cols <- function(p) {
+    b <- ggplot2::ggplot_build(p)$data
+    cols <- unique(unlist(lapply(b, function(d)
+      if ("colour" %in% names(d)) unique(d$colour))))
+    length(setdiff(cols, c("black", "#000000", "grey50", "gray50")))
+  }
+
+  # default: unchanged -> HCPC cluster count (7)
+  expect_equal(n_branch_cols(fviz_dend(hc)), 7)
+  # explicit k now honored (previously ignored)
+  expect_equal(n_branch_cols(fviz_dend(hc, k = 5)), 5)
+  expect_equal(n_branch_cols(fviz_dend(hc, k = 3)), 3)
+})


### PR DESCRIPTION
## Problem
`fviz_dend()` **unconditionally** set `k <- length(unique(x$data.clust$clust))` for HCPC objects, so a user-supplied `k` (e.g. `fviz_dend(res.hcpc, k = 5)`) was silently ignored and the tree was always colored at the HCPC cluster count. Reported in #81.

## Fix
Gate it: `if(is.null(k)) k <- length(unique(x$data.clust$clust))`. The default call (`k = NULL`) is **byte-identical** to before; an explicit `k` is now honored.

## No regression
- Default `fviz_dend(hcpc)` unchanged (proven k=7 identical old/new); `k=5`→5, `k=3`→3.
- Regression test added (FactoMineR-guarded).
- Clean-session `devtools::test()`: 360 pass / 0 fail.
- Adversarial review: SAFE — default byte-identical; other object-type branches untouched; valid-k bounds handled.

Note: the originally-reported "only 3 colored" symptom no longer reproduces on current code (it already uses the data.clust count, not the old `call$t$nb.clust`); this PR addresses the remaining part — the ignored `k=` override.

Fixes #81