### PR TITLE
feat(fviz_mca): overlay supplementary quantitative variables as arrows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@
   draws a grid with one tile per element and dimension, filled and labelled by the
   per-dimension cos2/contribution, so the quality/contribution across several
   dimensions can be read at once. The default (`display = "bar"`) is unchanged.
+* `fviz_mca_ind()` and `fviz_mca_biplot()` gain a `quanti.sup` argument. Set
+  `quanti.sup = TRUE` to overlay the supplementary quantitative variables of a
+  FactoMineR MCA on the map as correlation arrows, so a continuous covariate's
+  direction can be read against the category/individual cloud. Each arrow's length
+  is proportional to the variable's absolute correlation with the dimensions
+  (relative to the cloud extent). The default (`quanti.sup = FALSE`) leaves the map
+  unchanged.
 
 ## Minor changes
 

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -476,6 +476,64 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   
 }
 
+# Overlay the supplementary quantitative variables of an MCA as scaled
+# correlation arrows on an individual / category map.
+# +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# MCA supplementary quantitative variables are summarized by their correlation
+# with each dimension (X$quanti.sup$coord, signed, in [-1, 1]). factoextra's
+# standalone quanti.sup plot lives in the squared-correlation [0, 1] space, so it
+# is NOT reused here: for a biplot overlay we draw the RAW signed correlations as
+# arrows from the origin, scaled with the same convention as fviz_pca_biplot()
+# (longest arrow ~ 80% of the individual-cloud extent) so directions read against
+# the cloud. Arrow lengths are therefore relative.
+.add_mca_quanti_sup <- function(p, X, axes = c(1, 2), col = "#D55E00",
+                                geom = c("arrow", "text"), labelsize = 4,
+                                arrowsize = 0.5, repel = TRUE){
+  if(!inherits(X, "MCA") || is.null(X$quanti.sup)){
+    warning("quanti.sup = TRUE: no supplementary quantitative variables found ",
+            "(needs a FactoMineR MCA fitted with quanti.sup). Skipping the overlay.",
+            call. = FALSE)
+    return(p)
+  }
+  qs <- X$quanti.sup$coord[, axes, drop = FALSE]   # signed correlations in [-1, 1]
+  if(all(is.na(qs)) || suppressWarnings(max(abs(qs), na.rm = TRUE)) == 0) return(p)
+  # Cloud extent from the built plot, so scaling is correct for every `map` mode
+  # (e.g. colprincipal rescales the individuals). Arrow length is proportional to
+  # the |correlation|: a correlation of 1 reaches ~80% of the cloud extent, so a
+  # weak covariate draws a short arrow (length is honest, not normalised to 1).
+  rng <- tryCatch({
+    b <- ggplot2::ggplot_build(p)
+    max(abs(c(b$layout$panel_params[[1]]$x.range,
+              b$layout$panel_params[[1]]$y.range)), na.rm = TRUE)
+  }, error = function(e) max(abs(X$ind$coord[, axes]), na.rm = TRUE))
+  sf <- 0.8 * rng
+  df <- data.frame(name = rownames(qs),
+                   x = qs[, 1] * sf, y = qs[, 2] * sf,
+                   stringsAsFactors = TRUE)
+  if("arrow" %in% geom)
+    p <- p + .arrows(data = df, color = col, linewidth = arrowsize)
+  if("text" %in% geom){
+    # Place each label just BEYOND its arrow tip (a small fixed nudge along the
+    # arrow direction), so the arrow/head does not run through the text. A tiny
+    # arrow at the origin keeps its label in place (unit direction is ~0).
+    len <- sqrt(df$x^2 + df$y^2)
+    gap <- 0.06 * rng
+    df$lx <- df$x + ifelse(len > 0, df$x / len, 0) * gap
+    df$ly <- df$y + ifelse(len > 0, df$y / len, 0) * gap
+    # Repel the overlay labels by default: an MCA usually has a dominant first
+    # axis, so several arrows align and their tip labels would otherwise overprint.
+    if(isTRUE(repel) && requireNamespace("ggrepel", quietly = TRUE))
+      p <- p + ggpubr::geom_exec(ggrepel::geom_text_repel, data = df,
+                                 x = "lx", y = "ly", label = "name",
+                                 color = col, fontface = "italic", size = labelsize)
+    else
+      p <- p + ggpubr::geom_exec(geom_text, data = df, x = "lx", y = "ly",
+                                 label = "name", color = col,
+                                 fontface = "italic", size = labelsize)
+  }
+  p + labs(caption = "Arrows: supplementary quantitative variables (relative lengths)")
+}
+
 # Add arrow to the plot
 # FIX: ggplot2 3.4.0+ deprecation - size replaced with linewidth for geom_segment
 .arrows <- function(data, color = "black", alpha = 1, linewidth = 0.5,

--- a/R/fviz_mca.R
+++ b/R/fviz_mca.R
@@ -49,8 +49,13 @@ NULL
 #'  , "coord"), x values("x") or y values("y"). To use this, make sure that 
 #'  habillage ="none".
 #'@param shape.ind,shape.var point shapes of individuals and variables.
-#'@param col.quanti.sup,col.quali.sup a color for the quantitative/qualitative 
+#'@param col.quanti.sup,col.quali.sup a color for the quantitative/qualitative
 #'  supplementary variables.
+#'@param quanti.sup logical. If \code{TRUE}, the supplementary quantitative
+#'  variables of a FactoMineR \code{\link[FactoMineR]{MCA}} are overlaid on the
+#'  individuals / biplot map as correlation arrows (see the Details section).
+#'  Default \code{FALSE} leaves the map unchanged. Used by \code{fviz_mca_ind()}
+#'  and \code{fviz_mca_biplot()}.
 #'@param repel a boolean, whether to use ggrepel to avoid overplotting text
 #'  labels or not. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
@@ -84,9 +89,20 @@ NULL
 #'  columns are in principal coordinates. In this situation, it's not possible 
 #'  to interpret the distance between row points and column points. To overcome 
 #'  this problem, the simplest way is to make an asymmetric plot. The argument 
-#'  "map" can be used to change the plot type. For more explanation, read the 
+#'  "map" can be used to change the plot type. For more explanation, read the
 #'  details section of fviz_ca documentation.
-#'  
+#'
+#'  \code{quanti.sup = TRUE} overlays the supplementary quantitative variables on
+#'  the individuals / biplot map. Each such variable is drawn as an arrow from the
+#'  origin in the direction of its correlations with the shown dimensions
+#'  (\code{X$quanti.sup$coord}), so the arrow points toward the region of the
+#'  cloud where the variable takes larger values. Each arrow's length is
+#'  proportional to the variable's absolute correlation with the shown dimensions
+#'  (a correlation of 1 reaches about 80\% of the individual-cloud extent), so a
+#'  weak covariate draws a short arrow. The overlay labels are repelled by default
+#'  (needs the \code{ggrepel} package). \strong{Arrow lengths are relative} to the
+#'  cloud, so compare directions and relative lengths rather than absolute sizes.
+#'
 #'@return a ggplot
 #'@author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}
 #'@seealso \code{\link{get_mca}}, \code{\link{fviz_pca}}, \code{\link{fviz_ca}},
@@ -129,8 +145,14 @@ NULL
 #' p <- fviz_mca_ind(res.mca, label="none", habillage=grp,
 #'        addEllipses=TRUE, ellipse.level=0.95)
 #' print(p)
-#'       
-#'     
+#'
+#' # Overlay supplementary quantitative variables as correlation arrows.
+#' # Fit the MCA with quanti.sup, then set quanti.sup = TRUE when plotting.
+#' res.mca2 <- MCA(poison, quanti.sup = 1:2, quali.sup = 3:4, graph = FALSE)
+#' fviz_mca_ind(res.mca2, label = "none", habillage = poison$Vomiting,
+#'              addEllipses = TRUE, quanti.sup = TRUE)
+#'
+#'
 #' # Change group colors using RColorBrewer color palettes
 #' # Read more: http://www.sthda.com/english/wiki/ggplot2-colors
 #' p + scale_color_brewer(palette="Dark2") +
@@ -200,20 +222,26 @@ NULL
 #'@rdname fviz_mca
 #'@export
 fviz_mca_ind <- function(X,  axes = c(1,2), geom=c("point", "text"), geom.ind = geom, repel = FALSE,
-                         habillage = "none", palette = NULL, addEllipses = FALSE, 
+                         habillage = "none", palette = NULL, addEllipses = FALSE,
                          col.ind = "blue", col.ind.sup = "darkblue", alpha.ind = 1,
-                         shape.ind = 19, map ="symmetric", 
+                         shape.ind = 19, map ="symmetric",
                          select.ind = list(name = NULL, cos2 = NULL, contrib = NULL),
+                         quanti.sup = FALSE, col.quanti.sup = "#D55E00",
                          ...)
 {
-  
-  fviz (X, element = "ind", axes = axes, geom = geom.ind, habillage = habillage, 
+
+  p <- fviz (X, element = "ind", axes = axes, geom = geom.ind, habillage = habillage,
         addEllipses = addEllipses, palette = palette, pointshape = shape.ind,
         color = col.ind, alpha = alpha.ind,
         shape.sup = shape.ind, col.row.sup = col.ind.sup,
         select = select.ind,  map = map, repel = repel, ...)
 
-  
+  # Overlay supplementary quantitative variables as scaled correlation arrows.
+  # Default quanti.sup = FALSE leaves the map unchanged.
+  if(isTRUE(quanti.sup))
+    p <- .add_mca_quanti_sup(p, X, axes = axes, col = col.quanti.sup)
+
+  p
 }
 
 
@@ -257,16 +285,20 @@ fviz_mca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
                             geom.ind = geom, geom.var = geom,
                             repel = FALSE, label = "all", invisible="none",
                             habillage="none", addEllipses=FALSE, palette = NULL,
-                            arrows = c(FALSE, FALSE), map ="symmetric", 
-                            title = "MCA - Biplot", ...)
+                            arrows = c(FALSE, FALSE), map ="symmetric",
+                            title = "MCA - Biplot",
+                            quanti.sup = FALSE, col.quanti.sup = "#D55E00", ...)
 {
-  
+
   # Individuals
   geom2 <- geom.ind
   if(arrows[1]==TRUE) geom2 <- setdiff(unique(c(geom2, "arrow")), "point")
+  # quanti.sup/col.quanti.sup are forwarded explicitly (not via ...) so they do
+  # not leak into fviz_mca_var() below.
   p <- fviz_mca_ind(X,  axes = axes, geom = geom2, repel = repel,
                     label = label, invisible=invisible, habillage = habillage,
-                    addEllipses = addEllipses, palette = palette, map = map, ...)
+                    addEllipses = addEllipses, palette = palette, map = map,
+                    quanti.sup = quanti.sup, col.quanti.sup = col.quanti.sup, ...)
 
   # Variable
   geom2 <- geom.var

