### PR TITLE
docs(fviz_dend): drop invalid "triangle" from the type argument docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
   The default (`NULL`) keeps each method's existing behavior: the guide line is
   shown for `"silhouette"` and `"gap_stat"` and omitted for `"wss"`.
 
+## Minor changes
+
+* `fviz_dend()`: corrected the documentation of the `type` argument, which listed
+  a `"triangle"` value that the function does not accept (the valid values are
+  `"rectangle"`, `"circular"` and `"phylogenic"`). Thanks to @Nelson-Gon (#144).
+
 # factoextra 2.1.0
 
 ## New features

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -31,7 +31,7 @@
 #'   type = "phylogenic".
 #' @param lwd a numeric value specifying dendrogram branch and rectangle line
 #'   width.
-#' @param type type of plot. Allowed values are one of "rectangle", "triangle", 
+#' @param type type of plot. Allowed values are one of "rectangle",
 #'   "circular", "phylogenic".
 #' @param phylo_layout the layout to be used for phylogenic trees. Default value
 #'   is "layout.auto", which is kept as a compatibility alias for

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -76,7 +76,7 @@ type = "phylogenic".}
 \item{lwd}{a numeric value specifying dendrogram branch and rectangle line
 width.}
 
-\item{type}{type of plot. Allowed values are one of "rectangle", "triangle", 
+\item{type}{type of plot. Allowed values are one of "rectangle",
 "circular", "phylogenic".}
 
 \item{phylo_layout}{the layout to be used for phylogenic trees. Default value


### PR DESCRIPTION
The `fviz_dend()` `type` argument documentation listed a `"triangle"` value that
the function does not accept, so following the docs produces an error:

```r
library(factoextra)
hc <- hclust(dist(USArrests))
fviz_dend(hc, type = "triangle")
#> Error: 'arg' should be one of "rectangle", "circular", "phylogenic"
```

This corrects the `type` documentation to list only the accepted values
(`"rectangle"`, `"circular"`, `"phylogenic"`). Documentation-only — no behavior
change.

Re-implements the fix reported by @Nelson-Gon in #144.
