### PR TITLE
Add highlight argument to fviz_dend()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## New features
 
+* `fviz_dend()` gains a `highlight` argument to emphasize the branches leading to
+  specific leaves (with `highlight.col` / `highlight.lwd`); it layers on top of
+  the cluster colouring, so highlighted branches stand out while every other
+  branch keeps its colour. `highlight = NULL` (default) is unchanged. For other
+  branch styling (e.g. dashed branches) pass a pre-styled `dendextend` object,
+  which `fviz_dend()` honours (see `?fviz_dend`).
+
 * New `fviz_umap()` and `fviz_tsne()` to visualize a 2-D UMAP or t-SNE embedding
   (from `uwot`, `Rtsne`, `umap`, or a plain coordinate matrix) with factoextra's
   grouping, ellipse and palette styling, including colouring points by a

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -31,6 +31,15 @@
 #'   type = "phylogenic".
 #' @param lwd a numeric value specifying dendrogram branch and rectangle line
 #'   width.
+#' @param highlight an optional character vector of leaf labels; the branches
+#'   leading to those leaves are emphasized (thicker, and coloured
+#'   \code{highlight.col}) while every other branch keeps its colour and width.
+#'   \code{NULL} (default) highlights nothing. Has no effect for
+#'   \code{type = "phylogenic"} (that layout does not colour branch segments).
+#' @param highlight.col colour (name or hex) for the highlighted branches.
+#' @param highlight.lwd line width for the highlighted branches. \code{NULL}
+#'   (default) uses \code{2 * lwd} so the emphasis stands out by thickness
+#'   regardless of colour; set \code{highlight.lwd = lwd} for colour-only emphasis.
 #' @param type type of plot. Allowed values are one of "rectangle",
 #'   "circular", "phylogenic".
 #' @param phylo_layout the layout to be used for phylogenic trees. Default value
@@ -58,10 +67,19 @@
 #'   theme_gray(), theme_bw(), theme_minimal(), theme_classic(), theme_void(), 
 #'   ....
 #' @param ... other arguments to be passed to the function plot.dendrogram()
-#' @return an object of class fviz_dend which is a ggplot with the attributes 
-#'   "dendrogram" accessible using attr(x, "dendrogram"), where x is the result 
+#' @return an object of class fviz_dend which is a ggplot with the attributes
+#'   "dendrogram" accessible using attr(x, "dendrogram"), where x is the result
 #'   of fviz_dend().
-#' @examples 
+#' @details For branch styling beyond \code{highlight} - for example dashed
+#'   branches or per-branch colours - pre-style a \code{dendextend} dendrogram and
+#'   pass it to \code{fviz_dend()}, which honours its \code{set()} aesthetics:
+#'   \preformatted{
+#'   library(dendextend)
+#'   dend <- as.dendrogram(hclust(dist(scale(USArrests))))
+#'   dend <- set(dend, "branches_lty", 2)   # dashed branches
+#'   fviz_dend(dend)
+#'   }
+#' @examples
 #' \donttest{
 #' # Load and scale the data
 #' data(USArrests)
@@ -111,6 +129,7 @@
 fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  show_labels = TRUE, color_labels_by_k = TRUE,
                       match_coord_colors = FALSE,
                       label_cols = NULL, labels_font = "plain", labels_track_height = NULL, repel = FALSE, lwd = 0.7,
+                      highlight = NULL, highlight.col = "red", highlight.lwd = NULL,
                       type = c("rectangle",  "circular", "phylogenic"),
                       phylo_layout = "layout.auto",
                       rect = FALSE, rect_border = "gray", rect_lty = 2, rect_fill = FALSE, lower_rect,
@@ -182,9 +201,32 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
   }
   
   if(!is.null(label_cols)){
-    dend <- dendextend::set(dend, "labels_col", label_cols) 
+    dend <- dendextend::set(dend, "labels_col", label_cols)
   }
