### PR TITLE
Document comparing two dendrograms (tanglegram) in ?fviz_dend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,9 @@
 * `fviz_dend()`: corrected the documentation of the `type` argument, which listed
   a `"triangle"` value that the function does not accept (the valid values are
   `"rectangle"`, `"circular"` and `"phylogenic"`). Thanks to @Nelson-Gon (#144).
+* `?fviz_dend` now documents how to compare two dendrograms (a tanglegram) with
+  `dendextend::tanglegram()` / `untangle()` / `entanglement()`, which factoextra
+  already depends on.
 
 # factoextra 2.1.0
 

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -79,6 +79,24 @@
 #'   dend <- set(dend, "branches_lty", 2)   # dashed branches
 #'   fviz_dend(dend)
 #'   }
+#'
+#'   \strong{Comparing two dendrograms.} To compare two hierarchical clusterings of
+#'   the same observations (e.g. different linkages), draw a \emph{tanglegram} with
+#'   \code{dendextend} (already a dependency): the two trees face each other, matched
+#'   leaves are connected, and \code{entanglement()} measures agreement (0 = perfect,
+#'   1 = worst). This uses base graphics.
+#'   \preformatted{
+#'   library(dendextend)
+#'   d1 <- as.dendrogram(hclust(dist(scale(USArrests)), "complete"))
+#'   d2 <- as.dendrogram(hclust(dist(scale(USArrests)), "average"))
+#'   dl <- dendlist(d1, d2)
+#'   dl <- untangle(dl, method = "step2side")        # reduce crossings
+#'   tanglegram(dl, common_subtrees_color_branches = TRUE)
+#'   entanglement(dl)                                 # agreement, in [0, 1]
+#'   }
+#'   Both dendrograms must share the same leaf labels.
+#' @seealso \code{\link[dendextend]{tanglegram}}, \code{\link[dendextend]{entanglement}}
+#'   for comparing two dendrograms (see \strong{Details}).
 #' @examples
 #' \donttest{
 #' # Load and scale the data

--- a/man/fviz_dend.Rd
+++ b/man/fviz_dend.Rd
@@ -150,6 +150,22 @@ For branch styling beyond \code{highlight} - for example dashed
   dend <- set(dend, "branches_lty", 2)   # dashed branches
   fviz_dend(dend)
   }
+
+  \strong{Comparing two dendrograms.} To compare two hierarchical clusterings of
+  the same observations (e.g. different linkages), draw a \emph{tanglegram} with
+  \code{dendextend} (already a dependency): the two trees face each other, matched
+  leaves are connected, and \code{entanglement()} measures agreement (0 = perfect,
+  1 = worst). This uses base graphics.
+  \preformatted{
+  library(dendextend)
+  d1 <- as.dendrogram(hclust(dist(scale(USArrests)), "complete"))
+  d2 <- as.dendrogram(hclust(dist(scale(USArrests)), "average"))
+  dl <- dendlist(d1, d2)
+  dl <- untangle(dl, method = "step2side")        # reduce crossings
+  tanglegram(dl, common_subtrees_color_branches = TRUE)
+  entanglement(dl)                                 # agreement, in [0, 1]
+  }
+  Both dendrograms must share the same leaf labels.
 }
 \examples{
 \donttest{
@@ -197,4 +213,8 @@ fviz_dend(res.hc, k = 4,
  }
 
 }
+}
+\seealso{
+\code{\link[dendextend]{tanglegram}}, \code{\link[dendextend]{entanglement}}
+  for comparing two dendrograms (see \strong{Details}).
 }


### PR DESCRIPTION
Documentation-only. Adds a "Comparing two dendrograms" `@details` section + `@seealso` to `?fviz_dend` showing the `dendextend::tanglegram()` / `untangle()` / `entanglement()` recipe (dendextend is already an Import, so no new dependency).

No new function is added: a themed ggplot `fviz_dend_compare()` would be *less* capable than dendextend's 43-argument `tanglegram()` while re-implementing a dependency's signature feature — gold-plating at low demand. The recipe was verified to run (entanglement matches `dendextend::entanglement()`).

No code change; existing behavior byte-identical.