### PR TITLE
Add max.points downsampling for large individual/cluster plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,19 @@
   draws a grid with one tile per element and dimension, filled and labelled by the
   per-dimension cos2/contribution, so the quality/contribution across several
   dimensions can be read at once. The default (`display = "bar"`) is unchanged.
+* `fviz_pca_ind()`, `fviz_cluster()` (and the other individual / row / column
+  plots) gain a `max.points` argument for large datasets. When there are more
+  than `max.points` points, a reproducible random subset of that many is drawn so
+  labels, colours and ellipses stay readable instead of over-plotting. When points
+  are grouped (e.g. `habillage`, or clusters in `fviz_cluster()`) the draw is
+  stratified so every group keeps a minimum number of points and none is
+  decimated, and a message reports how many points are shown. Only the drawn
+  points are thinned: any ellipse (`addEllipses` / the cluster frame) and the
+  group/cluster centres are still computed on the full data, so a convex hull or
+  confidence ellipse is not distorted by dropping the extreme points a random
+  draw tends to lose. The draw does not disturb the caller's random stream.
+  `max.points = NULL` (default) draws every point, and `sample.seed` controls
+  which subset is chosen.
 * `fviz_mca_ind()` and `fviz_mca_biplot()` gain a `quanti.sup` argument. Set
   `quanti.sup = TRUE` to overlay the supplementary quantitative variables of a
   FactoMineR MCA on the map as correlation arrows, so a continuous covariate's

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -98,6 +98,19 @@ NULL
 #'  contrib > 1, ex: 5,  then the top 5 individuals/variables with the highest 
 #'  contrib are drawn }
 #'@param ggp a ggplot. If not NULL, points are added to an existing plot.
+#'@param max.points integer or NULL. When the individual / row / column cloud has
+#'  more than \code{max.points} points, a random subset of that many \emph{points}
+#'  is drawn so the plot stays readable (usable labels instead of an over-plotted
+#'  cloud). Only the drawn points/labels are thinned: any ellipse
+#'  (\code{addEllipses}) and the group mean point are still computed on the
+#'  \strong{full} data, so a convex / confidence frame is not shrunk or inflated by
+#'  the draw. When points are coloured/split by a group (e.g. \code{habillage}),
+#'  the draw is \strong{stratified} so every group keeps at least a minimum number
+#'  of points and none is decimated. A message reports how many points are shown.
+#'  The subset is reproducible (see \code{sample.seed}) and does not change the
+#'  caller's random stream. \code{NULL} (default) draws every point.
+#'@param sample.seed the random seed used to pick the \code{max.points} subset,
+#'  for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.
 #'@inheritParams ggpubr::ggpar
 #'@param font.family character vector specifying font family.
 #'@param ... Arguments to be passed to the functions ggpubr::ggscatter() & 
@@ -153,6 +166,7 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
                           rotate.labels = FALSE,
                           ggtheme = theme_minimal(),
                           ggp = NULL, font.family = "",
