### PR TITLE
Consolidation: refresh README, pkgdown reference, and embedding docs

### DIFF
--- a/R/fviz_umap.R
+++ b/R/fviz_umap.R
@@ -61,9 +61,16 @@ NULL
 #' trustworthy}, but the \strong{size} of a cluster, the \strong{distance} between
 #' well-separated clusters and the amount of empty space between them are not
 #' quantitatively meaningful and change with the method's \code{perplexity} /
-#' \code{n_neighbors} settings - read groupings, not geometry. Similar embedding
-#' scatter plots are drawn by \code{Seurat::DimPlot()} / \code{FeaturePlot()} and
-#' \code{ggpca}.
+#' \code{n_neighbors} settings (Wattenberg et al., 2016) - read groupings, not
+#' geometry. Similar embedding scatter plots are drawn by \code{Seurat::DimPlot()}
+#' / \code{FeaturePlot()} and \code{ggpca}.
+#'
+#' @references
+#' McInnes, L., Healy, J. and Melville, J. (2018). UMAP: Uniform Manifold
+#' Approximation and Projection for Dimension Reduction. \emph{arXiv:1802.03426}.
+#'
+#' Wattenberg, M., \enc{Viégas}{Viegas}, F. and Johnson, I. (2016). How to Use
+#' t-SNE Effectively. \emph{Distill}. \doi{10.23915/distill.00002}.
 #'
 #' @seealso \code{\link{fviz_pca}}, \code{\link{as_factoextra_pca}},
 #'   \code{\link{fviz_cluster}}.

--- a/README.Rmd
+++ b/README.Rmd
@@ -136,36 +136,36 @@ The current maintenance baseline targets:
 library("factoextra")
 ```
 
-## Recent maintenance highlights
+## What's new in the development version
 
-The current development version includes:
-
-- helper-level `k = 1` handling for clustering diagnostics such as `fviz_nbclust(..., method = "wss")` and hierarchical `eclust()` auto-selection
-- silhouette diagnostics now omit the undefined `k = 1` point and keep the optimal-k guide aligned with the displayed cluster count
-- stricter validation for scaled clustering data and non-finite distance objects
-- clearer MCA `quanti.sup`, `axes`, `ncp`, and `parallel.iter` validation paths, including integer-like numeric support for `fviz_eig()`
-- refreshed examples and manuals for the updated clustering and validation workflows
+- **tidymodels on-ramp**: a PCA fitted in a `recipes` recipe (`step_pca()`) or a fitted `workflow` plots directly with the `fviz_pca_*` family via `as_factoextra_pca()` (honest scree, real variable-component correlations)
+- **UMAP / t-SNE**: `fviz_umap()` and `fviz_tsne()` visualize a 2-D embedding (from `uwot`, `Rtsne`, `umap`, or a coordinate matrix), including colouring by a continuous feature value; axes carry no percentage and there is no scree/loadings surface (embeddings have no eigenvalues)
+- **Themes and palettes**: `theme_factoextra()` (a clean publication theme) and `factoextra_palette("okabe")` (the Okabe-Ito colorblind-safe palette), both explicit and stateless
+- **Large datasets**: a `max.points` argument on the individual/cluster plots draws a readable subset while keeping ellipses/centres on the full data
+- **`display = "heatmap"`** for `fviz_cos2()` / `fviz_contrib()` reads the quality/contribution across several dimensions at once
+- **`fviz_dend(highlight = ...)`** emphasizes the branches leading to specific leaves
+- **`fviz_mca_ind(..., quanti.sup = TRUE)`** overlays supplementary quantitative variables on an MCA map
 
 ```{r, eval = FALSE}
-data(iris)
-iris.scaled <- scale(iris[, -5])
-res.pca <- prcomp(iris[, -5], scale = TRUE)
+# tidymodels PCA -> factoextra
+library(recipes)
+rec <- recipe(~ ., data = iris[, 1:4]) |>
+  step_normalize(all_numeric_predictors()) |>
+  step_pca(all_numeric_predictors(), num_comp = 4)
+prep(rec) |> as_factoextra_pca() |> fviz_pca_biplot(habillage = iris$Species)
 