--- a/man/fviz_mca.Rd
+++ b/man/fviz_mca.Rd
@@ -22,6 +22,8 @@ fviz_mca_ind(
   shape.ind = 19,
   map = "symmetric",
   select.ind = list(name = NULL, cos2 = NULL, contrib = NULL),
+  quanti.sup = FALSE,
+  col.quanti.sup = "#D55E00",
   ...
 )
 
@@ -57,6 +59,8 @@ fviz_mca_biplot(
   arrows = c(FALSE, FALSE),
   map = "symmetric",
   title = "MCA - Biplot",
+  quanti.sup = FALSE,
+  col.quanti.sup = "#D55E00",
   ...
 )
 
@@ -135,6 +139,15 @@ then the top 5 individuals/variables with the highest cos2 are drawn. \item
 contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
 the highest contrib are drawn }}
 
+\item{quanti.sup}{logical. If \code{TRUE}, the supplementary quantitative
+variables of a FactoMineR \code{\link[FactoMineR]{MCA}} are overlaid on the
+individuals / biplot map as correlation arrows (see the Details section).
+Default \code{FALSE} leaves the map unchanged. Used by \code{fviz_mca_ind()}
+and \code{fviz_mca_biplot()}.}
+
+\item{col.quanti.sup, col.quali.sup}{a color for the quantitative/qualitative
+supplementary variables.}
+
 \item{...}{Additional arguments. \itemize{ \item in fviz_mca_ind(), 
 fviz_mca_var() and fviz_mca_cor(): Additional arguments are passed to the 
 functions fviz() and ggpubr::ggpar(). \item in fviz_mca_biplot() and 
@@ -145,9 +158,6 @@ fviz_mca_var().}}
 "mca.cor" for plotting the correlation between variables and principal 
 dimensions; ii) "var.cat" for variable categories and iii) "quanti.sup" for
 the supplementary quantitative variables.}