+                          max.points = NULL, sample.seed = 123,
                            ...)
   {
   
@@ -272,8 +286,35 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
     df[, c("x", "y")] <- df[, c("x", "y")]*extra_args$scale.
   # (M)CA: scale coords according to the type of map
   if(facto.class %in% c("CA", "MCA") && !(element %in% c("mca.cor", "quanti.sup"))){
-  if(!is.null(extra_args$map)) df <- .scale_ca(df, res.ca = X,  element = element, 
+  if(!is.null(extra_args$map)) df <- .scale_ca(df, res.ca = X,  element = element,
                                                type = extra_args$map, axes = axes)
+  }
+  # Downsample a very large point cloud so the plot stays readable (usable labels
+  # and ellipses instead of an over-plotted blob). max.points = NULL (default)
+  # keeps every point, so existing calls are byte-identical. Only the individual /
+  # row / column clouds are subsettable, and the draw is seeded + RNG-safe so the
+  # subset is reproducible without perturbing the caller's random stream.
+  # `df` is kept at full size here; when sampling is requested we record the
+  # subset in `sampled_idx` and thin only the drawn point/text layers AFTER the
+  # plot is built (below). The ellipse and group mean point are then computed by
+  # ggscatter on the full data, so a convex / confidence frame is not shrunk or
+  # inflated by dropping the extreme points (or the count) a random draw perturbs.
+  sampled_idx <- NULL
+  if(!is.null(max.points) && element %in% c("ind", "row", "col")){
+    max.points <- .coerce_integerish(max.points, "max.points", lower = 1L)
+    if(nrow(df) > max.points){
+      # When points are coloured by a group (habillage / col.ind factor), that
+      # grouping column now lives in `color` (e.g. the quali var name, "Col." or
+      # "Groups"). Stratify on it so a small group keeps its floor and its ellipse
+      # stays meaningful; continuous colouring (cos2/contrib) is not a grouping.
+      grp_col <- if(is.character(color) && length(color) == 1L && color %in% names(df) &&
+                    .is_grouping_var(df[[color]])) color
+                 else if("Groups" %in% names(df)) "Groups" else NULL
+      grps <- if(!is.null(grp_col)) df[[grp_col]] else NULL
+      sampled_idx <- .sample_indices(nrow(df), max.points, groups = grps, seed = sample.seed)
+      message("Showing a random ", length(sampled_idx), " of ", nrow(df),
+              " points (max.points); set max.points = NULL to show all.")
+    }
   }
   # Main plot
   #%%%%%%%%%%%%%%%%%%%
@@ -329,6 +370,22 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   # repel = FALSE); ggrepel ignores the angle aesthetic. (#98)
   if(isTRUE(rotate.labels) && "arrow" %in% geom)
     p <- .rotate_text_labels(p, n_layers_before)
+
+  # Thin only the drawn scatter/labels to the sampled subset; the group mean point
+  # (StatMean) and ellipse (StatEllipse / StatChull polygon) added by the ggscatter
+  # call above keep their full-data layers, so the frame stays faithful. Only this
+  # element's layers (index > n_layers_before) are touched, so chained biplot
+  # layers and supplementary points (added later) are left intact.
+  if(!is.null(sampled_idx)){
+    sub <- df[sampled_idx, , drop = FALSE]
+    for(i in seq_along(p$layers)){
+      if(i <= n_layers_before) next
+      g <- p$layers[[i]]$geom; s <- p$layers[[i]]$stat
+      is_point <- inherits(g, "GeomPoint") && inherits(s, "StatIdentity")
+      is_text  <- inherits(g, c("GeomText", "GeomLabel", "GeomTextRepel", "GeomLabelRepel"))
+      if(is_point || is_text) p$layers[[i]]$data <- sub
+    }
+  }
 
   if(!is.null(gradient.cols))
     p <- p + ggpubr::gradient_color(gradient.cols)

--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -50,6 +50,19 @@
 #'@param xlab,ylab character vector specifying x and y axis labels,
 #'  respectively. Use xlab = FALSE and ylab = FALSE to hide xlab and ylab,
 #'  respectively.
+#'@param max.points integer or NULL. When the data has more than
+#'  \code{max.points} observations, a random subset of that many \emph{points} is
+#'  drawn so the cluster plot stays readable instead of over-plotting. Only the
+#'  drawn scatter/labels are thinned: the cluster frame (convex hull / ellipse)
+#'  and centres are still computed on the \strong{full} data, so a convex hull is
+#'  not shrunk by dropping the extreme points a random draw tends to lose. The
+#'  draw is \strong{stratified by cluster} so every cluster keeps at least a
+#'  minimum number of points, and a message reports how many are shown. Any
+#'  DBSCAN/Mclust outliers are always drawn. The subset is reproducible (see
+#'  \code{sample.seed}) and does not change the caller's random stream. \code{NULL}
+#'  (default) draws every observation.
+#'@param sample.seed the random seed used to pick the \code{max.points} subset,
+#'  for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.
 #'@inheritParams ggpubr::ggpar
 #'@param ... other arguments to be passed to the functions
 #'  \code{\link[ggpubr]{ggscatter}} and \code{\link[ggpubr]{ggpar}}.
@@ -120,7 +133,8 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
                          main = "Cluster plot",  xlab = NULL, ylab = NULL,
                          outlier.color = "black", outlier.shape = 19,
                          outlier.pointsize = pointsize, outlier.labelsize = labelsize,
-                         ggtheme = theme_grey(), ...){
+                         ggtheme = theme_grey(),
+                         max.points = NULL, sample.seed = 123, ...){
   
   # Backward compatibility: deprecated arguments converted with warning
   extra_args <- list(...)
@@ -305,7 +319,31 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
       label_coord <- label_coord[-outliers, , drop = FALSE]
     }
   }
