### PR TITLE
feat(fviz_cos2, fviz_contrib): add a cos2/contribution heat-grid display

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   `mark_optimal = FALSE` omits the optimal-cluster guide line for every method.
   The default (`NULL`) keeps each method's existing behavior: the guide line is
   shown for `"silhouette"` and `"gap_stat"` and omitted for `"wss"`.
+* `fviz_cos2()` and `fviz_contrib()` gain a `display` argument. `display = "heatmap"`
+  draws a grid with one tile per element and dimension, filled and labelled by the
+  per-dimension cos2/contribution, so the quality/contribution across several
+  dimensions can be read at once. The default (`display = "bar"`) is unchanged.
 
 # factoextra 2.1.0
 

--- a/R/facto_summarize.R
+++ b/R/facto_summarize.R
@@ -253,6 +253,84 @@ facto_summarize <- function(X, element, node.level = 1, group.names,
     res = list(res = res, res.partial = res.partial)
     }
   }
-  
+
   res
+}
+
+
+# Per-axis result matrix (element x selected dimensions).
+# +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Reuses the same extractor dispatch as facto_summarize() but returns the raw
+# per-dimension cos2/contrib matrix WITHOUT summing across axes (facto_summarize
+# collapses the axes into one value per element). Used by the fviz_cos2()/
+# fviz_contrib() heat-grid display.
+.facto_element_matrix <- function(X, element, result, axes){
+  element <- element[1]
+  facto_class <- .get_facto_class(X)
+  elmt <- switch(facto_class,
+                 CA   = get_ca(X, element),
+                 PCA  = get_pca(X, element),
+                 MCA  = get_mca(X, element),
+                 FAMD = get_famd(X, element),
+                 MFA  = get_mfa(X, element),
+                 HMFA = get_hmfa(X, element))
+  m <- elmt[[result]]
+  if(is.null(m))
+    stop("'", result, "' is not available for element = '", element, "'.", call. = FALSE)
+  axes <- .validate_axis_indices(axes, ndim = ncol(elmt$coord))
+  m <- m[, axes, drop = FALSE]
+  colnames(m) <- paste0("Dim", axes)
+  nm <- rownames(elmt$coord)
+  if(is.null(nm)) nm <- as.character(seq_len(nrow(m)))
+  rownames(m) <- as.character(nm)
+  m
+}
+
+
+# Heat-grid (element x dimension) of cos2/contrib values.
+# +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Shared by fviz_cos2()/fviz_contrib() when display = "heatmap". Shows one tile
+# per (element, dimension) filled by the cos2/contrib value, with the value
+# printed in the tile. Elements are ordered by their total over the shown axes,
+# and `top` keeps the leading ones (matching the barplot's top-elements idea).
+.fviz_result_heatmap <- function(X, choice, result, axes, top = Inf,
+                                 fill = "steelblue", ggtheme = theme_minimal(),
+                                 title = NULL, legend.title = result){
+  m <- .facto_element_matrix(X, choice, result, axes)
+  # order elements by total across the shown axes; keep the top ones
+  ord <- order(rowSums(m, na.rm = TRUE), decreasing = TRUE)
+  m <- m[ord, , drop = FALSE]
+  if(is.finite(top) && top < nrow(m)) m <- m[seq_len(top), , drop = FALSE]
+
+  elements <- rownames(m)
+  dims <- colnames(m)
+  df <- data.frame(
+    name  = factor(rep(elements, times = ncol(m)), levels = rev(elements)),
+    dim   = factor(rep(dims, each = nrow(m)), levels = dims),
+    value = as.vector(m),
+    stringsAsFactors = TRUE
+  )
+  # cos2 in [0,1] reads better with 2 decimals; contrib (%) with 1.
+  digits <- if(identical(result, "cos2")) 2 else 1
+  df$label <- ifelse(is.na(df$value), "",
+                     formatC(df$value, format = "f", digits = digits))
+  # Adaptive label colour: white text on dark tiles so the value stays legible
+  # for any `fill` (e.g. "navy"), not just the light default. The tile colour is
+  # the white->fill gradient at the value's position; pick white when it's dark.
+  rng <- range(df$value, na.rm = TRUE)
+  tpos <- if(diff(rng) > 0) (df$value - rng[1]) / diff(rng) else rep(0, nrow(df))
+  tpos[is.na(tpos)] <- 0
+  tile_rgb <- grDevices::colorRamp(c("white", fill), space = "Lab")(tpos)
+  lum <- (0.2126 * tile_rgb[, 1] + 0.7152 * tile_rgb[, 2] + 0.0722 * tile_rgb[, 3]) / 255
+  df$txt_col <- ifelse(lum < 0.4, "white", "black")
+  p <- ggplot(df, aes(x = .data[["dim"]], y = .data[["name"]], fill = .data[["value"]])) +
+    geom_tile(color = "white", linewidth = 0.5) +
+    geom_text(aes(label = .data[["label"]], color = .data[["txt_col"]]), size = 3) +
+    scale_color_identity() +
+    scale_fill_gradient(low = "white", high = fill, name = legend.title,
+                        na.value = "white") +
+    labs(title = title, x = "", y = "") +
+    ggtheme +
+    theme(panel.grid = element_blank())
+  p
 }