-  
+
+  # Emphasize the branches leading to specific leaves. Applied AFTER the k /
+  # label colouring so it layers on top: highlighted branches take
+  # `highlight.col` (and optionally `highlight.lwd`), every other branch keeps
+  # its existing colour/width (the Inf sentinel). highlight = NULL (default)
+  # leaves the dendrogram untouched, so existing plots are unchanged. (#P2.3)
+  if(!is.null(highlight)){
+    bad <- setdiff(highlight, labels(dend))
+    if(length(bad))
+      stop("`highlight` contains labels not in the dendrogram: ",
+           paste(bad, collapse = ", "), ".", call. = FALSE)
+    if(phylogenic)
+      warning("`highlight` has no effect for type = \"phylogenic\": that layout ",
+              "does not colour branch segments.", call. = FALSE)
+    dend <- dendextend::set(dend, "by_labels_branches_col", value = highlight,
+                            TF_values = c(highlight.col, Inf))
+    # Emphasize by THICKNESS by default (2x lwd): thickness always stands out,
+    # even when highlight.col happens to match a nearby cluster colour. Pass
+    # highlight.lwd = lwd for colour-only emphasis.
+    h_lwd <- if(is.null(highlight.lwd)) 2 * lwd else highlight.lwd
+    dend <- dendextend::set(dend, "by_labels_branches_lwd", value = highlight,
+                            TF_values = c(h_lwd, Inf))
+  }
+
   leaflab <- ifelse(show_labels, "perpendicular", "none")
   
   if(xlab =="") xlab <- NULL

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -18,6 +18,9 @@ fviz_dend(
   labels_track_height = NULL,
   repel = FALSE,
   lwd = 0.7,
+  highlight = NULL,
+  highlight.col = "red",
+  highlight.lwd = NULL,
   type = c("rectangle", "circular", "phylogenic"),
   phylo_layout = "layout.auto",
   rect = FALSE,
@@ -76,6 +79,18 @@ type = "phylogenic".}
 \item{lwd}{a numeric value specifying dendrogram branch and rectangle line
 width.}
 
+\item{highlight}{an optional character vector of leaf labels; the branches
+leading to those leaves are emphasized (thicker, and coloured
+\code{highlight.col}) while every other branch keeps its colour and width.
+\code{NULL} (default) highlights nothing. Has no effect for
+\code{type = "phylogenic"} (that layout does not colour branch segments).}
+
+\item{highlight.col}{colour (name or hex) for the highlighted branches.}
+
+\item{highlight.lwd}{line width for the highlighted branches. \code{NULL}
+(default) uses \code{2 * lwd} so the emphasis stands out by thickness
+regardless of colour; set \code{highlight.lwd = lwd} for colour-only emphasis.}
+
 \item{type}{type of plot. Allowed values are one of "rectangle",
 "circular", "phylogenic".}
 