-  
+
+  # Downsample a very large cluster plot so points/labels stay readable. The draw
+  # is deferred until AFTER the plot is built (below): the cluster frame (convex
+  # hull / ellipse) and centres are computed on the FULL data and only the drawn
+  # scatter/labels are thinned. A convex hull is defined by its extreme points -
+  # exactly the ones a random draw is most likely to drop - so thinning the hull's
+  # input would shrink it and understate the cluster; keeping the frame on the full
+  # data avoids that. max.points = NULL (default) keeps every observation, so
+  # existing calls are byte-identical. Any dbscan/Mclust outliers were split off
+  # above and are always drawn; the draw is seeded + RNG-safe (reproducible without
+  # perturbing the caller's random stream) and stratified by cluster.
+  sampled <- NULL
+  if(!is.null(max.points)){
+    max.points <- .coerce_integerish(max.points, "max.points", lower = 1L)
+    if(nrow(plot.data) > max.points){
+      sampled <- .sample_indices(nrow(plot.data), max.points, groups = cluster,
+                                 seed = sample.seed)
+      n_out <- if(is_outliers) nrow(outliers_data) else 0L
+      message("fviz_cluster(): showing a random ", length(sampled), " of ",
+              nrow(plot.data), " clustered points",
+              if(n_out > 0) paste0(" (+ ", n_out, " outliers, always shown)") else "",
+              "; set max.points = NULL to show all.")
+    }
+  }
+
   # Plot
   # ++++++++++++++++++++++++
   lab <- NULL
@@ -331,7 +369,21 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
     extra_args
   )
   p <- do.call(ggpubr::ggscatter, ggscatter_args)
-  
+
+  # Thin only the drawn scatter/labels to the sampled subset; the frame (convex
+  # hull / ellipse, a StatChull/StatEllipse polygon) and the cluster centres (a
+  # StatMean point) keep their full-data layers, so boundaries and centres stay
+  # faithful. Matched by geom/stat class (not layer index) for version-robustness.
+  if(!is.null(sampled)){
+    sub <- plot.data[sampled, , drop = FALSE]
+    for(i in seq_along(p$layers)){
+      g <- p$layers[[i]]$geom; s <- p$layers[[i]]$stat
+      is_point <- inherits(g, "GeomPoint") && inherits(s, "StatIdentity")
+      is_text  <- inherits(g, c("GeomText", "GeomLabel", "GeomTextRepel", "GeomLabelRepel"))
+      if(is_point || is_text) p$layers[[i]]$data <- sub
+    }
+  }
+
   # Add outliers (can exist only in dbscan)
   if(is_outliers)
     p <- .add_outliers(p, outliers_data, outliers_labs, outlier.color, outlier.shape,

--- a/R/fviz_pca.R
+++ b/R/fviz_pca.R
@@ -199,13 +199,15 @@ fviz_pca_ind <- function(X,  axes = c(1,2), geom = c("point", "text"),
                          col.ind = "black", fill.ind = "white", col.ind.sup = "blue", alpha.ind =1,
                          shape.ind = NULL,
                          select.ind = list(name = NULL, cos2 = NULL, contrib = NULL),
+                         max.points = NULL, sample.seed = 123,
                          ...)
 {
 
   .args <- list(X = X, element = "ind", axes = axes, geom = geom.ind,
                 habillage = habillage, palette = palette, addEllipses = addEllipses,
                 color = col.ind, fill = fill.ind, alpha = alpha.ind, col.row.sup = col.ind.sup,
-                select = select.ind, repel = repel, ...)
+                select = select.ind, repel = repel,
+                max.points = max.points, sample.seed = sample.seed, ...)
   # shape.ind = a factor maps point shape to a (possibly different) grouping than
   # col.ind, e.g. colour by one variable and shape by another. NULL (default)
   # keeps the previous behavior (shape follows habillage/colour). (#36, #51)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -72,6 +72,63 @@ NULL
   force(expr)
 }
 
