### PR TITLE
Document consistent theming across the fviz_* family

### DIFF
--- a/R/theme_palette.R
+++ b/R/theme_palette.R
@@ -106,6 +106,14 @@ factoextra_palette <- function(palette = "okabe", n = NULL){
 #'
 #' @seealso \code{\link{factoextra_palette}}
 #'
+#' @details The \code{fviz_*} functions have different default themes
+#'   (\code{fviz_pca_*} use \code{theme_minimal()}, \code{fviz_cluster()} uses
+#'   \code{theme_grey()}, \code{fviz_dend()} uses \code{theme_classic()}, ...).
+#'   For one consistent look across several plots in the same document, pass
+#'   \code{ggtheme = theme_factoextra()} to each call (see the last example) rather
+#'   than relying on \code{ggplot2::theme_set()}, which the \code{fviz_*} functions
+#'   override with their explicit \code{ggtheme} default.
+#'
 #' @examples
 #' \donttest{
 #' data(iris)
@@ -116,6 +124,11 @@ factoextra_palette <- function(palette = "okabe", n = NULL){
 #'
 #' # or add it to an existing plot
 #' fviz_pca_var(res.pca) + theme_factoextra()
+#'
+#' # a consistent look across the family: pass the same ggtheme to each call
+#' km <- kmeans(scale(iris[, 1:4]), 3)
+#' fviz_pca_ind(res.pca, ggtheme = theme_factoextra())
+#' fviz_cluster(km, data = iris[, 1:4], ggtheme = theme_factoextra())
 #' }
 #' @export
 theme_factoextra <- function(base_size = 12, base_family = ""){

--- a/man/theme_factoextra.Rd
+++ b/man/theme_factoextra.Rd
@@ -22,6 +22,15 @@ axis lines. Pass it through the \code{ggtheme} argument, e.g.
 \code{fviz_pca_ind(res, ggtheme = theme_factoextra())}, or add it to any
 returned plot with \code{+ theme_factoextra()}.
 }
+\details{
+The \code{fviz_*} functions have different default themes
+  (\code{fviz_pca_*} use \code{theme_minimal()}, \code{fviz_cluster()} uses
+  \code{theme_grey()}, \code{fviz_dend()} uses \code{theme_classic()}, ...).
+  For one consistent look across several plots in the same document, pass
+  \code{ggtheme = theme_factoextra()} to each call (see the last example) rather
+  than relying on \code{ggplot2::theme_set()}, which the \code{fviz_*} functions
+  override with their explicit \code{ggtheme} default.
+}
 \examples{
 \donttest{
 data(iris)
@@ -32,6 +41,11 @@ fviz_pca_ind(res.pca, habillage = iris$Species,
 
 # or add it to an existing plot
 fviz_pca_var(res.pca) + theme_factoextra()
+
+# a consistent look across the family: pass the same ggtheme to each call
+km <- kmeans(scale(iris[, 1:4]), 3)
+fviz_pca_ind(res.pca, ggtheme = theme_factoextra())
+fviz_cluster(km, data = iris[, 1:4], ggtheme = theme_factoextra())
 }
 }
 \seealso{


### PR DESCRIPTION
Addresses #264 with the non-breaking route. The `fviz_*` functions have different default themes and unifying the default would change every existing plot's appearance (a breaking default-output change), so the default is left unchanged.

Instead, `?theme_factoextra` now documents that passing `ggtheme = theme_factoextra()` to each call gives one consistent look across the family, with an example — and notes that `ggplot2::theme_set()` does *not* affect `fviz_*` (each function overrides it with its explicit `ggtheme` default). Documentation only; no code/default change.