### PR TITLE
feat(fviz): rotate.labels to align variable labels with arrows (#98)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 
 ## New Features
 
+* New `rotate.labels` argument in `fviz()` (and thus `fviz_pca_var()`,
+  `fviz_pca_biplot()`, etc.): when `TRUE`, variable text labels are rotated to
+  the angle of their arrows (ggbiplot style). Defaults to `FALSE` (unchanged);
+  use with `repel = FALSE`. (#98)
 * PCA extractors and `fviz_pca_*()` now support **ade4 between-class and
   within-class PCA** (`ade4::bca()` / `ade4::wca()`). Individual contributions
   match `ade4::inertia.dudi()`. (#126)

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -64,6 +64,12 @@ NULL
 #'  MCA/MFA/HMFA/FAMD. Use \code{add.circle = TRUE} to force the circle (e.g. a
 #'  \code{prcomp(scale = FALSE)} fit on data you scaled manually) or
 #'  \code{add.circle = FALSE} to suppress it.
+#'@param rotate.labels logical. If \code{TRUE}, the text labels of the plotted
+#'  element are rotated to the angle of their arrows (ggbiplot style); labels in
+#'  the left half-plane are flipped to stay upright. Default is \code{FALSE}
+#'  (no rotation). Use together with \code{repel = FALSE}, as ggrepel ignores the
+#'  label angle. Most useful for variable plots/biplots (e.g.
+#'  \code{fviz_pca_var}, \code{fviz_pca_biplot}).
 #'@param axes.linetype linetype of x and y axes.
 #'@param color color to be used for the specified geometries (point, text). Can 
 #'  be a continuous variable or a factor variable. Possible values include also 
@@ -144,6 +150,7 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
                           select = list(name = NULL, cos2 = NULL, contrib = NULL),
                           title = NULL, axes.linetype = "dashed",
                           repel = FALSE, col.circle ="grey70", circlesize = 0.5, add.circle = NULL,
+                          rotate.labels = FALSE,
                           ggtheme = theme_minimal(),
                           ggp = NULL, font.family = "",
                            ...)
@@ -299,6 +306,15 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
     }
   }
 
+  # Optionally rotate this element's text labels to the angle of their arrows
+  # (ggbiplot style). Gated on rotate.labels = TRUE, so the default is
+  # byte-identical. Restricted to elements that actually draw arrows ("arrow" in
+  # geom), i.e. variable plots: this keeps biplots from rotating the individual
+  # labels (whose angle would be meaningless). Works with plain geom_text (use
+  # repel = FALSE); ggrepel ignores the angle aesthetic. (#98)
+  if(isTRUE(rotate.labels) && "arrow" %in% geom)
+    p <- .rotate_text_labels(p, n_layers_before)
+
   if(!is.null(gradient.cols))
     p <- p + ggpubr::gradient_color(gradient.cols)
     
@@ -404,6 +420,30 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
             paste(class(X), collapse = ", "))
   }
   scale_unit
+}
+
+# Rotate the text labels of the layers added for the current element so each
+# label is aligned with its arrow direction (ggbiplot style). Labels in the
+# left half-plane are flipped by 180 degrees so they stay upright/readable.
+# Only layers with index > n_layers_before are touched, preserving any layers
+# carried in via ggp (e.g. the individuals layer of a biplot). (#98)
+.rotate_text_labels <- function(p, n_layers_before = 0L){
+  .text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  for(i in seq_along(p$layers)){
+    if(i <= n_layers_before) next
+    layer <- p$layers[[i]]
+    if(!inherits(layer$geom, .text_geoms)) next
+    ld <- as.data.frame(layer$data)
+    if(is.null(ld) || !all(c("x", "y") %in% names(ld)) || nrow(ld) == 0) next
+    ang <- atan2(ld$y, ld$x) * 180 / pi
+    flip <- ang > 90 | ang < -90
+    ang[flip] <- ang[flip] + 180
+    ld[[".fviz_angle"]] <- ang
+    p$layers[[i]]$data <- ld
+    p$layers[[i]]$mapping <- utils::modifyList(
+      layer$mapping, ggplot2::aes(angle = .data[[".fviz_angle"]]))
+  }
+  p
 }
 
 # Add correlation circle to variables plot

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -35,6 +35,7 @@ fviz(
   col.circle = "grey70",
   circlesize = 0.5,
   add.circle = NULL,
+  rotate.labels = FALSE,
   ggtheme = theme_minimal(),
   ggp = NULL,
   font.family = "",
@@ -166,6 +167,13 @@ unit-variance (scaled) data, and for quantitative variables of
 MCA/MFA/HMFA/FAMD. Use \code{add.circle = TRUE} to force the circle (e.g. a
 \code{prcomp(scale = FALSE)} fit on data you scaled manually) or
 \code{add.circle = FALSE} to suppress it.}