+# Pick row indices for a downsampled plot (used by max.points).
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# n          : total number of rows
+# max.points : draw at most this many; if n <= max.points, keep all rows
+# groups     : optional grouping (habillage / cluster). When present, sampling is
+#              STRATIFIED with a per-group floor so a small group is not decimated
+#              (a group reduced to a few points would give a misleading ellipse).
+#              Every group keeps at least min(group size, floor) points, and the
+#              remaining budget is spread proportionally to the larger groups.
+# seed       : fixed seed for a reproducible subset; RNG-safe via .with_preserved_seed.
+.sample_indices <- function(n, max.points, groups = NULL, seed = 123, min.per.group = 20L){
+  if(n <= max.points) return(seq_len(n))
+  .with_preserved_seed(seed, {
+    stratify <- !is.null(groups) && length(unique(groups)) >= 2
+    if(!stratify){
+      sort(sample.int(n, max.points))
+    } else {
+      # Coerce to character so NA-group rows stay eligible (folded into an explicit
+      # stratum) and empty/unused factor levels drop out on their own - a leftover
+      # level must not shrink the per-group floor.
+      g <- as.character(groups)
+      g[is.na(g)] <- ".__NA__."
+      idx <- split(seq_len(n), g)
+      sizes <- lengths(idx)
+      ng <- length(idx)
+      # cap the floor so the guaranteed minimums never exceed the total budget
+      eff_floor <- min(min.per.group, max.points %/% ng)
+      keep <- pmin(sizes, eff_floor)
+      remaining <- max(max.points - sum(keep), 0L)
+      leftover <- pmax(sizes - keep, 0L)
+      # Spread the remaining budget proportionally to the larger groups, then hand
+      # out the rounding shortfall by largest fractional remainder (Hamilton
+      # apportionment) so the total lands on max.points exactly. Each group is
+      # capped at its leftover, and total leftover always covers `remaining`
+      # (n >= max.points), so the shortfall is always placeable.
+      extra <- rep(0L, ng)
+      if(remaining > 0 && sum(leftover) > 0){
+        quota <- remaining * leftover / sum(leftover)
+        extra <- pmin(as.integer(quota), leftover)
+        short <- remaining - sum(extra)
+        while(short > 0){
+          frac <- quota - extra               # remainder; negative once a +1 lands
+          frac[extra >= leftover] <- -Inf     # group at capacity: skip
+          if(all(!is.finite(frac))) break
+          j <- which.max(frac)
+          extra[j] <- extra[j] + 1L
+          short <- short - 1L
+        }
+      }
+      target <- pmin(keep + extra, sizes)
+      out <- unlist(Map(function(ix, t) if(t >= length(ix)) ix else sample(ix, t),
+                        idx, target), use.names = FALSE)
+      sort(as.integer(out))
+    }
+  })
+}
+
 .coerce_integerish <- function(value, arg, lower = 1L, upper = .Machine$integer.max,
                                value_label = "single positive integer value"){
   tol <- sqrt(.Machine$double.eps)

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -39,6 +39,8 @@ fviz(
   ggtheme = theme_minimal(),
   ggp = NULL,
   font.family = "",
+  max.points = NULL,
+  sample.seed = 123,
   ...
 )
 }
@@ -182,6 +184,21 @@ theme_minimal(), theme_classic(), theme_void(), ....}
 \item{ggp}{a ggplot. If not NULL, points are added to an existing plot.}
 
 \item{font.family}{character vector specifying font family.}