-# WSS now computes the k = 1 baseline internally
-fviz_nbclust(iris.scaled, hcut, method = "wss", hc_method = "complete")
+# UMAP embedding, coloured by a feature value, with the house theme + palette
+um <- uwot::umap(iris[, 1:4])
+fviz_umap(um, habillage = iris$Species, addEllipses = TRUE,
+          palette = factoextra_palette("okabe"), ggtheme = theme_factoextra())
+fviz_umap(um, col.ind = iris$Petal.Length)   # colour by a continuous feature
 
-# Parallel analysis validation is explicit and reproducible
-fviz_eig(res.pca, choice = "eigenvalue", parallel = TRUE,
-         parallel.iter = 10, parallel.seed = 123)
-
-# FactoMineR MCA quantitative supplementary variables are supported directly
-library(FactoMineR)
-data(poison)
-res.mca <- MCA(poison, quanti.sup = 1:2, graph = FALSE)
-get_mca(res.mca, "quanti.sup")
-
-# If installation leaves stale 00LOCK-* directories in your library,
-# remove those directories manually before reinstalling.
+# cos2 across several dimensions as a heatmap; large-n scatter; branch highlight
+res.pca <- prcomp(iris[, -5], scale. = TRUE)
+fviz_cos2(res.pca, choice = "var", axes = 1:3, display = "heatmap")
+fviz_pca_ind(res.pca, geom = "point", max.points = 200)
+fviz_dend(hclust(dist(scale(USArrests))), k = 4,
+          highlight = c("California", "Texas", "New York"))
 ```
       
       
@@ -195,6 +195,7 @@ Functions | Description
 *fviz_ellipses* | Draw confidence ellipses around the categories.
 *fviz_cos2* | Visualize the quality of representation of the row/column variable from the results of PCA, CA, MCA functions.
 *fviz_contrib* | Visualize the contributions of row/column elements from the results of PCA, CA, MCA functions.
+*fviz_umap*(fviz_tsne) | Visualize a 2-D UMAP / t-SNE embedding (no eigenvalues; from *uwot*, *Rtsne*, *umap* or a coordinate matrix).
 
     
    
@@ -211,7 +212,8 @@ Functions | Description
 *get_mfa* | Extract results from *Multiple Factor Analysis* outputs, including supplementary qualitative categories.
 *get_famd* | Extract results from *Factor Analysis of Mixed Data* outputs, including supplementary qualitative categories.
 *get_hmfa* | Extract results from *Hierarchical Multiple Factor Analysis* outputs.
-*facto_summarize* | Subset and summarize the output of factor analyses. 
+*facto_summarize* | Subset and summarize the output of factor analyses.
+*as_factoextra_pca* | Build a fviz-ready object from pre-computed coordinates, a tidymodels `recipe`/`workflow` (`step_pca()`), or any eigenvalue-based dimension reduction.
 
    
         
@@ -232,7 +234,14 @@ Functions | Description
 *hkmeans* (hkmeans_tree, print.hkmeans) | Hierarchical k-means clustering.
 *eclust* | Visual enhancement of clustering analysis
 
-     
+### Themes and color palettes
+
+Functions | Description
+--------- | -----------------------------------------------------------
+*theme_factoextra* | A clean publication theme for factoextra plots (via `ggtheme` or `+`).
+*factoextra_palette* | Colorblind-safe categorical colors (Okabe-Ito) for the `palette` argument.
+
+
 ## Dimension reduction and factoextra
       
 As depicted in the figure below, the type of analysis to be performed depends on the data set formats and structures.  

--- a/README.md
+++ b/README.md
@@ -168,45 +168,52 @@ The current maintenance baseline targets:
 library("factoextra")
 ```
 
-## Recent maintenance highlights
+## What’s new in the development version
 