-
-\item{col.quanti.sup, col.quali.sup}{a color for the quantitative/qualitative 
-supplementary variables.}
 
 \item{label}{a text specifying the elements to be labelled. Default value is 
 "all". Allowed values are "none" or the combination of c("ind", 
@@ -188,8 +198,19 @@ The default plot of MCA is a "symmetric" plot in which both rows and
  columns are in principal coordinates. In this situation, it's not possible 
  to interpret the distance between row points and column points. To overcome 
  this problem, the simplest way is to make an asymmetric plot. The argument 
- "map" can be used to change the plot type. For more explanation, read the 
+ "map" can be used to change the plot type. For more explanation, read the
  details section of fviz_ca documentation.
+
+ \code{quanti.sup = TRUE} overlays the supplementary quantitative variables on
+ the individuals / biplot map. Each such variable is drawn as an arrow from the
+ origin in the direction of its correlations with the shown dimensions
+ (\code{X$quanti.sup$coord}), so the arrow points toward the region of the
+ cloud where the variable takes larger values. Each arrow's length is
+ proportional to the variable's absolute correlation with the shown dimensions
+ (a correlation of 1 reaches about 80\% of the individual-cloud extent), so a
+ weak covariate draws a short arrow. The overlay labels are repelled by default
+ (needs the \code{ggrepel} package). \strong{Arrow lengths are relative} to the
+ cloud, so compare directions and relative lengths rather than absolute sizes.
 }
 \examples{
 # Multiple Correspondence Analysis
@@ -229,8 +250,14 @@ grp <- as.factor(poison.active[, "Vomiting"])
 p <- fviz_mca_ind(res.mca, label="none", habillage=grp,
        addEllipses=TRUE, ellipse.level=0.95)
 print(p)
-      
-    
+
+# Overlay supplementary quantitative variables as correlation arrows.
+# Fit the MCA with quanti.sup, then set quanti.sup = TRUE when plotting.
+res.mca2 <- MCA(poison, quanti.sup = 1:2, quali.sup = 3:4, graph = FALSE)
+fviz_mca_ind(res.mca2, label = "none", habillage = poison$Vomiting,
+             addEllipses = TRUE, quanti.sup = TRUE)
+
+
 # Change group colors using RColorBrewer color palettes
 # Read more: http://www.sthda.com/english/wiki/ggplot2-colors
 p + scale_color_brewer(palette="Dark2") +

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -386,3 +386,39 @@ test_that("fviz_cos2/fviz_contrib heatmap works across methods (CA)", {
   expect_s3_class(fviz_cos2(res.ca, choice = "row", axes = 1:2, display = "heatmap"), "ggplot")
   expect_s3_class(fviz_contrib(res.ca, choice = "col", axes = 1:2, display = "heatmap"), "ggplot")
 })
+
+test_that("fviz_mca quanti.sup overlays scaled correlation arrows; default off", {
+  skip_if_not_installed("FactoMineR")
+  data(poison, package = "FactoMineR")
+  res <- FactoMineR::MCA(poison, quanti.sup = 1:2, quali.sup = 3:4, graph = FALSE)
+  has_seg <- function(p) any(vapply(p$layers, function(l) inherits(l$geom, "GeomSegment"), logical(1)))
+  seg_ends <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomSegment"), logical(1)))[1]
+    ggplot2::layer_data(p, i)[, c("xend", "yend")]
+  }
+
+  # Default off: no arrow overlay for ind or biplot.
+  expect_false(has_seg(fviz_mca_ind(res)))
+  expect_false(has_seg(fviz_mca_biplot(res)))
+
+  # quanti.sup = TRUE overlays arrows whose endpoints equal the signed
+  # supplementary correlations times a single positive scale factor (arrow
+  # length proportional to |correlation|, sign/direction preserved).
+  p <- fviz_mca_ind(res, quanti.sup = TRUE)
+  expect_true(has_seg(p))
+  qs   <- res$quanti.sup$coord[, 1:2]
+  ends <- seg_ends(p)
+  ends <- ends[order(ends$xend), ]
+  qso  <- qs[order(qs[, 1]), ]
+  k <- ends$xend[1] / qso[1, 1]           # implied scale factor
+  expect_gt(k, 0)                          # arrows not flipped
+  expect_equal(unname(as.matrix(ends)), unname(as.matrix(qso * k)), tolerance = 1e-6)
+  # Sign preserved: a variable negatively correlated with Dim1 points left.
+  expect_true(any(ends$xend < 0))
+  expect_true(has_seg(fviz_mca_biplot(res, quanti.sup = TRUE)))
+
+  # No supplementary quantitative variables -> warn and no arrows (no error).
+  res2 <- FactoMineR::MCA(poison[, 5:15], graph = FALSE)
+  expect_warning(p2 <- fviz_mca_ind(res2, quanti.sup = TRUE), "supplementary quantitative")
+  expect_false(has_seg(p2))
+})


### PR DESCRIPTION
`fviz_mca_ind()` and `fviz_mca_biplot()` gain a `quanti.sup` argument. Set
`quanti.sup = TRUE` to overlay the supplementary quantitative variables of a
FactoMineR MCA on the map as correlation arrows, so a continuous covariate's
direction can be read directly against the category / individual cloud — instead
of a separate `fviz_mca_var(choice = "quanti.sup")` plot or a hand-built overlay.

Each arrow points in the direction of the variable's correlations with the shown
dimensions, and its length is proportional to the absolute correlation (a
correlation of 1 reaches about 80% of the cloud extent, so a weak covariate draws
a short arrow). Labels are repelled by default. The default (`quanti.sup = FALSE`)
leaves the map unchanged.

## Example

```r
library(factoextra)
library(FactoMineR)
data(poison)
res.mca <- MCA(poison, quanti.sup = 1:2, quali.sup = 3:4, graph = FALSE)

# Individuals coloured by a category, with the supplementary quantitative
# variables (Time, Age) overlaid as correlation arrows
fviz_mca_ind(res.mca, label = "none", habillage = poison$Vomiting,
             addEllipses = TRUE, quanti.sup = TRUE)
```

![MCA individuals with quanti.sup arrows](https://i.imgur.com/2vmLQz8.png)

Here `Time` points left, toward the `Vomit_y` cluster, while `Age` (weak
correlation) stays a short arrow near the origin.

```r
# Also available on the biplot
fviz_mca_biplot(res.mca, quanti.sup = TRUE, repel = TRUE)
```

## Notes

- Additive: `quanti.sup = FALSE` (default) reproduces the current output for every
  map/mode. Arrow endpoints equal `res.mca$quanti.sup$coord[, axes]` times a single
  scale factor (sign and direction preserved).
- `col.quanti.sup` sets the arrow colour (default a distinct vermillion so it stands
  off the individuals). Only FactoMineR MCA objects carry supplementary quantitative
  variables; other MCA backends warn and skip.