+
+\item{max.points}{integer or NULL. When the individual / row / column cloud has
+more than \code{max.points} points, a random subset of that many \emph{points}
+is drawn so the plot stays readable (usable labels instead of an over-plotted
+cloud). Only the drawn points/labels are thinned: any ellipse
+(\code{addEllipses}) and the group mean point are still computed on the
+\strong{full} data, so a convex / confidence frame is not shrunk or inflated by
+the draw. When points are coloured/split by a group (e.g. \code{habillage}),
+the draw is \strong{stratified} so every group keeps at least a minimum number
+of points and none is decimated. A message reports how many points are shown.
+The subset is reproducible (see \code{sample.seed}) and does not change the
+caller's random stream. \code{NULL} (default) draws every point.}
+
+\item{sample.seed}{the random seed used to pick the \code{max.points} subset,
+for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.}
 
 \item{...}{Arguments to be passed to the functions ggpubr::ggscatter() & 
 ggpubr::ggpar().}

--- a/man/fviz_cluster.Rd
+++ b/man/fviz_cluster.Rd
@@ -28,6 +28,8 @@ fviz_cluster(
   outlier.pointsize = pointsize,
   outlier.labelsize = labelsize,
   ggtheme = theme_grey(),
+  max.points = NULL,
+  sample.seed = 123,
   ...
 )
 }
@@ -94,6 +96,21 @@ clustering.}
 \item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
+
+\item{max.points}{integer or NULL. When the data has more than
+\code{max.points} observations, a random subset of that many \emph{points} is
+drawn so the cluster plot stays readable instead of over-plotting. Only the
+drawn scatter/labels are thinned: the cluster frame (convex hull / ellipse)
+and centres are still computed on the \strong{full} data, so a convex hull is
+not shrunk by dropping the extreme points a random draw tends to lose. The
+draw is \strong{stratified by cluster} so every cluster keeps at least a
+minimum number of points, and a message reports how many are shown. Any
+DBSCAN/Mclust outliers are always drawn. The subset is reproducible (see
+\code{sample.seed}) and does not change the caller's random stream. \code{NULL}
+(default) draws every observation.}
+
+\item{sample.seed}{the random seed used to pick the \code{max.points} subset,
+for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.}
 
 \item{...}{other arguments to be passed to the functions
 \code{\link[ggpubr]{ggscatter}} and \code{\link[ggpubr]{ggpar}}.}

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -24,6 +24,8 @@ fviz_pca_ind(
   alpha.ind = 1,
   shape.ind = NULL,
   select.ind = list(name = NULL, cos2 = NULL, contrib = NULL),
+  max.points = NULL,
+  sample.seed = 123,
   ...
 )
 
@@ -147,6 +149,21 @@ individuals/variables to be drawn \item cos2: if cos2 is in [0, 1], ex:
 ex: 5, then the top 5 individuals/variables with the highest cos2 are
 drawn. \item contrib: if contrib > 1, ex: 5,  then the top 5
 individuals/variables with the highest contrib are drawn }}
+
+\item{max.points}{integer or NULL. When the individual / row / column cloud has
+more than \code{max.points} points, a random subset of that many \emph{points}
+is drawn so the plot stays readable (usable labels instead of an over-plotted
+cloud). Only the drawn points/labels are thinned: any ellipse
+(\code{addEllipses}) and the group mean point are still computed on the
+\strong{full} data, so a convex / confidence frame is not shrunk or inflated by
+the draw. When points are coloured/split by a group (e.g. \code{habillage}),
+the draw is \strong{stratified} so every group keeps at least a minimum number
+of points and none is decimated. A message reports how many points are shown.
+The subset is reproducible (see \code{sample.seed}) and does not change the
+caller's random stream. \code{NULL} (default) draws every point.}
+
+\item{sample.seed}{the random seed used to pick the \code{max.points} subset,
+for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.}
 
 \item{col.quanti.sup}{a color for the quantitative supplementary variables.}
 

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -422,3 +422,167 @@ test_that("fviz_mca quanti.sup overlays scaled correlation arrows; default off",
   expect_warning(p2 <- fviz_mca_ind(res2, quanti.sup = TRUE), "supplementary quantitative")
   expect_false(has_seg(p2))
 })
