### PR TITLE
Pin continuous colour/fill/size mapping to full range under max.points

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,10 @@
   points are thinned: any ellipse (`addEllipses` / the cluster frame) and the
   group/cluster centres are still computed on the full data, so a convex hull or
   confidence ellipse is not distorted by dropping the extreme points a random
-  draw tends to lose. The draw does not disturb the caller's random stream.
+  draw tends to lose. A continuous colour, fill or size mapping (e.g. `col.ind =
+  "cos2"`) and its legend are likewise pinned to the full-data range, so a
+  point's colour, fill and size do not depend on how many points are drawn. The
+  draw does not disturb the caller's random stream.
   `max.points = NULL` (default) draws every point, and `sample.seed` controls
   which subset is chosen.
 * `fviz_mca_ind()` and `fviz_mca_biplot()` gain a `quanti.sup` argument. Set

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -106,9 +106,13 @@ NULL
 #'  \strong{full} data, so a convex / confidence frame is not shrunk or inflated by
 #'  the draw. When points are coloured/split by a group (e.g. \code{habillage}),
 #'  the draw is \strong{stratified} so every group keeps at least a minimum number
-#'  of points and none is decimated. A message reports how many points are shown.
-#'  The subset is reproducible (see \code{sample.seed}) and does not change the
-#'  caller's random stream. \code{NULL} (default) draws every point.
+#'  of points and none is decimated. When colour, fill or size is mapped to a
+#'  continuous metric (e.g. \code{col.ind = "cos2"}), its scale and legend are
+#'  pinned to the full-data range, so a point's colour, fill and size do not depend
+#'  on how many points are drawn. A message reports how many points are shown. The
+#'  subset is reproducible
+#'  (see \code{sample.seed}) and does not change the caller's random stream.
+#'  \code{NULL} (default) draws every point.
 #'@param sample.seed the random seed used to pick the \code{max.points} subset,
 #'  for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.
 #'@inheritParams ggpubr::ggpar
@@ -389,8 +393,24 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
 
   if(!is.null(gradient.cols))
     p <- p + ggpubr::gradient_color(gradient.cols)
-    
-    
+
+  # When max.points has thinned the drawn points (sampled_idx set), pin every
+  # continuous aesthetic (colour / fill / size) to the full-data range, so its
+  # scale and legend do not retrain on the drawn subset and a point's colour, fill
+  # and size do not depend on how many points were drawn. expand_limits only widens
+  # the existing scale (subset range is a subset of the full range), so a custom
+  # gradient.cols palette is preserved. Uses `df` (the post-select, post-CA-scale,
+  # still un-thinned set that would be plotted at max.points = NULL) so the range
+  # matches the non-sampled plot exactly under select.ind / a rescaled CA map --
+  # the layer-swap above thins only the drawn layers' data, never `df` itself.
+  # Gated on the sampling path and on a continuous mapping, so default plots and
+  # discrete / fixed aesthetics are byte-identical.
+  if(!is.null(sampled_idx)){
+    p <- .pin_full_range(p, "colour", color, df)
+    p <- .pin_full_range(p, "fill", fill, df)
+    p <- .pin_full_range(p, "size", pointsize, df)
+  }
+
   if(is.null(extra_args$legend)) p <- p + theme(legend.position = "right" )
   # Add arrows
   if("arrow" %in% geom && !hide[[element]])
@@ -451,6 +471,21 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
 # Helper functions
 #+++++++++++++++++++++
 
+
+# Pin a continuous aesthetic (colour / fill / size) to the full-data range so a
+# max.points subsample does not retrain its scale/legend on the drawn subset.
+# `var` is the mapped column name (or a fixed value like "black"/1.5); the pin
+# only applies when it names a numeric column of `data`. expand_limits() widens
+# the existing scale without replacing the palette.
+.pin_full_range <- function(p, aes, var, data){
+  if(is.character(var) && length(var) == 1L && var %in% names(data) &&
+     is.numeric(data[[var]])){
+    lim <- suppressWarnings(range(data[[var]], na.rm = TRUE))
+    if(all(is.finite(lim)))   # skip an all-NA metric (range -> c(Inf, -Inf))
+      p <- p + do.call(expand_limits, stats::setNames(list(lim), aes))
+  }
+  p
+}
 
 # Check if fill/color variable is continous in the context of PCA
 .is_continuous_var <- function(x){

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -193,9 +193,13 @@ cloud). Only the drawn points/labels are thinned: any ellipse
 \strong{full} data, so a convex / confidence frame is not shrunk or inflated by
 the draw. When points are coloured/split by a group (e.g. \code{habillage}),
 the draw is \strong{stratified} so every group keeps at least a minimum number
-of points and none is decimated. A message reports how many points are shown.
-The subset is reproducible (see \code{sample.seed}) and does not change the
-caller's random stream. \code{NULL} (default) draws every point.}
+of points and none is decimated. When colour, fill or size is mapped to a
+continuous metric (e.g. \code{col.ind = "cos2"}), its scale and legend are
+pinned to the full-data range, so a point's colour, fill and size do not depend
+on how many points are drawn. A message reports how many points are shown. The
+subset is reproducible
+(see \code{sample.seed}) and does not change the caller's random stream.
+\code{NULL} (default) draws every point.}
 
 \item{sample.seed}{the random seed used to pick the \code{max.points} subset,
 for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.}

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -158,9 +158,13 @@ cloud). Only the drawn points/labels are thinned: any ellipse
 \strong{full} data, so a convex / confidence frame is not shrunk or inflated by
 the draw. When points are coloured/split by a group (e.g. \code{habillage}),
 the draw is \strong{stratified} so every group keeps at least a minimum number