-The current development version includes:
-
-  - helper-level `k = 1` handling for clustering diagnostics such as
-    `fviz_nbclust(..., method = "wss")` and hierarchical `eclust()`
-    auto-selection
-  - silhouette diagnostics now omit the undefined `k = 1` point and keep
-    the optimal-k guide aligned with the displayed cluster count
-  - stricter validation for scaled clustering data and non-finite
-    distance objects
-  - clearer MCA `quanti.sup`, `axes`, `ncp`, and `parallel.iter`
-    validation paths, including integer-like numeric support for
-    `fviz_eig()`
-  - refreshed examples and manuals for the updated clustering and
-    validation workflows
+  - **tidymodels on-ramp**: a PCA fitted in a `recipes` recipe
+    (`step_pca()`) or a fitted `workflow` plots directly with the
+    `fviz_pca_*` family via `as_factoextra_pca()` (honest scree, real
+    variable-component correlations)
+  - **UMAP / t-SNE**: `fviz_umap()` and `fviz_tsne()` visualize a 2-D
+    embedding (from `uwot`, `Rtsne`, `umap`, or a coordinate matrix),
+    including colouring by a continuous feature value; axes carry no
+    percentage and there is no scree/loadings surface (embeddings have no
+    eigenvalues)
+  - **Themes and palettes**: `theme_factoextra()` (a clean publication
+    theme) and `factoextra_palette("okabe")` (the Okabe-Ito
+    colorblind-safe palette), both explicit and stateless
+  - **Large datasets**: a `max.points` argument on the individual/cluster
+    plots draws a readable subset while keeping ellipses/centres on the
+    full data
+  - **`display = "heatmap"`** for `fviz_cos2()` / `fviz_contrib()` reads
+    the quality/contribution across several dimensions at once
+  - **`fviz_dend(highlight = ...)`** emphasizes the branches leading to
+    specific leaves
+  - **`fviz_mca_ind(..., quanti.sup = TRUE)`** overlays supplementary
+    quantitative variables on an MCA map
 
 <!-- end list -->
 
 ``` r
-data(iris)
-iris.scaled <- scale(iris[, -5])
-res.pca <- prcomp(iris[, -5], scale = TRUE)
+# tidymodels PCA -> factoextra
+library(recipes)
+rec <- recipe(~ ., data = iris[, 1:4]) |>
+  step_normalize(all_numeric_predictors()) |>
+  step_pca(all_numeric_predictors(), num_comp = 4)
+prep(rec) |> as_factoextra_pca() |> fviz_pca_biplot(habillage = iris$Species)
 
-# WSS now computes the k = 1 baseline internally
-fviz_nbclust(iris.scaled, hcut, method = "wss", hc_method = "complete")
+# UMAP embedding, coloured by a feature value, with the house theme + palette
+um <- uwot::umap(iris[, 1:4])
+fviz_umap(um, habillage = iris$Species, addEllipses = TRUE,
+          palette = factoextra_palette("okabe"), ggtheme = theme_factoextra())
+fviz_umap(um, col.ind = iris$Petal.Length)   # colour by a continuous feature
 
-# Parallel analysis validation is explicit and reproducible
-fviz_eig(res.pca, choice = "eigenvalue", parallel = TRUE,
-         parallel.iter = 10, parallel.seed = 123)
-
-# FactoMineR MCA quantitative supplementary variables are supported directly
-library(FactoMineR)
-data(poison)
-res.mca <- MCA(poison, quanti.sup = 1:2, graph = FALSE)
-get_mca(res.mca, "quanti.sup")
-
-# If installation leaves stale 00LOCK-* directories in your library,
-# remove those directories manually before reinstalling.
+# cos2 across several dimensions as a heatmap; large-n scatter; branch highlight
+res.pca <- prcomp(iris[, -5], scale. = TRUE)
+fviz_cos2(res.pca, choice = "var", axes = 1:3, display = "heatmap")
+fviz_pca_ind(res.pca, geom = "point", max.points = 200)
+fviz_dend(hclust(dist(scale(USArrests))), k = 4,
+          highlight = c("California", "Texas", "New York"))
 ```
 
 ## Main functions in the factoextra package
@@ -229,6 +236,7 @@ list.</span>
 | *fviz\_ellipses*                  | Draw confidence ellipses around the categories.                                                                                           |
 | *fviz\_cos2*                      | Visualize the quality of representation of the row/column variable from the results of PCA, CA, MCA functions.                            |
 | *fviz\_contrib*                   | Visualize the contributions of row/column elements from the results of PCA, CA, MCA functions.                                            |