+
+test_that("max.points downsamples large clouds; default draws every point (no-regression)", {
+  set.seed(1)
+  X <- matrix(rnorm(600 * 4), 600, 4); rownames(X) <- paste0("o", seq_len(600))
+  res <- prcomp(X, scale. = TRUE)
+  ptdata <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomPoint"), logical(1)))[1]
+    ggplot2::layer_data(p, i)
+  }
+  npts <- function(p) nrow(ptdata(p))
+
+  # Default draws every point and is byte-identical to an explicit max.points = NULL.
+  p_def  <- fviz_pca_ind(res, geom = "point")
+  p_null <- fviz_pca_ind(res, geom = "point", max.points = NULL)
+  expect_equal(npts(p_def), 600)
+  expect_identical(ggplot2::ggplot_build(p_def)$data, ggplot2::ggplot_build(p_null)$data)
+
+  # max.points caps the drawn points (and announces it); a value >= n is a no-op.
+  expect_message(
+    expect_equal(npts(fviz_pca_ind(res, geom = "point", max.points = 100)), 100),
+    "random 100 of 600"
+  )
+  expect_equal(npts(suppressMessages(fviz_pca_ind(res, geom = "point", max.points = 10000))), 600)
+
+  # Reproducible subset and the caller's RNG stream is left untouched.
+  set.seed(99); before <- get(".Random.seed", envir = .GlobalEnv)
+  d1 <- ptdata(suppressMessages(fviz_pca_ind(res, geom = "point", max.points = 50)))
+  d2 <- ptdata(suppressMessages(fviz_pca_ind(res, geom = "point", max.points = 50)))
+  expect_equal(sort(d1$x), sort(d2$x))
+  expect_identical(get(".Random.seed", envir = .GlobalEnv), before)
+
+  # fviz_cluster gains the same argument, default unchanged.
+  set.seed(1); km <- stats::kmeans(scale(X), 3, nstart = 1)
+  expect_equal(npts(fviz_cluster(km, data = X, geom = "point", ellipse = FALSE)), 600)
+  expect_equal(npts(suppressMessages(
+    fviz_cluster(km, data = X, geom = "point", ellipse = FALSE, max.points = 120))), 120)
+})
+
+test_that("max.points sampling is stratified: small groups are preserved, not decimated", {
+  # A heavily unbalanced grouping: 3000 common + 30 rare individuals. Uniform
+  # sampling would leave the rare group with ~3 points (a meaningless ellipse);
+  # stratified sampling keeps a per-group floor so it stays representative.
+  set.seed(1)
+  X <- rbind(matrix(rnorm(3000 * 4), 3000, 4), matrix(rnorm(30 * 4, 6), 30, 4))
+  rownames(X) <- paste0("o", seq_len(nrow(X)))
+  grp <- factor(rep(c("Common", "Rare"), c(3000, 30)))
+  res <- prcomp(X, scale. = TRUE)
+
+  p <- suppressMessages(
+    fviz_pca_ind(res, geom = "point", habillage = grp, max.points = 300))
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomPoint"), logical(1)))[1]
+  d <- ggplot2::layer_data(p, i)
+  per_group <- as.integer(table(d$colour))          # two colours == two groups
+
+  expect_equal(sum(per_group), 300)                 # total lands exactly on max.points
+  expect_gte(min(per_group), 20)                    # rare group kept its floor, not ~3
+
+  # The internal sampler itself: exact total, rare group protected, reproducible.
+  g <- rep(c("A", "B"), c(3000, 30))
+  idx <- factoextra:::.sample_indices(3030, 300, groups = g)
+  expect_equal(length(idx), 300)
+  expect_gte(sum(idx > 3000), 20)
+  expect_identical(idx, factoextra:::.sample_indices(3030, 300, groups = g))
+  # ungrouped draw stays exact too
+  expect_equal(length(factoextra:::.sample_indices(600, 100)), 100)
+  # NA-group rows stay eligible (not silently dropped) and empty factor levels
+  # do not shrink the floor.
+  gna <- c(rep("A", 500), rep("B", 500), rep(NA, 40))
+  ina <- factoextra:::.sample_indices(1040, 200, groups = gna)
+  expect_equal(length(ina), 200)
+  expect_gt(sum(ina > 1000), 0)                      # NA-group rows drawn
+  gf <- factor(c(rep("A", 500), rep("B", 500), rep("C", 40)),
+               levels = c("A", "B", "C", "Dunused"))
+  expect_equal(length(factoextra:::.sample_indices(1040, 200, groups = gf)), 200)
+})
+
+test_that("max.points stratifies for every grouping form (habillage, col.ind, FactoMineR)", {
+  # Regression: stratification must fire whatever the grouping column is named
+  # (vector habillage -> 'Groups', FactoMineR named habillage -> the quali name,
+  # col.ind = factor -> 'Col.'), not only when a literal 'Groups' column exists.
+  set.seed(1)
+  X <- rbind(matrix(rnorm(900 * 4), 900, 4), matrix(rnorm(20 * 4, 6), 20, 4))
+  rownames(X) <- paste0("o", seq_len(920))
+  grp <- factor(rep(c("Common", "Rare"), c(900, 20)))
+  res <- prcomp(X, scale. = TRUE)
+  rare_kept <- function(p) {
+    i <- which(vapply(p$layers, function(l)
+      inherits(l$geom, "GeomPoint") && inherits(l$stat, "StatIdentity"), logical(1)))[1]
+    min(as.integer(table(ggplot2::layer_data(p, i)$colour)))
+  }
+  # vector habillage and col.ind = factor
+  expect_gte(rare_kept(suppressMessages(
+    fviz_pca_ind(res, habillage = grp, geom = "point", max.points = 200))), 20)
+  expect_gte(rare_kept(suppressMessages(
+    fviz_pca_ind(res, col.ind = grp, geom = "point", max.points = 200))), 20)
+
+  # FactoMineR named-column habillage
+  skip_if_not_installed("FactoMineR")
+  pc <- FactoMineR::PCA(cbind.data.frame(X, Grp = grp), quali.sup = 5, graph = FALSE)
+  expect_gte(rare_kept(suppressMessages(
+    fviz_pca_ind(pc, habillage = "Grp", geom = "point", max.points = 200))), 20)
+})
+
+test_that("fviz_cluster max.points keeps the cluster frame faithful (hull not shrunk)", {
+  set.seed(1)
+  X <- matrix(rnorm(1500 * 4), 1500, 4)
+  km <- stats::kmeans(scale(X), 4, nstart = 5)
+  hull_areas <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    li <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomPolygon"), logical(1)))[1]
+    d <- b$data[[li]]
+    sort(round(as.numeric(tapply(seq_len(nrow(d)), d$group, function(ix) {
+      x <- d$x[ix]; y <- d$y[ix]
+      abs(sum(x * c(y[-1], y[1]) - c(x[-1], x[1]) * y)) / 2
+    })), 3))
+  }
+  npts <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    li <- which(vapply(p$layers, function(l)
+      inherits(l$geom, "GeomPoint") && inherits(l$stat, "StatIdentity"), logical(1)))[1]
+    nrow(b$data[[li]])
+  }
+  p_full <- suppressMessages(fviz_cluster(km, data = X, geom = "point", ellipse.type = "convex"))
+  p_samp <- suppressMessages(fviz_cluster(km, data = X, geom = "point",
+                                          ellipse.type = "convex", max.points = 200))
+  # Convex hull is computed on the full data -> byte-identical to the un-sampled
+  # frame, even though only 200 points are drawn (a naive subset would shrink it).
+  expect_identical(hull_areas(p_samp), hull_areas(p_full))
+  expect_equal(npts(p_samp), 200)
+})
+
+test_that("fviz_pca_ind max.points keeps addEllipses frames faithful (convex/confidence)", {
+  # The fviz() scatter path also draws ellipses; a naive subset would shrink a
+  # convex hull (~ -40%) and inflate a confidence ellipse (~ +900%, it scales
+  # 1/sqrt(n)). Only the drawn points are thinned; the frame stays on full data.
+  set.seed(1)
+  X <- rbind(matrix(rnorm(1500 * 4), 1500, 4), matrix(rnorm(30 * 4, 6), 30, 4))
+  rownames(X) <- paste0("o", seq_len(1530))
+  grp <- factor(rep(c("A", "B"), c(1500, 30)))
+  res <- prcomp(X, scale. = TRUE)
+  poly_areas <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    li <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomPolygon"), logical(1)))[1]
+    d <- b$data[[li]]
+    sort(round(as.numeric(tapply(seq_len(nrow(d)), d$group, function(ix) {
+      x <- d$x[ix]; y <- d$y[ix]
+      abs(sum(x * c(y[-1], y[1]) - c(x[-1], x[1]) * y)) / 2
+    })), 3))
+  }
+  npts <- function(p) {
+    b <- ggplot2::ggplot_build(p)
+    li <- which(vapply(p$layers, function(l)
+      inherits(l$geom, "GeomPoint") && inherits(l$stat, "StatIdentity"), logical(1)))[1]
+    nrow(b$data[[li]])
+  }
+  for (et in c("convex", "confidence", "norm", "t")) {
+    pf <- suppressMessages(fviz_pca_ind(res, habillage = grp, addEllipses = TRUE,
+                                        ellipse.type = et, geom = "point"))
+    ps <- suppressMessages(fviz_pca_ind(res, habillage = grp, addEllipses = TRUE,
+                                        ellipse.type = et, geom = "point", max.points = 200))
+    expect_identical(poly_areas(ps), poly_areas(pf))   # frame on full data
+    expect_equal(npts(ps), 200)                        # points thinned
+  }
+})