-of points and none is decimated. A message reports how many points are shown.
-The subset is reproducible (see \code{sample.seed}) and does not change the
-caller's random stream. \code{NULL} (default) draws every point.}
+of points and none is decimated. When colour, fill or size is mapped to a
+continuous metric (e.g. \code{col.ind = "cos2"}), its scale and legend are
+pinned to the full-data range, so a point's colour, fill and size do not depend
+on how many points are drawn. A message reports how many points are shown. The
+subset is reproducible
+(see \code{sample.seed}) and does not change the caller's random stream.
+\code{NULL} (default) draws every point.}
 
 \item{sample.seed}{the random seed used to pick the \code{max.points} subset,
 for a reproducible figure. Ignored when \code{max.points} is \code{NULL}.}

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -586,3 +586,49 @@ test_that("fviz_pca_ind max.points keeps addEllipses frames faithful (convex/con
     expect_equal(npts(ps), 200)                        # points thinned
   }
 })
+
+test_that("max.points pins a continuous colour/fill gradient to the full-data range", {
+  # A subset would otherwise retrain the gradient (and legend) on its own range,
+  # so a point's colour would depend on max.points. The scale is pinned to the
+  # full data instead. Only fires on the sampling path and for continuous mapping.
+  set.seed(42)
+  X <- matrix(rnorm(4000 * 4), 4000, 4); rownames(X) <- paste0("o", seq_len(4000))
+  res <- prcomp(X, scale. = TRUE)
+  crange <- function(p, aes = "colour") {
+    sc <- ggplot2::ggplot_build(p)$plot$scales$get_scales(aes)
+    if (is.null(sc)) return(NA_real_)
+    range(sc$range$range, na.rm = TRUE)
+  }
+  # colour: sampled range == full range (pinned)
+  cf <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", col.ind = "cos2")))
+  cs <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", col.ind = "cos2", max.points = 400)))
+  expect_equal(cs, cf)
+  # holds with a custom gradient.cols palette too
+  csg <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", col.ind = "cos2",
+                                              max.points = 400, gradient.cols = c("blue", "red"))))
+  expect_equal(csg, cf)
+  # fill: sampled range == full range (pinned)
+  ff <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", fill.ind = "contrib",
+                                             pointshape = 21)), "fill")
+  fs <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", fill.ind = "contrib",
+                                             pointshape = 21, max.points = 400)), "fill")
+  expect_equal(fs, ff)
+  # size mapped to a metric: sampled range == full range (pinned)
+  sf <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", pointsize = "cos2")), "size")
+  ss <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", pointsize = "cos2",
+                                             max.points = 400)), "size")
+  expect_equal(ss, sf)
+  # discrete colouring is untouched: still a discrete scale, points thinned, no error
+  grp <- factor(rep(letters[1:4], 1000))
+  pg <- suppressMessages(fviz_pca_ind(res, geom = "point", habillage = grp, max.points = 400))
+  sc <- ggplot2::ggplot_build(pg)$plot$scales$get_scales("colour")
+  expect_true(sc$is_discrete())
+
+  # select.ind: the pin matches the NON-sampled selected plot (the selected range),
+  # not the pre-select full range -- so a selected point's colour is stable.
+  ref  <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", col.ind = "cos2",
+                                               select.ind = list(cos2 = 0.5))))
+  samp <- crange(suppressMessages(fviz_pca_ind(res, geom = "point", col.ind = "cos2",
+                                               select.ind = list(cos2 = 0.5), max.points = 400)))
+  expect_equal(samp, ref)
+})


### PR DESCRIPTION
Closes #258.

## Summary

When `max.points` subsamples a large plot and colour / fill / size is mapped to a
continuous metric (e.g. `col.ind = "cos2"`), the scale and its legend would train
on the **drawn subset's** range rather than the full data. So a point's colour
(and the legend endpoints) depended on how many points were drawn — the same
low-metric point could render bright or dark depending on `max.points`.

This pins each continuous aesthetic (colour, fill, size) to the **full-data
range**, mirroring the existing `alpha` pin, so the encoding is stable regardless
of the draw size. It uses `expand_limits`, which widens the existing scale
**without replacing the palette**, so a custom `gradient.cols` is preserved.

## Example

```r
library(factoextra)
set.seed(7)
X <- matrix(rnorm(3000 * 4), 3000, 4); rownames(X) <- paste0("o", 1:3000)
res <- prcomp(X, scale. = TRUE)
# a metric whose rare high values fall on points the subsample drops
metric <- runif(3000, 0, 3); metric[sample(3000, 20)] <- runif(20, 90, 100)

fviz_pca_ind(res, geom = "point", col.ind = metric, max.points = 400)
```

Before (gradient retrains on the subset) vs after (pinned to the full data):

![before/after](https://i.imgur.com/FgfBGDy.png)

In *before*, the legend collapses to the subset's range and low-metric points are
remapped across the whole ramp; in *after*, the legend spans the full-data range
and each point's colour reflects its true value.

## Notes

- Fires only on the `max.points` sampling path and only for a **continuous**
  mapping, so plots without `max.points` and plots with discrete/fixed aesthetics
  are **byte-identical** (verified via `ggplot_build()` across ind/biplot/CA/MCA/
  var/cluster, including a size-mapped plot).
- The full range is taken from the post-select, post-CA-scale data, so it matches
  the non-sampled plot exactly under `select.ind` or a rescaled CA `map`.
- Tests added: colour/fill/size pinned to full range (incl. custom `gradient.cols`),
  discrete colouring untouched, and `select.ind` consistency.
- Depends on `max.points` (#257, merged); `max.points` is unreleased dev, so this
  completes the feature before CRAN. NEWS folded into the existing `max.points`
  entry.