+| *fviz\_umap*(fviz\_tsne)          | Visualize a 2-D UMAP / t-SNE embedding (no eigenvalues; from *uwot*, *Rtsne*, *umap* or a coordinate matrix).                             |
 
 ### Extracting data from dimension reduction analysis outputs
 
@@ -242,6 +250,7 @@ list.</span>
 | *get\_famd*        | Extract results from *Factor Analysis of Mixed Data* outputs, including supplementary qualitative categories.                                                |
 | *get\_hmfa*        | Extract results from *Hierarchical Multiple Factor Analysis* outputs.                                                                                        |
 | *facto\_summarize* | Subset and summarize the output of factor analyses.                                                                                                          |
+| *as\_factoextra\_pca* | Build a fviz-ready object from pre-computed coordinates, a tidymodels `recipe`/`workflow` (`step_pca()`), or any eigenvalue-based dimension reduction.       |
 
 ### Clustering analysis and visualization
 
@@ -257,6 +266,13 @@ list.</span>
 | *hcut*                                   | Computes Hierarchical Clustering and Cut the Tree           |
 | *hkmeans* (hkmeans\_tree, print.hkmeans) | Hierarchical k-means clustering.                            |
 | *eclust*                                 | Visual enhancement of clustering analysis                   |
+
+### Themes and color palettes
+
+| Functions            | Description                                                             |
+| -------------------- | ---------------------------------------------------------------------- |
+| *theme\_factoextra*  | A clean publication theme for factoextra plots (via `ggtheme` or `+`). |
+| *factoextra\_palette* | Colorblind-safe categorical colors (Okabe-Ito) for the `palette` argument. |
 
 ## Dimension reduction and factoextra
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://rpkgs.datanovia.com/factoextra/
 templates:
   params:
     bootswatch: lumen
@@ -16,6 +17,10 @@ reference:
       - fviz_ellipses
       - fviz_cos2
       - fviz_contrib
+  - title: Visualizing Embeddings (UMAP / t-SNE)
+    desc: Scatter plots of UMAP / t-SNE embeddings (no eigenvalues; see the two-track note in ?fviz_umap).
+    contents:
+      - fviz_umap
   - title: Extracting Data from Dimension Reduction Analysis Outputs
     desc: Extracting data from the output of PCA, CA, MCA, FAMD, MFA and HMFA.
     contents:
@@ -47,6 +52,11 @@ reference:
       - housetasks
       - poison
       - multishapes
+  - title: Themes and Color Palettes
+    desc: Stateless, explicit helpers for publication-grade appearance.
+    contents:
+      - theme_factoextra
+      - factoextra_palette
   - title: Others
     contents:
       - fviz_add

--- a/man/fviz_umap.Rd
+++ b/man/fviz_umap.Rd
@@ -135,9 +135,9 @@ decomposition. In the layout, \strong{tight local neighbourhoods are
 trustworthy}, but the \strong{size} of a cluster, the \strong{distance} between
 well-separated clusters and the amount of empty space between them are not
 quantitatively meaningful and change with the method's \code{perplexity} /