--- a/R/fviz_contrib.R
+++ b/R/fviz_contrib.R
@@ -44,6 +44,9 @@ NULL
 #' # Variable contributions on axes 1 + 2
 #' fviz_contrib(res.pca, choice="var", axes = 1:2)
 #'
+#' # Heat-grid of contributions across several dimensions
+#' fviz_contrib(res.pca, choice = "var", axes = 1:3, display = "heatmap")
+#'
 #' # Contributions of individuals on axis 1
 #' fviz_contrib(res.pca, choice="ind", axes = 1)
 #'
@@ -90,15 +93,27 @@ NULL
 #'  }
 #' @export
 fviz_contrib <- function(X, choice = c("row", "col", "var", "ind", "quanti.var", "quali.var", "group", "partial.axes"),
-                         axes=1, fill="steelblue", color = "steelblue", 
+                         axes=1, fill="steelblue", color = "steelblue",
                          sort.val = c("desc", "asc", "none"), top = Inf,
-                         xtickslab.rt = 45, ggtheme = theme_minimal(), ...)
+                         xtickslab.rt = 45, ggtheme = theme_minimal(),
+                         display = c("bar", "heatmap"), ...)
 {
 
   sort.val <- match.arg(sort.val)
   choice = match.arg(choice)
-  
+  display <- match.arg(display)
+
   title <- .build_title(choice[1], "Contribution", axes)
+
+  # display = "heatmap": one tile per (element, dimension) of the per-axis
+  # contribution, instead of a bar of the axis-averaged contribution. The
+  # barplot path (with its reference line) below is unchanged.
+  if(display == "heatmap")
+    return(.fviz_result_heatmap(X, choice = choice[1], result = "contrib",
+                                axes = axes, top = top, fill = fill,
+                                ggtheme = ggtheme,
+                                title = sub(" to Dim-.*$", " per dimension", title),
+                                legend.title = "contrib"))
 
   dd <- facto_summarize(X, element = choice, result = "contrib", axes = axes)
   contrib <- dd$contrib

--- a/R/fviz_cos2.R
+++ b/R/fviz_cos2.R
@@ -20,6 +20,15 @@ NULL
 #'   (for descending).
 #' @param top a numeric value specifying the number of top elements to be shown.
 #' @param xtickslab.rt rotation angle for x axis tick labels. Default is 45 degrees.
+#' @param display how to display the values. \code{"bar"} (default) draws the
+#'   usual barplot of the cos2/contribution summed over \code{axes}.
+#'   \code{"heatmap"} draws a grid with one tile per element and dimension,
+#'   filled by the per-dimension cos2/contribution and labelled with its value,
+#'   so several dimensions can be read at once. With \code{"heatmap"}, elements
+#'   are ordered by their (unweighted) total over the requested \code{axes} and
+#'   \code{top} keeps the leading ones; the bar-specific \code{sort.val} and
+#'   \code{color} arguments are ignored, and \code{fill} sets the high end of the
+#'   white-to-colour gradient.
 #' @inheritParams ggpubr::ggpar
 #'   
 #' @return a ggplot
@@ -42,7 +51,10 @@ NULL
 #'          
 #' # Variable cos2 on axes 1 + 2
 #' fviz_cos2(res.pca, choice="var", axes = 1:2)
-#' 
+#'
+#' # Heat-grid of cos2 across several dimensions
+#' fviz_cos2(res.pca, choice = "var", axes = 1:4, display = "heatmap")
+#'
 #' # cos2 of individuals on axis 1
 #' fviz_cos2(res.pca, choice="ind", axes = 1)
 #' 
@@ -87,13 +99,24 @@ NULL
 #'  }
 #' @export
 fviz_cos2 <- function(X, choice = c("row", "col", "var", "ind", "quanti.var", "quali.var", "group"), axes=1,
-                   fill="steelblue", color = "steelblue",  
-                   sort.val = c("desc", "asc", "none"), top = Inf, 
-                   xtickslab.rt = 45, ggtheme = theme_minimal(), ...)
+                   fill="steelblue", color = "steelblue",
+                   sort.val = c("desc", "asc", "none"), top = Inf,
+                   xtickslab.rt = 45, ggtheme = theme_minimal(),
+                   display = c("bar", "heatmap"), ...)
 {
    sort.val <- match.arg(sort.val)
+   display <- match.arg(display)
    title <- .build_title(choice[1], "Cos2", axes)
-  
+
+   # display = "heatmap": one tile per (element, dimension), instead of a bar
+   # of the cos2 summed over the axes. Barplot path below is unchanged.
+   if(display == "heatmap")
+     return(.fviz_result_heatmap(X, choice = choice[1], result = "cos2",
+                                 axes = axes, top = top, fill = fill,
+                                 ggtheme = ggtheme,
+                                 title = sub(" to Dim-.*$", " per dimension", title),
+                                 legend.title = "cos2"))
+
    dd <- facto_summarize(X, element = choice, result = "cos2", axes = axes)
    cos2 <- dd$cos2
    

--- a/man/fviz_contrib.Rd
+++ b/man/fviz_contrib.Rd
@@ -16,6 +16,7 @@ fviz_contrib(
   top = Inf,
   xtickslab.rt = 45,
   ggtheme = theme_minimal(),
+  display = c("bar", "heatmap"),
   ...
 )
 
@@ -54,6 +55,16 @@ Allowed values are "none" (no sorting), "asc" (for ascending) or "desc" (for des
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
+
+\item{display}{how to display the values. \code{"bar"} (default) draws the
+usual barplot of the cos2/contribution summed over \code{axes}.
+\code{"heatmap"} draws a grid with one tile per element and dimension,
+filled by the per-dimension cos2/contribution and labelled with its value,
+so several dimensions can be read at once. With \code{"heatmap"}, elements
+are ordered by their (unweighted) total over the requested \code{axes} and
+\code{top} keeps the leading ones; the bar-specific \code{sort.val} and
+\code{color} arguments are ignored, and \code{fill} sets the high end of the
+white-to-colour gradient.}
 
 \item{...}{other arguments to be passed to the function \link[ggpubr]{ggpar}.}
 
@@ -101,6 +112,9 @@ fviz_contrib(res.pca, choice="var", axes = 1,
 fviz_contrib(res.pca, choice="var", axes = 2)
 # Variable contributions on axes 1 + 2
 fviz_contrib(res.pca, choice="var", axes = 1:2)
+
+# Heat-grid of contributions across several dimensions
+fviz_contrib(res.pca, choice = "var", axes = 1:3, display = "heatmap")
 
 # Contributions of individuals on axis 1
 fviz_contrib(res.pca, choice="ind", axes = 1)

--- a/man/fviz_cos2.Rd
+++ b/man/fviz_cos2.Rd
@@ -14,6 +14,7 @@ fviz_cos2(
   top = Inf,
   xtickslab.rt = 45,
   ggtheme = theme_minimal(),
+  display = c("bar", "heatmap"),
   ...
 )
 }
@@ -42,6 +43,16 @@ Allowed values are "none" (no sorting), "asc" (for ascending) or "desc"
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
+
+\item{display}{how to display the values. \code{"bar"} (default) draws the
+usual barplot of the cos2/contribution summed over \code{axes}.
+\code{"heatmap"} draws a grid with one tile per element and dimension,
+filled by the per-dimension cos2/contribution and labelled with its value,
+so several dimensions can be read at once. With \code{"heatmap"}, elements
+are ordered by their (unweighted) total over the requested \code{axes} and
+\code{top} keeps the leading ones; the bar-specific \code{sort.val} and
+\code{color} arguments are ignored, and \code{fill} sets the high end of the
+white-to-colour gradient.}
 
 \item{...}{not used}
 }
@@ -72,6 +83,9 @@ fviz_cos2(res.pca, choice="var", axes = 1,
          
 # Variable cos2 on axes 1 + 2
 fviz_cos2(res.pca, choice="var", axes = 1:2)
+
+# Heat-grid of cos2 across several dimensions
+fviz_cos2(res.pca, choice = "var", axes = 1:4, display = "heatmap")
 
 # cos2 of individuals on axis 1
 fviz_cos2(res.pca, choice="ind", axes = 1)

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -347,3 +347,42 @@ test_that("quali.sup plots reject contrib-based selection cleanly", {
     "There are no supplementary qualitative variables"
   )
 })
+
+test_that("fviz_cos2/fviz_contrib heatmap shows per-dimension values; bar default unchanged", {
+  data(decathlon2)
+  res <- prcomp(decathlon2[1:23, 1:10], scale. = TRUE)
+  has_geom <- function(p, g) any(vapply(p$layers, function(l) inherits(l$geom, g), logical(1)))
+
+  # Default is the barplot (no tiles) -- unchanged.
+  expect_false(has_geom(fviz_cos2(res, choice = "var", axes = 1:2), "GeomTile"))
+  expect_false(has_geom(fviz_contrib(res, choice = "var", axes = 1:2), "GeomTile"))
+
+  # display = "heatmap" draws a tile grid.
+  p_heat <- fviz_cos2(res, choice = "var", axes = 1:3, display = "heatmap")
+  expect_s3_class(p_heat, "ggplot")
+  expect_true(has_geom(p_heat, "GeomTile"))
+  expect_true(has_geom(fviz_contrib(res, choice = "var", axes = 1:2, display = "heatmap"), "GeomTile"))
+
+  # The tile values equal get_pca_var()$cos2 / $contrib for the shown axes, cell-for-cell.
+  ref <- get_pca_var(res)$cos2[, 1:3]
+  m <- factoextra:::.facto_element_matrix(res, "var", "cos2", 1:3)
+  colnames(m) <- colnames(ref)
+  expect_equal(m[rownames(ref), ], ref)
+
+  refc <- get_pca_var(res)$contrib[, 1:2]
+  mc <- factoextra:::.facto_element_matrix(res, "var", "contrib", 1:2)
+  colnames(mc) <- colnames(refc)
+  expect_equal(mc[rownames(refc), ], refc)
+
+  # `top` keeps the leading elements.
+  p_top <- fviz_cos2(res, choice = "var", axes = 1:2, top = 4, display = "heatmap")
+  expect_equal(length(unique(ggplot2::ggplot_build(p_top)$data[[1]]$y)), 4)
+})
+
+test_that("fviz_cos2/fviz_contrib heatmap works across methods (CA)", {
+  skip_if_not_installed("FactoMineR")
+  data(housetasks)
+  res.ca <- FactoMineR::CA(housetasks, graph = FALSE)
+  expect_s3_class(fviz_cos2(res.ca, choice = "row", axes = 1:2, display = "heatmap"), "ggplot")
+  expect_s3_class(fviz_contrib(res.ca, choice = "col", axes = 1:2, display = "heatmap"), "ggplot")
+})


### PR DESCRIPTION
`fviz_cos2()` and `fviz_contrib()` gain a `display` argument. `display = "heatmap"`
draws a grid with one tile per element and dimension, filled and labelled by the
per-dimension cos2/contribution, so the quality of representation / contribution
across several dimensions can be read at once — instead of reading one barplot per
dimension. The default (`display = "bar"`) is unchanged.

## Example

```r
library(factoextra)
data(decathlon2)
res.pca <- prcomp(decathlon2[1:23, 1:10], scale. = TRUE)

# Quality of representation (cos2) across the first 4 dimensions
fviz_cos2(res.pca, choice = "var", axes = 1:4, display = "heatmap")
```

![cos2 heat-grid](https://i.imgur.com/zPUiEl1.png)

```r
# Contributions across the first 3 dimensions
fviz_contrib(res.pca, choice = "var", axes = 1:3, display = "heatmap")
```

![contribution heat-grid](https://i.imgur.com/vn8J39y.png)

## Notes

- Additive: `display = "bar"` (default) reproduces the current output for every
  method and choice.
- Works for the same elements as the barplot (rows/columns for CA, variables/
  individuals/categories for PCA/MCA/FAMD/MFA). Tile values equal
  `get_*()$cos2` / `$contrib` for the shown axes.
- The value labels switch to white on dark tiles, so a custom `fill` (e.g.
  `fill = "navy"`) stays legible.