+
+\item{rotate.labels}{logical. If \code{TRUE}, the text labels of the plotted
+element are rotated to the angle of their arrows (ggbiplot style); labels in
+the left half-plane are flipped to stay upright. Default is \code{FALSE}
+(no rotation). Use together with \code{repel = FALSE}, as ggrepel ignores the
+label angle. Most useful for variable plots/biplots (e.g.
+\code{fviz_pca_var}, \code{fviz_pca_biplot}).}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -872,3 +872,43 @@ test_that("fviz_dend honors an explicit k for HCPC, defaults to HCPC count (#81)
   expect_equal(n_branch_cols(fviz_dend(hc, k = 2)), 2)
   expect_equal(n_branch_cols(fviz_dend(hc, k = 4)), 4)
 })
+
+test_that("rotate.labels rotates variable labels, default off (#98)", {
+  res.pca <- prcomp(iris[, -5], scale. = TRUE)
+  text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  text_layer <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, text_geoms), logical(1)))[1]
+    p$layers[[i]]
+  }
+
+  # default: no angle aesthetic (unchanged behavior)
+  lay0 <- text_layer(fviz_pca_var(res.pca, repel = FALSE))
+  expect_false("angle" %in% names(lay0$mapping))
+  expect_false(".fviz_angle" %in% names(as.data.frame(lay0$data)))
+
+  # rotate.labels = TRUE: angle aesthetic + per-label angle column
+  lay1 <- text_layer(fviz_pca_var(res.pca, repel = FALSE, rotate.labels = TRUE))
+  expect_true("angle" %in% names(lay1$mapping))
+  d <- as.data.frame(lay1$data)
+  expect_true(".fviz_angle" %in% names(d))
+  # angles match arrow directions (flipped into the readable [-90, 90] range)
+  expect_true(all(d$.fviz_angle >= -90 - 1e-6 & d$.fviz_angle <= 90 + 1e-6))
+
+  # rotation is restricted to arrow-bearing (variable) labels: fviz_pca_ind has
+  # no arrows, so rotate.labels must be a no-op there.
+  lay_ind <- text_layer(fviz_pca_ind(res.pca, repel = FALSE, rotate.labels = TRUE))
+  expect_false("angle" %in% names(lay_ind$mapping))
+
+  # biplot: only the variable labels are rotated, NOT the individual labels.
+  pb <- fviz_pca_biplot(res.pca, repel = FALSE, rotate.labels = TRUE)
+  angled <- vapply(pb$layers, function(l)
+    inherits(l$geom, text_geoms) &&
+      ".fviz_angle" %in% names(as.data.frame(l$data)), logical(1))
+  n_rows <- vapply(pb$layers, function(l)
+    if (inherits(l$geom, text_geoms)) nrow(as.data.frame(l$data)) else NA_integer_,
+    integer(1))
+  expect_true(any(angled))
+  # angled layer holds the variables (ncol), not the individuals (nrow of data)
+  expect_true(all(n_rows[angled] == ncol(iris[, -5])))
+  expect_s3_class(fviz_pca_biplot(res.pca), "ggplot")
+})


### PR DESCRIPTION
## What
New `rotate.labels` argument (default `FALSE`) on `fviz()`, surfaced through `fviz_pca_var()`/`fviz_pca_biplot()` etc. When `TRUE`, variable text labels are rotated to the angle of their arrows (ggbiplot style); left-half labels are flipped to stay upright. Requested in #98.

## Scope / correctness
Rotation is restricted to elements that **draw arrows** (`"arrow" %in% geom`), so:
- `fviz_pca_var(..., rotate.labels = TRUE)` → variable labels rotated.
- `fviz_pca_ind(..., rotate.labels = TRUE)` → no-op (no arrows).
- `fviz_pca_biplot(..., rotate.labels = TRUE)` → rotates only the **variable** labels, not the 150 individual labels.

Use with `repel = FALSE` (ggrepel ignores the angle aesthetic).

## No regression
- Default `rotate.labels = FALSE` → gated by `isTRUE()`, output **byte-identical** for all `fviz_*`.
- Not forwarded to ggscatter (named formal of fviz).
- Regression test asserts default-off, rotate-on, ind no-op, and biplot rotates only variables.
- Clean `devtools::test()`: 367 pass / 0 fail; full `R CMD check --as-cran`: 0 errors / 0 warnings (1 pre-existing Date NOTE).
- Adversarial review: SAFE; the biplot over-rotation it flagged (D1) is fixed by the arrow gate + a biplot test.

Fixes #98