### PR TITLE
feat(fviz_pca): shape.ind — colour by one factor, shape by another (#36, #51)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@
 
 ## New Features
 
+* New `shape.ind` argument in `fviz_pca_ind()` and `fviz_pca_biplot()` maps point
+  **shape** to a grouping factor independently of colour, so individuals can be
+  coloured by one variable and shaped by another (e.g.
+  `fviz_pca_ind(res, col.ind = group1, shape.ind = group2)`). `fviz()` likewise
+  now accepts a factor for `pointshape`. Default behaviour is unchanged. (#36, #51)
 * New `rotate.labels` argument in `fviz()` (and thus `fviz_pca_var()`,
   `fviz_pca_biplot()`, etc.): when `TRUE`, variable text labels are rotated to
   the angle of their arrows (ggbiplot style). Defaults to `FALSE` (unchanged);

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -234,6 +234,21 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
     df[[.col.name]] <- fill
     fill <- .col.name
   }
+  # Augment the data if pointshape is a grouping (factor/character) variable,
+  # so points can be shaped by a DIFFERENT factor than `color`/habillage (e.g.
+  # colour individuals by one variable and set their shape by another). Gated on
+  # pointshape being a grouping var; the default numeric pointshape (e.g. 19) is
+  # untouched, so existing plots are byte-identical. The `if(missing(pointshape))`
+  # guards above already prevent colour/habillage from overwriting it. (#36, #51)
+  if(.is_grouping_var(pointshape)){
+    if(nrow(df) != length(pointshape)) stop(
+      "The length of the `shape`/`shape.ind` variable must equal the number of ",
+      "elements being plotted (individuals for fviz_*_ind()), or be a single ",
+      "value.", call. = FALSE)
+    .shape.name <- "Shape."
+    df[[.shape.name]] <- as.factor(pointshape)
+    pointshape <- .shape.name
+  }
   # Augment the data, if pointsize is a continuous variable
   if(length(pointsize) > 1){
     if(nrow(df) != length(pointsize)) pointsize <- 1.5

--- a/R/fviz_pca.R
+++ b/R/fviz_pca.R
@@ -60,6 +60,13 @@
 #'   "coord"), x values ("x") or y values ("y"). To use automatic coloring (by 
 #'   cos2, contrib, ....), make sure that habillage ="none".
 #' @param fill.ind,fill.var same as col.ind and col.var but for the fill color.
+#' @param shape.ind optional factor variable to map the point \strong{shape} of
+#'   individuals, independently of their color. This allows colouring
+#'   individuals by one grouping variable (\code{col.ind}/\code{habillage}) and
+#'   shaping them by another (e.g. \code{fviz_pca_ind(res, col.ind = group1,
+#'   shape.ind = group2)}). Default \code{NULL} keeps the previous behaviour
+#'   (shape follows the colour grouping). Use \code{+ labs(shape = , colour = )}
+#'   to rename the legends.
 #' @param col.ind.sup color for supplementary individuals
 #' @param alpha.ind,alpha.var controls the transparency of individual and 
 #'   variable colors, respectively. The value can variate from 0 (total 
@@ -188,17 +195,23 @@ fviz_pca <- function(X, ...){
 #' @export 
 fviz_pca_ind <- function(X,  axes = c(1,2), geom = c("point", "text"),
                          geom.ind = geom, repel = FALSE,
-                         habillage="none", palette = NULL, addEllipses=FALSE, 
+                         habillage="none", palette = NULL, addEllipses=FALSE,
                          col.ind = "black", fill.ind = "white", col.ind.sup = "blue", alpha.ind =1,
+                         shape.ind = NULL,
                          select.ind = list(name = NULL, cos2 = NULL, contrib = NULL),
                          ...)
 {
- 
-  fviz (X, element = "ind", axes = axes, geom = geom.ind,
-                 habillage = habillage, palette = palette, addEllipses = addEllipses, 
-                 color = col.ind, fill = fill.ind, alpha = alpha.ind, col.row.sup = col.ind.sup,
-                select = select.ind, repel = repel,  ...)
-  
+
+  .args <- list(X = X, element = "ind", axes = axes, geom = geom.ind,
+                habillage = habillage, palette = palette, addEllipses = addEllipses,
+                color = col.ind, fill = fill.ind, alpha = alpha.ind, col.row.sup = col.ind.sup,
+                select = select.ind, repel = repel, ...)
+  # shape.ind = a factor maps point shape to a (possibly different) grouping than
+  # col.ind, e.g. colour by one variable and shape by another. NULL (default)
+  # keeps the previous behavior (shape follows habillage/colour). (#36, #51)
+  if(!is.null(shape.ind)) .args$pointshape <- shape.ind
+  do.call(fviz, .args)
+
 }
 
 
@@ -228,6 +241,7 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
                             col.var = "steelblue", fill.var = "white", gradient.cols = NULL,
                             label = "all", invisible="none", repel = FALSE,
                             habillage = "none", palette = NULL, addEllipses=FALSE,
+                            shape.ind = NULL,
                             title = "PCA - Biplot",
                             biplot.type = c("auto", "form", "covariance"), ...)
 {
@@ -305,9 +319,9 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
   
   # Individuals
   p <- fviz_pca_ind(X,  axes = axes, geom = geom.ind, repel = repel,
-                    col.ind = col.ind, fill.ind = fill.ind,
+                    col.ind = col.ind, fill.ind = fill.ind, shape.ind = shape.ind,
                     label = label, invisible=invisible, habillage = habillage,
-                    addEllipses = addEllipses, # palette = palette, 
+                    addEllipses = addEllipses, # palette = palette,
                     ellipse.border.remove = ellipse.border.remove,
                     ...)
   # Add variables

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -22,6 +22,7 @@ fviz_pca_ind(
   fill.ind = "white",
   col.ind.sup = "blue",
   alpha.ind = 1,
+  shape.ind = NULL,
   select.ind = list(name = NULL, cos2 = NULL, contrib = NULL),
   ...
 )
@@ -58,6 +59,7 @@ fviz_pca_biplot(
   habillage = "none",
   palette = NULL,
   addEllipses = FALSE,
+  shape.ind = NULL,
   title = "PCA - Biplot",
   biplot.type = c("auto", "form", "covariance"),
   ...
@@ -128,6 +130,14 @@ transparency for the individual/variable colors are automatically
 controlled by their qualities ("cos2"), contributions ("contrib"), 
 coordinates (x^2+y^2, "coord"), x values("x") or y values("y"). To use 
 this, make sure that habillage ="none".}
+
+\item{shape.ind}{optional factor variable to map the point \strong{shape} of
+individuals, independently of their color. This allows colouring
+individuals by one grouping variable (\code{col.ind}/\code{habillage}) and
+shaping them by another (e.g. \code{fviz_pca_ind(res, col.ind = group1,
+shape.ind = group2)}). Default \code{NULL} keeps the previous behaviour
+(shape follows the colour grouping). Use \code{+ labs(shape = , colour = )}
+to rename the legends.}
 
 \item{select.ind, select.var}{a selection of individuals/variables to be
 drawn. Allowed values are NULL or a list containing the arguments name,

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -912,3 +912,44 @@ test_that("rotate.labels rotates variable labels, default off (#98)", {
   expect_true(all(n_rows[angled] == ncol(iris[, -5])))
   expect_s3_class(fviz_pca_biplot(res.pca), "ggplot")
 })
+
+test_that("shape.ind maps point shape to a second factor, default unchanged (#36, #51)", {
+  res.pca <- prcomp(iris[, -5], scale. = TRUE)
+  set.seed(1)
+  g2 <- factor(sample(c("a", "b"), nrow(iris), TRUE))
+
+  scales_of <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    unlist(lapply(b$plot$scales$scales, function(s) s$aesthetics))
+  }
+
+  # default (no shape.ind): unchanged, builds fine
+  expect_s3_class(fviz_pca_ind(res.pca, habillage = iris$Species, geom = "point"), "ggplot")
+
+  # two groupings: colour by Species, shape by g2 -> both a colour and a shape scale
+  p <- fviz_pca_ind(res.pca, col.ind = iris$Species, shape.ind = g2, geom = "point")
+  sc <- scales_of(p)
+  expect_true("colour" %in% sc)
+  expect_true("shape" %in% sc)
+
+  # a length-mismatched shape factor errors clearly
+  expect_error(fviz_pca_ind(res.pca, shape.ind = factor(c("a", "b"))),
+               "number of elements being plotted")
+
+  # biplot forwards shape.ind to individuals only and still builds
+  expect_s3_class(
+    fviz_pca_biplot(res.pca, col.ind = iris$Species, shape.ind = g2, geom.ind = "point"),
+    "ggplot")
+})
+
+test_that("numeric pointshape path is unchanged by the shape.ind feature (#36 no-regression)", {
+  res.pca <- prcomp(iris[, -5], scale. = TRUE)
+  # default fviz_pca_ind with a habillage still maps shape to the habillage group
+  # (no Shape. column injected; pointshape stays the auto-mapped grouping)
+  p <- fviz_pca_ind(res.pca, habillage = iris$Species, geom = "point")
+  has_shape_col <- any(vapply(p$layers, function(l) {
+    d <- tryCatch(as.data.frame(l$data), error = function(e) data.frame())
+    "Shape." %in% names(d)
+  }, logical(1)))
+  expect_false(has_shape_col)
+})


### PR DESCRIPTION
## What
New `shape.ind` argument on `fviz_pca_ind()` / `fviz_pca_biplot()`: colour individuals by one grouping variable (`col.ind`/`habillage`) and set their **shape** by a different factor — the long-standing request in #36 (and dup #51).

```r
fviz_pca_ind(res.pca, col.ind = group1, shape.ind = group2, geom = "point")
```

`fviz()` now accepts a factor for `pointshape` (added as a `Shape.` column → independent shape legend).

## No regression (proven)
- Gated on `pointshape` being a grouping factor; numeric `pointshape` (default) and the existing colour/habillage shape auto-mapping are **unchanged**.
- Adversarial review: `ggplot_build()` data + scales **byte-identical to master** for default / habillage / col.ind=cos2 / col.ind=factor / biplot / text paths. Auto-mapped pointshape (a length-1 column name) is not double-processed.
- New regression tests: default unchanged, dual colour+shape scales, length-mismatch error, biplot.
- Clean `devtools::test()`: 375 pass / 0 fail; `R CMD check --as-cran`: 0 errors / 0 warnings (1 pre-existing Date NOTE).

Fixes #36
Fixes #51