@@ -116,14 +131,25 @@ theme_gray(), theme_bw(), theme_minimal(), theme_classic(), theme_void(),
 \item{...}{other arguments to be passed to the function plot.dendrogram()}
 }
 \value{
-an object of class fviz_dend which is a ggplot with the attributes 
-  "dendrogram" accessible using attr(x, "dendrogram"), where x is the result 
+an object of class fviz_dend which is a ggplot with the attributes
+  "dendrogram" accessible using attr(x, "dendrogram"), where x is the result
   of fviz_dend().
 }
 \description{
 Draws easily beautiful dendrograms using either R base plot or 
   ggplot2. Provides also an option for drawing a circular dendrogram and 
   phylogenic trees.
+}
+\details{
+For branch styling beyond \code{highlight} - for example dashed
+  branches or per-branch colours - pre-style a \code{dendextend} dendrogram and
+  pass it to \code{fviz_dend()}, which honours its \code{set()} aesthetics:
+  \preformatted{
+  library(dendextend)
+  dend <- as.dendrogram(hclust(dist(scale(USArrests))))
+  dend <- set(dend, "branches_lty", 2)   # dashed branches
+  fviz_dend(dend)
+  }
 }
 \examples{
 \donttest{

--- a/tests/testthat/test-fviz-dend-highlight.R
+++ b/tests/testthat/test-fviz-dend-highlight.R
@@ -1,0 +1,47 @@
+seg_data <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomSegment"), logical(1)))[1]
+  b$data[[i]]
+}
+
+test_that("fviz_dend(highlight=) emphasizes the chosen branches, layering on k colours", {
+  hc <- hclust(dist(scale(USArrests)))
+  labs <- labels(as.dendrogram(hc))
+
+  p <- fviz_dend(hc, k = 4, highlight = labs[1:4], highlight.col = "red")
+  cols <- seg_data(p)$colour
+  # the highlight colour is drawn ...
+  expect_true("red" %in% cols)
+  # ... and the k cluster colours are still present (highlight layered on top)
+  expect_gt(length(setdiff(unique(cols), c("red", "black"))), 1L)
+
+  # by default the highlighted branches are thickened (2 * lwd) so emphasis
+  # holds even if highlight.col collides with a cluster colour
+  pd <- fviz_dend(hc, k = 4, highlight = labs[1:4], lwd = 0.7)
+  expect_true(any(seg_data(pd)$linewidth == 1.4))
+  # an explicit highlight.lwd is honoured
+  p2 <- fviz_dend(hc, k = 4, highlight = labs[1:4], highlight.lwd = 3)
+  expect_true(any(seg_data(p2)$linewidth == 3))
+  # colour-only emphasis when highlight.lwd = lwd
+  p3 <- fviz_dend(hc, k = 4, highlight = labs[1:4], lwd = 0.7, highlight.lwd = 0.7)
+  expect_setequal(unique(seg_data(p3)$linewidth), 0.7)
+})
+
+test_that("fviz_dend(highlight=) warns for type = 'phylogenic' (branches not coloured)", {
+  hc <- hclust(dist(scale(USArrests)))
+  expect_warning(fviz_dend(hc, highlight = labels(as.dendrogram(hc))[1:3],
+                           type = "phylogenic"), "phylogenic")
+})
+
+test_that("fviz_dend(highlight=NULL) is byte-identical to no highlight (no regression)", {
+  hc <- hclust(dist(scale(USArrests)))
+  a <- ggplot2::ggplot_build(fviz_dend(hc, k = 3))
+  b <- ggplot2::ggplot_build(fviz_dend(hc, k = 3, highlight = NULL))
+  expect_identical(a$data, b$data)
+})
+
+test_that("fviz_dend(highlight=) errors on labels not in the dendrogram", {
+  hc <- hclust(dist(scale(USArrests)))
+  expect_error(fviz_dend(hc, highlight = c("Alabama", "NotAState")),
+               "not in the dendrogram")
+})


### PR DESCRIPTION
## Summary

`fviz_dend()` gains a `highlight` argument to emphasize the branches leading to
specific leaves - a common need when pointing out particular samples in a cluster
tree.

```r
hc <- hclust(dist(scale(USArrests)))
fviz_dend(hc, k = 4, highlight = c("California", "Texas", "New York", "Florida"))
```

![dendrogram with highlighted branches](https://raw.githubusercontent.com/kassambara/factoextra/pr-figures/p23_highlight.png)

The highlighted branches are drawn thicker and in `highlight.col` (default red),
layered on top of the cluster colouring so every other branch keeps its colour.
Emphasis is by thickness by default (`highlight.lwd = 2 * lwd`), so it stands out
even when `highlight.col` happens to match a nearby cluster colour; pass
`highlight.lwd = lwd` for colour-only emphasis.

## Notes

- `highlight = NULL` (default) leaves the dendrogram untouched - existing plots are
  **byte-identical** (verified against `origin/master` across rectangle / circular /
  phylogenic / horizontal / k / rect / hcut / hkmeans / agnes configs).
- `highlight` has no effect for `type = "phylogenic"` (that layout does not colour
  branch segments) and warns if used there.
- For other branch styling (dashed branches, per-branch colours) the docs point to
  pre-styling a `dendextend` object, whose `set()` aesthetics `fviz_dend()` already
  honours - so no redundant arguments were added for those.
- Tests cover the emphasis (colour + default thickness), the colour-only mode, the
  no-regression `NULL` default, the bad-label error, and the phylogenic warning.
