### PR TITLE
ci: run checks against development ggplot2 (early-warning leg)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,7 +12,12 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }}${{ matrix.config.ggplot2 && ', ggplot2-dev' || '' }})
+
+    # The ggplot2-dev leg is an early-warning radar for the next ggplot2 break;
+    # it must never block the gate, so it is allowed to fail. All other legs keep
+    # allow_failure unset -> continue-on-error resolves to false (gate unchanged).
+    continue-on-error: ${{ matrix.config.allow_failure || false }}
 
     strategy:
       fail-fast: false
@@ -23,6 +28,10 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          # Early-warning leg: run the checks against the development ggplot2 to
+          # catch the next 3.5/4.0-style break before it reaches CRAN. Non-blocking
+          # (allow_failure) so an upstream ggplot2 break never reddens the gate.
+          - {os: ubuntu-latest,   r: 'release', ggplot2: 'devel', allow_failure: true}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -62,6 +71,13 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+
+      - name: Install development ggplot2 (early-warning leg only)
+        if: ${{ matrix.config.ggplot2 == 'devel' }}
+        run: |
+          if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
+          pak::pak("tidyverse/ggplot2")
+        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 CLAUDE.md
 docs/
 Rplots.pdf
-.claude/skills/
+.claude/
 .vscode/
 .github/aw/logs/
-.claude/notes/

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -42,6 +42,21 @@ test_that("fviz_dend supports rectangular dendrogram layout", {
   expect_s3_class(p, "ggplot")
 })
 
+test_that("fviz_dend supports circular and horizontal dendrogram layouts", {
+  # Exercises the coord_polar (circular) and coord_flip (horizontal) branches of
+  # .ggplot_dend. These layout+theme paths were otherwise untested, leaving the
+  # ggplot2-dev CI leg blind to a break isolated there.
+  hc <- hclust(dist(scale(USArrests)))
+  p_circular <- fviz_dend(hc, k = 3, type = "circular")
+  p_horiz <- fviz_dend(hc, k = 3, horiz = TRUE)
+
+  expect_s3_class(p_circular, "ggplot")
+  expect_s3_class(p_horiz, "ggplot")
+  # Force the layout transforms to run (coord_polar / coord_flip fire at build).
+  expect_no_error(ggplot2::ggplot_build(p_circular))
+  expect_no_error(ggplot2::ggplot_build(p_horiz))
+})
+
 test_that("fviz_dend applies lwd to branch segments without adding a linewidth guide", {
   hc <- hclust(dist(scale(USArrests)))
 


### PR DESCRIPTION
Adds a non-blocking CI leg that installs the development ggplot2 and runs
`R CMD check` against it, so a future breaking change in ggplot2 surfaces
here before it reaches CRAN. The leg is allowed to fail (`continue-on-error`),
so an upstream ggplot2 break never blocks the pull-request checks; the five
existing legs are unchanged.

So the new leg has something to observe in the dendrogram code, this also
adds smoke tests for the circular and horizontal `fviz_dend()` layouts
(the `coord_polar` / `coord_flip` paths), which previously ran only in
interactive examples.

Also folds in a small repo-hygiene change: ignore the whole `.claude/`
directory instead of two specific subdirectories.

No package behavior changes — `fviz_*` / `get_*` output is untouched. Full
test suite: 411 pass, 0 failures.