### PR DESCRIPTION
## Summary

Large datasets over-plot the individual / row / column scatter and cluster plots
into a solid blob — labels, colours and ellipses become unreadable. This adds an
opt-in `max.points` (with `sample.seed`) to `fviz_pca_ind()` and the `fviz()`
family, and to `fviz_cluster()`. When the cloud has more than `max.points`
points, a reproducible random subset of that many is drawn.

`max.points = NULL` (default) draws every point, so **existing calls are
byte-identical** (verified against `origin/master`).

### Only the points are thinned — the frame stays honest

A convex hull is defined by its extreme points, exactly the ones a random draw is
most likely to drop; a confidence ellipse scales ~1/√n. So the draw thins **only
the drawn points/labels**: any ellipse (`addEllipses` / the cluster frame) and the
group/cluster centres are computed on the **full** data. Hull and ellipse areas
are byte-identical between the full and sampled plots.

### Grouped draws are stratified

When points are grouped (`habillage`, `col.ind` factor, or clusters) the draw is
stratified with a per-group floor, so a small group is not decimated to a
handful of points (which would give a misleading ellipse); the total lands
exactly on `max.points`. The draw is RNG-safe (it does not disturb the caller's
random stream) and a message reports how many points are shown.

## Example

```r
library(factoextra)

# 8000 individuals: over-plotted vs a readable random subset
set.seed(42)
X <- matrix(rnorm(8000 * 4), 8000, 4); rownames(X) <- paste0("o", 1:8000)
res <- prcomp(X, scale. = TRUE)

fviz_pca_ind(res, geom = "point", col.ind = "cos2")                 # all 8000
fviz_pca_ind(res, geom = "point", col.ind = "cos2", max.points = 800)  # subset
```

