### PR TITLE
fix: warn on unrecognized label/invisible values (#165)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@
 
 ## Bug Fixes
 
+* `fviz_*()` now **warn** when `label` or `invisible` contain an unrecognized
+  value (e.g. `label = "id"` instead of `"ind"`) and list the valid values,
+  instead of silently drawing nothing. Recognized values are unchanged. (#165)
 * `get_pca_ind()` now works for **ade4 `dudi.pca`** objects. Their `$li`/`$tab`
   are data frames, which previously collapsed the internal `cos2` matrix into a
   list and raised "attempt to set 'colnames' on an object with less than two

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -711,6 +711,22 @@ NULL
 # possible values are "all", "none" or the combination of 
 # c("row", "row.sup", "col", "col.sup", "ind", "ind.sup", "quali", "var", "quanti.sup")
 ## Returns a list 
+# Warn when a label/invisible vector contains tokens that are not recognized, so
+# a typo such as label = "id" (instead of "ind") no longer silently draws nothing
+# but tells the user which values are valid. Only warns for genuinely unknown
+# tokens; recognized values keep their exact previous behavior. (#165)
+.warn_unknown_elements <- function(values, valid, arg){
+  if(is.null(values)) return(invisible(NULL))
+  unknown <- setdiff(as.character(values), valid)
+  if(length(unknown))
+    warning("Unknown ", arg, " value(s): ",
+            paste0('"', unknown, '"', collapse = ", "),
+            ". Valid values are \"all\", \"none\" or any of: ",
+            paste0('"', setdiff(valid, c("all", "none")), '"', collapse = ", "),
+            ".", call. = FALSE)
+  invisible(NULL)
+}
+
 .label <- function(label){
   lab  <- list()
   element <- c("var", "quanti.sup", "quali.sup", "quanti.sup","quanti", # var - PCA, MCA, MFA
@@ -721,6 +737,7 @@ NULL
                "row", "row.sup", # row - ca
                "col", "col.sup" # col - ca
                )
+  .warn_unknown_elements(label, c("all", "none", element), "label")
   for(el in element){
     if(label[1] == "all" || el %in% label) lab[[el]] <- TRUE
     else lab[[el]] <- FALSE
@@ -745,6 +762,7 @@ NULL
                "row", "row.sup", # row - ca
                "col", "col.sup" # col - ca
   )
+  .warn_unknown_elements(invisible, c("all", "none", element), "invisible")
   for(el in element){
     if(el %in% invisible) hide[[el]] <- TRUE
     else hide[[el]] <- FALSE

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -953,3 +953,31 @@ test_that("numeric pointshape path is unchanged by the shape.ind feature (#36 no
   }, logical(1)))
   expect_false(has_shape_col)
 })
+
+test_that("unknown label/invisible tokens warn instead of silently doing nothing (#165)", {
+  res <- prcomp(iris[, -5], scale. = TRUE)
+
+  # the reported case: label = "id" (typo for "ind") now warns and names valids.
+  # (A biplot calls fviz() for ind and var, so it warns once per pass; capture
+  # all warnings to assert the message without leaking the second one.)
+  w <- testthat::capture_warnings(fviz_pca_biplot(res, label = c("var", "id")))
+  expect_true(any(grepl("Unknown label value", w)))
+  expect_warning(fviz_pca_ind(res, invisible = "ids"),
+                 "Unknown invisible value")
+
+  # valid tokens stay silent (no behavior change)
+  expect_silent(fviz_pca_ind(res, label = "all"))
+  expect_silent(fviz_pca_ind(res, label = c("var", "ind")))
+  expect_silent(fviz_pca_ind(res, label = "none"))
+  expect_silent(fviz_pca_ind(res, invisible = "none"))
+  expect_silent(fviz_pca_biplot(res, label = "all"))
+
+  # rendering for the correct keyword is unaffected: "ind" still draws labels
+  text_geoms <- c("GeomText", "GeomTextRepel", "GeomLabel", "GeomLabelRepel")
+  p <- suppressWarnings(fviz_pca_ind(res, label = "ind", geom = c("point", "text")))
+  has_ind_text <- any(vapply(p$layers, function(l) {
+    inherits(l$geom, text_geoms) &&
+      nrow(as.data.frame(l$data)) == nrow(iris)
+  }, logical(1)))
+  expect_true(has_ind_text)
+})


### PR DESCRIPTION
## Problem
`fviz_*()` silently ignored unknown `label`/`invisible` tokens. In #165 (M. Friendly) `fviz_pca_biplot(..., label = c("var", "id"))` drew **no individual labels** because `"id"` is not a recognized keyword (the valid one is `"ind"`) — with no feedback, which he reasonably called a design flaw. (Functionally there is no bug: `label = "ind"` or the default `"all"` works, including with `habillage`.)

## Fix
`.label()` and `.hide()` now **warn** and list the valid values when given an unrecognized token. Recognized values are completely unchanged.

## No regression (critical: CI runs error_on='warning')
- Audited every `.label()`/`.hide()` call site, all `fviz_*` defaults, and all `man/`+`vignettes/` examples — **no existing valid call newly warns** (all tokens reduce to all/none/var/ind/row/col/…valid). Adversarial review confirmed.
- Recognized-token rendering byte-identical.
- Clean `devtools::test()`: 383 pass / 0 fail / 0 warn; `R CMD check --as-cran`: examples OK, 0 errors / 0 warnings (1 pre-existing Date NOTE).
- Regression test: `label="id"`/`invisible="ids"` warn; valid tokens silent; `label="ind"` still draws labels.

Refs #165