-\code{n_neighbors} settings - read groupings, not geometry. Similar embedding
-scatter plots are drawn by \code{Seurat::DimPlot()} / \code{FeaturePlot()} and
-\code{ggpca}.
+\code{n_neighbors} settings (Wattenberg et al., 2016) - read groupings, not
+geometry. Similar embedding scatter plots are drawn by \code{Seurat::DimPlot()}
+/ \code{FeaturePlot()} and \code{ggpca}.
 }
 \examples{
 \donttest{
@@ -149,6 +149,13 @@ if (requireNamespace("uwot", quietly = TRUE)) {
   fviz_umap(um, col.ind = iris$Petal.Length)
 }
 }
+}
+\references{
+McInnes, L., Healy, J. and Melville, J. (2018). UMAP: Uniform Manifold
+Approximation and Projection for Dimension Reduction. \emph{arXiv:1802.03426}.
+
+Wattenberg, M., \enc{Viégas}{Viegas}, F. and Johnson, I. (2016). How to Use
+t-SNE Effectively. \emph{Distill}. \doi{10.23915/distill.00002}.
 }
 \seealso{
 \code{\link{fviz_pca}}, \code{\link{as_factoextra_pca}},

--- a/vignettes/extending-factoextra.Rmd
+++ b/vignettes/extending-factoextra.Rmd
@@ -72,12 +72,12 @@ fviz_eig(res)
 fviz_contrib(res, choice = "var", axes = 1)
 ```
 
-The same pattern turns the output of methods factoextra doesn't natively know
-about into elegant biplots — e.g. classical MDS or a UMAP/t-SNE embedding
+The same pattern turns the output of any **eigenvalue-based** method factoextra
+doesn't natively know about into elegant biplots — e.g. classical MDS / PCoA
 (coordinates only; supply `var.coord` only if your method has variable loadings):
 
 ```{r quick-start-mds}
-mds <- stats::cmdscale(dist(scale(mtcars)), k = 3)   # classical MDS
+mds <- stats::cmdscale(dist(scale(mtcars)), k = 3)   # classical MDS (eigen-based)
 fviz_pca_ind(as_factoextra_pca(ind.coord = mds), repel = TRUE)
 ```
 
@@ -85,6 +85,28 @@ When you don't pass `eig`, it defaults to the variance of each coordinate column
 (the natural eigenvalue), so the scree plot and axis percentages still work. When
 you don't pass `cos2`/`contrib`, they are computed from the coordinates
 (`cos2` is then the quality of representation *within the supplied dimensions*).
+
+### Non-linear embeddings (UMAP, t-SNE): use the dedicated faces
+
+A UMAP or t-SNE embedding has **no eigenvalues**, so it must *not* go through
+`as_factoextra_pca()` — a scree plot, variable loadings or a correlation circle
+would be meaningless for it. Plot it with `fviz_umap()` / `fviz_tsne()` instead,
+which label the axes `UMAP1`/`UMAP2` (`tSNE1`/`tSNE2`) with no percentage, omit
+the eigen surface entirely, and default the group outline to a convex hull rather
+than a confidence ellipse (which would assume a metric the embedding does not
+preserve):
+
+```{r umap-face}
+um <- uwot::umap(iris[, 1:4])
+fviz_umap(um, habillage = iris$Species, addEllipses = TRUE)
+fviz_umap(um, col.ind = iris$Petal.Length)   # colour by a continuous feature value
+```
+
+In an embedding, tight local neighbourhoods are trustworthy, but the size of a
+cluster, the distance between well-separated clusters and the empty space between
+them are not quantitatively meaningful and change with the method's `perplexity` /
+`n_neighbors` settings (Wattenberg, Viégas & Johnson, 2016) — read groupings, not
+geometry.
 
 Use the constructor when you have results in hand. Read on if instead you want
 factoextra to recognise a **class** of analysis objects directly (so users of


### PR DESCRIPTION
Documentation-only consolidation (no code change, no figure regeneration).

**pkgdown**
- Adds `fviz_umap`/`fviz_tsne`, `theme_factoextra`, `factoextra_palette` to the reference index (new *Embeddings* and *Themes and Color Palettes* sections) + the site `url`. Every export is now referenced.

**README**
- A "What's new" section covering the tidymodels on-ramp, UMAP/t-SNE, themes/palettes, `max.points`, the cos2/contrib heatmap and the dendrogram highlight, with a runnable example; new functions added to the tables. `README.Rmd`/`README.md` in sync; existing figures untouched. Every example in the new block was run and builds.

**Embeddings docs (decided against a new vignette; anti-fluff)**
- `?fviz_umap`: cite the UMAP method paper (McInnes, Healy & Melville, 2018, arXiv:1802.03426) and the t-SNE interpretation guidance (Wattenberg, Viégas & Johnson, 2016, doi:10.23915/distill.00002) for the "read groupings, not geometry" caveat (both verified to resolve).
- The `extending-factoextra` vignette no longer suggests feeding a UMAP/t-SNE embedding into `as_factoextra_pca()` (embeddings have no eigenvalues); it points to `fviz_umap()`/`fviz_tsne()` and explains the honest defaults. Both chunks are `eval = FALSE`, so no build-time dependency is added.