![density before/after](https://i.imgur.com/VNMMg6k.png)

```r
# Cluster plot: the convex hull stays on the full data while points are thinned
set.seed(1)
Y <- matrix(rnorm(2000 * 4), 2000, 4)
km <- kmeans(scale(Y), 4, nstart = 5)

fviz_cluster(km, data = Y, geom = "point", ellipse.type = "convex")
fviz_cluster(km, data = Y, geom = "point", ellipse.type = "convex", max.points = 250)
#> Showing a random 250 of 2000 clustered points; set max.points = NULL to show all.
```

![cluster hull faithful](https://i.imgur.com/USzVwI4.png)

The right panel draws only 250 points, yet the four convex hulls overlay the
full-data hulls exactly — the cluster extent is not understated.

## Notes

- New argument defaults to `NULL` (current behaviour); the sampling code path does
  not fire for existing inputs.
- Stratified sampling uses a per-group floor with largest-remainder apportionment
  so the total is exact and small groups keep a representative count.
- Tests added: default byte-identity, exact-count capping, RNG-safety,
  reproducibility, stratification across grouping forms (vector/`col.ind`/named
  habillage), NA-group preservation, and full-data-frame fidelity for
  convex/confidence ellipses in both `fviz_pca_ind()` and `fviz_cluster()`.
