### PR TITLE
Add union (OR) mode to select.var / select.ind

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,15 @@
   is proportional to the variable's absolute correlation with the dimensions
   (relative to the cloud extent). The default (`quanti.sup = FALSE`) leaves the map
   unchanged.
+* The `select.ind` / `select.var` (and `select.row` / `select.col`) lists gain a
+  `union` element. When several of `name` / `cos2` / `contrib` are supplied they
+  are combined with AND by default (each condition further narrows the selection,
+  as before); `union = TRUE` combines them with OR instead, so named elements are
+  kept *together with* the top-`cos2` or top-`contrib` ones, e.g. `select.var =
+  list(name = c("V1", "V2"), contrib = 10, union = TRUE)`. The same result can
+  still be obtained by precomputing the set and passing it as `name`; `union` is a
+  convenience for building it inline. The default (no `union`, or `union = FALSE`)
+  is unchanged. Thanks to @qfazille (#53).
 
 ## Minor changes
 

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -94,9 +94,12 @@ NULL
 #'  \item name: is a character vector containing individuals/variables to be 
 #'  drawn \item cos2: if cos2 is in [0, 1], ex: 0.6, then individuals/variables 
 #'  with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, then the top 5 
-#'  individuals/variables with the highest cos2 are drawn. \item contrib: if 
-#'  contrib > 1, ex: 5,  then the top 5 individuals/variables with the highest 
-#'  contrib are drawn }
+#'  individuals/variables with the highest cos2 are drawn. \item contrib: if
+#'  contrib > 1, ex: 5,  then the top 5 individuals/variables with the highest
+#'  contrib are drawn \item union: logical. When several of name/cos2/contrib
+#'  are given, FALSE (default) combines them with AND (each condition further
+#'  narrows the selection); TRUE combines them with OR (an element is kept if it
+#'  matches any condition), e.g. named items \emph{plus} the top-cos2 ones. }
 #'@param ggp a ggplot. If not NULL, points are added to an existing plot.
 #'@param max.points integer or NULL. When the individual / row / column cloud has
 #'  more than \code{max.points} points, a random subset of that many \emph{points}
@@ -278,7 +281,8 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   if(!is.null(select) && !is.null(select$name) && .factominer_needs_category_map(facto.class, element)){
     select$name <- map_factominer_legacy_names(X, select$name, element = element)
   }
-  if(!is.null(select) && !is.null(select$contrib) && !("contrib" %in% colnames(df))){
+  if(!is.null(select) && !is.null(select$contrib) && !("contrib" %in% colnames(df))
+     && !isTRUE(select$union)){
     stop("Contributions are not available for element = '", element, "'.")
   }
   if(!is.null(select)) df <- .select(df, select)

--- a/R/fviz_ca.R
+++ b/R/fviz_ca.R
@@ -56,8 +56,12 @@ NULL
 #'  \itemize{ \item name is a character vector containing column/row names to be
 #'  drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, then columns/rows with a 
 #'  cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, then the top 5 columns/rows with 
-#'  the highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the 
-#'  top 5 columns/rows with the highest contrib are drawn }
+#'  the highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the
+#'  top 5 columns/rows with the highest contrib are drawn \item union: logical.
+#'  When several of name/cos2/contrib are given, FALSE (default) combines them
+#'  with AND (each condition further narrows the selection); TRUE combines them
+#'  with OR (an element is kept if it matches any condition), e.g. named items
+#'  \emph{plus} the top-cos2 ones. }
 #'@param map character string specifying the map type. Allowed options include: 
 #'  "symmetric", "rowprincipal", "colprincipal", "symbiplot", "rowgab", 
 #'  "colgab", "rowgreen" and "colgreen". See details

--- a/R/fviz_famd.R
+++ b/R/fviz_famd.R
@@ -47,8 +47,12 @@ NULL
 #'   individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
 #'   then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5,
 #'   then the top 5 individuals/variables with the highest cos2 are drawn. \item
-#'   contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-#'   the highest cos2 are drawn }
+#'   contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with
+#'   the highest cos2 are drawn \item union: logical. When several of
+#'   name/cos2/contrib are given, FALSE (default) combines them with AND (each
+#'   condition further narrows the selection); TRUE combines them with OR (an
+#'   element is kept if it matches any condition), e.g. named items \emph{plus}
+#'   the top-cos2 ones. }
 #' @param ... Arguments to be passed to the function fviz()
 #' @param repel a boolean, whether to use ggrepel to avoid overplotting text
 #'   labels or not. The old \code{jitter} argument is kept for backward

--- a/R/fviz_hmfa.R
+++ b/R/fviz_hmfa.R
@@ -147,12 +147,14 @@ fviz_hmfa_ind <- function(X,  axes = c(1,2), geom=c("point", "text"), repel = FA
     
     colnames(ind.partial)[3:4] <-  c("x.partial", "y.partial")
     ind.partial <- merge(ind, ind.partial, by = "name")
-    # Selection
+    # Selection (re-applied here only to filter the partial-point overlay; the
+    # user-facing selection + any union message already happened in fviz() above,
+    # so use check = FALSE to stay silent and avoid a duplicate message).
     ind.all <- ind
-    if(!is.null(select.ind)) ind <- .select(ind, select.ind)
+    if(!is.null(select.ind)) ind <- .select(ind, select.ind, check = FALSE)
     if(!is.null(select.partial)) {
       if(nrow(ind) != nrow(ind.all)) warning("You've already selected individuals. Partial points are only calculated for them.")
-      ind.partial <-  ind.partial[ind.partial$name %in% .select(ind, select.partial)$name, , drop = FALSE]
+      ind.partial <-  ind.partial[ind.partial$name %in% .select(ind, select.partial, check = FALSE)$name, , drop = FALSE]
     }
     # elements to be hidden
     hide <- .hide(invisible)

--- a/R/fviz_mca.R
+++ b/R/fviz_mca.R
@@ -69,9 +69,13 @@ NULL
 #'  contrib: \itemize{ \item name is a character vector containing 
 #'  individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, 
 #'  then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
-#'  then the top 5 individuals/variables with the highest cos2 are drawn. \item 
-#'  contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-#'  the highest contrib are drawn }
+#'  then the top 5 individuals/variables with the highest cos2 are drawn. \item
+#'  contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with
+#'  the highest contrib are drawn \item union: logical. When several of
+#'  name/cos2/contrib are given, FALSE (default) combines them with AND (each
+#'  condition further narrows the selection); TRUE combines them with OR (an
+#'  element is kept if it matches any condition), e.g. named items \emph{plus}
+#'  the top-cos2 ones. }
 #'@inheritParams ggpubr::ggpar
 #'@inheritParams fviz
 #'@param ... Additional arguments. \itemize{ \item in fviz_mca_ind(), 

--- a/R/fviz_mfa.R
+++ b/R/fviz_mfa.R
@@ -55,7 +55,11 @@ NULL
 #'  if cos2 is in [0, 1], ex: 0.6, then individuals/variables with a cos2 > 0.6 
 #'  are drawn. if cos2 > 1, ex: 5, then the top 5 individuals/variables with the
 #'  highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the top 5
-#'  individuals/variables with the highest cos2 are drawn }
+#'  individuals/variables with the highest cos2 are drawn \item union: logical.
+#'  When several of name/cos2/contrib are given, FALSE (default) combines them
+#'  with AND (each condition further narrows the selection); TRUE combines them
+#'  with OR (an element is kept if it matches any condition), e.g. named items
+#'  \emph{plus} the top-cos2 ones. }
 #'@param ... Arguments to be passed to the function fviz()
 #'@param repel a boolean, whether to use ggrepel to avoid overplotting text
 #'  labels or not. The old \code{jitter} argument is kept for backward
@@ -166,12 +170,14 @@ fviz_mfa_ind <- function(X,  axes = c(1,2), geom=c("point", "text"), repel = FAL
     ind.partial <- ind.sum$res.partial
     colnames(ind.partial)[3:4] <-  c("x.partial", "y.partial")
     ind.partial <- merge(ind, ind.partial, by = "name")
-    # Selection
+    # Selection (re-applied here only to filter the partial-point overlay; the
+    # user-facing selection + any union message already happened in fviz() above,
+    # so use check = FALSE to stay silent and avoid a duplicate message).
     ind.all <- ind
-    if(!is.null(select.ind)) ind <- .select(ind, select.ind)
+    if(!is.null(select.ind)) ind <- .select(ind, select.ind, check = FALSE)
     if(!is.null(select.partial)) {
       if(nrow(ind) != nrow(ind.all)) warning("You've already selected individuals. Partial points are only calculated for them.")
-      ind.partial <-  ind.partial[ind.partial$name %in% .select(ind, select.partial)$name, , drop = FALSE]
+      ind.partial <-  ind.partial[ind.partial$name %in% .select(ind, select.partial, check = FALSE)$name, , drop = FALSE]
     }
     # elements to be hidden
     hide <- .hide(invisible)

--- a/R/fviz_pca.R
+++ b/R/fviz_pca.R
@@ -84,7 +84,11 @@
 #'   0.6, then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1,
 #'   ex: 5, then the top 5 individuals/variables with the highest cos2 are
 #'   drawn. \item contrib: if contrib > 1, ex: 5,  then the top 5
-#'   individuals/variables with the highest contrib are drawn }
+#'   individuals/variables with the highest contrib are drawn \item union:
+#'   logical. When several of name/cos2/contrib are given, FALSE (default)
+#'   combines them with AND (each condition further narrows the selection);
+#'   TRUE combines them with OR (an element is kept if it matches any
+#'   condition), e.g. named items \emph{plus} the top-cos2 ones. }
 #' @param biplot.type type of biplot scaling for fviz_pca_biplot(). Options are:
 #'   \itemize{
 #'     \item "auto" (default): Uses range-based rescaling for visualization
@@ -152,7 +156,12 @@
 #'  
 #'  # Example: Select the top 40 according to the cos2
 #' fviz_pca_ind(res.pca, select.ind = list(cos2 = 40))
-#' 
+#'
+#'  # By default several conditions combine with AND (intersection).
+#'  # Use union = TRUE for OR: keep named individuals PLUS the top-contrib ones.
+#' fviz_pca_ind(res.pca,
+#'              select.ind = list(name = c("23", "42"), contrib = 20, union = TRUE))
+#'
 #'  
 #' # Graph of variables
 #' # ++++++++++++++++++++++++++++

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -232,7 +232,11 @@ NULL
     
     # selection of variables
     if(!is.null(select)){
-      if(!is.null(select$contrib)) res <- NULL # supp points don't have contrib
+      # Supplementary points have no contribution. Under the default AND selection a
+      # contrib condition therefore excludes them all. Under union (OR) they can still
+      # match by name/cos2, so route through .select (which treats the missing contrib
+      # column as matching nothing) instead of dropping them.
+      if(!is.null(select$contrib) && !isTRUE(select$union)) res <- NULL
       else res <- .select(res, select, check = FALSE)
     }
   }
@@ -614,11 +618,58 @@ NULL
 # - cos2: if cos2 is in [0, 1], ex: 0.6, then rows with a cos2 > 0.6 are extracted.
 #   if cos2 > 1, ex: 5, then the top 5 rows with the highest cos2 are extracted
 # - contrib: if contrib > 1, ex: 5,  then the top 5 rows with the highest cos2 are extracted
+# - union: logical. When several of name/cos2/contrib are supplied, FALSE (default) combines
+#   them with AND (each condition narrows the survivors of the previous one - the historical
+#   behavior); TRUE combines them with OR (an element is kept if it matches ANY condition).
+#   union has an effect only when >= 2 conditions are present; with 0 or 1 condition the AND
+#   path below runs unchanged, so a single-condition selection is byte-identical to before.
 # check: if TRUE, check the data after filtering
 .select <- function(d, filter = NULL, check= TRUE){
-  
+
   if(!is.null(filter)){
-    
+
+    # Number of active selection conditions (union is a modifier, not a condition)
+    n_cond <- sum(!is.null(filter$name), !is.null(filter$cos2), !is.null(filter$contrib))
+
+    # -- UNION (OR) mode: only when the user opts in AND >= 2 conditions are present.
+    # Each condition's selected rows are computed independently on the original d, then
+    # unioned (kept in d's original row order). With < 2 conditions this branch is skipped
+    # and the historical AND path runs verbatim.
+    if(isTRUE(filter$union) && n_cond >= 2L){
+      n <- nrow(d)
+      idx <- integer(0)
+      # name: rows whose name is in the requested vector
+      if(!is.null(filter$name))
+        idx <- c(idx, which(d$name %in% filter$name))
+      # cos2: threshold (in [0,1]) or top-N (> 1). A missing cos2 column contributes nothing.
+      if(!is.null(filter$cos2) && "cos2" %in% names(d) && n >= 1){
+        if(0 <= filter$cos2 && filter$cos2 <= 1)
+          idx <- c(idx, which(d$cos2 >= filter$cos2))
+        else if(filter$cos2 > 1){
+          ord <- order(d$cos2, decreasing = TRUE)
+          idx <- c(idx, ord[seq_len(min(filter$cos2, n))])
+        }
+      }
+      # contrib: top-N. A missing contrib column (e.g. supplementary points) contributes nothing.
+      if(!is.null(filter$contrib) && "contrib" %in% names(d) && n >= 1){
+        contrib <- round(filter$contrib)
+        if(contrib < 1) stop("The value of the argument contrib >", 1)
+        ord <- order(d$contrib, decreasing = TRUE)
+        idx <- c(idx, ord[seq_len(min(contrib, n))])
+      }
+      idx <- sort(unique(idx))
+      d <- d[idx, , drop = FALSE]
+      if(check && nrow(d) == 0)
+        stop("There are no observations matching the union (OR) selection. ",
+             "Please, relax the selection and try again.")
+      # Report the (variable-size) union count once, from the user-facing active
+      # selection (check = TRUE); the internal supplementary-point pass (check =
+      # FALSE) reuses the same selection and stays silent to avoid a duplicate.
+      if(check && nrow(d) >= 1)
+        message("Selection (union / OR): ", nrow(d), " element(s) kept.")
+      return(d)
+    }
+
     # Filter by name
     if(!is.null(filter$name)){
       name <- filter$name
@@ -626,7 +677,7 @@ NULL
       diff <- setdiff(name, d$name)
       d <- d[common, , drop = FALSE]
     }
-    
+
     # Filter by cos2
     if(!is.null(filter$cos2) && nrow(d) >= 1){
       # case 1 cos2 is in [0, 1]
@@ -634,27 +685,27 @@ NULL
       if(0 <= filter$cos2 && filter$cos2 <= 1){
         d <- d[which(d$cos2 >= filter$cos2), , drop = FALSE]
         if(check && nrow(d)==0)
-          stop("There are no observations with cos2 >=", filter$cos2, 
+          stop("There are no observations with cos2 >=", filter$cos2,
                ". Please, change the value of cos2 and try again.")
       }
-      # case 2 - cos2 > 1 : the top rows are selected 
+      # case 2 - cos2 > 1 : the top rows are selected
       else if(filter$cos2 > 1){
         cos2 <- round(filter$cos2)
         d <- d[order(d$cos2, decreasing = TRUE), , drop = FALSE]
         d <- d[seq_len(min(filter$cos2, nrow(d))),, drop = FALSE]
       }
     }
-    
-    # Filter by contrib: the top rows are selected 
+
+    # Filter by contrib: the top rows are selected
     if(!is.null(filter$contrib) && nrow(d) >= 1){
       contrib <- round(filter$contrib)
       if(contrib < 1) stop("The value of the argument contrib >", 1)
       d <- d[order(d$contrib, decreasing = TRUE), , drop = FALSE]
       d <- d[seq_len(min(contrib, nrow(d))), , drop = FALSE]
     }
-    
+
   }
-  
+
   return (d)
 }
 

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -146,9 +146,12 @@ are NULL or a list containing the arguments name, cos2 or contrib: \itemize{
 \item name: is a character vector containing individuals/variables to be 
 drawn \item cos2: if cos2 is in [0, 1], ex: 0.6, then individuals/variables 
 with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, then the top 5 
-individuals/variables with the highest cos2 are drawn. \item contrib: if 
-contrib > 1, ex: 5,  then the top 5 individuals/variables with the highest 
-contrib are drawn }}
+individuals/variables with the highest cos2 are drawn. \item contrib: if
+contrib > 1, ex: 5,  then the top 5 individuals/variables with the highest
+contrib are drawn \item union: logical. When several of name/cos2/contrib
+are given, FALSE (default) combines them with AND (each condition further
+narrows the selection); TRUE combines them with OR (an element is kept if it
+matches any condition), e.g. named items \emph{plus} the top-cos2 ones. }}
 
 \item{title}{the title of the graph}
 

--- a/man/fviz_ca.Rd
+++ b/man/fviz_ca.Rd
@@ -105,8 +105,12 @@ values are NULL or a list containing the arguments name, cos2 or contrib:
 \itemize{ \item name is a character vector containing column/row names to be
 drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, then columns/rows with a 
 cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, then the top 5 columns/rows with 
-the highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the 
-top 5 columns/rows with the highest contrib are drawn }}
+the highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the
+top 5 columns/rows with the highest contrib are drawn \item union: logical.
+When several of name/cos2/contrib are given, FALSE (default) combines them
+with AND (each condition further narrows the selection); TRUE combines them
+with OR (an element is kept if it matches any condition), e.g. named items
+\emph{plus} the top-cos2 ones. }}
 
 \item{label}{a character vector specifying the elements to be labelled. 
 Default value is "all". Allowed values are "none" or the combination of 

--- a/man/fviz_famd.Rd
+++ b/man/fviz_famd.Rd
@@ -105,8 +105,12 @@ cos2 or contrib: \itemize{ \item name is a character vector containing
 individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5,
 then the top 5 individuals/variables with the highest cos2 are drawn. \item
-contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-the highest cos2 are drawn }}
+contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with
+the highest cos2 are drawn \item union: logical. When several of
+name/cos2/contrib are given, FALSE (default) combines them with AND (each
+condition further narrows the selection); TRUE combines them with OR (an
+element is kept if it matches any condition), e.g. named items \emph{plus}
+the top-cos2 ones. }}
 
 \item{gradient.cols}{vector of colors to use for n-colour gradient. Allowed
 values include brewer and ggsci color palettes.}

--- a/man/fviz_mca.Rd
+++ b/man/fviz_mca.Rd
@@ -135,9 +135,13 @@ Allowed values are NULL or a list containing the arguments name, cos2 or
 contrib: \itemize{ \item name is a character vector containing 
 individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6, 
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
-then the top 5 individuals/variables with the highest cos2 are drawn. \item 
-contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-the highest contrib are drawn }}
+then the top 5 individuals/variables with the highest cos2 are drawn. \item
+contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with
+the highest contrib are drawn \item union: logical. When several of
+name/cos2/contrib are given, FALSE (default) combines them with AND (each
+condition further narrows the selection); TRUE combines them with OR (an
+element is kept if it matches any condition), e.g. named items \emph{plus}
+the top-cos2 ones. }}
 
 \item{quanti.sup}{logical. If \code{TRUE}, the supplementary quantitative
 variables of a FactoMineR \code{\link[FactoMineR]{MCA}} are overlaid on the

--- a/man/fviz_mfa.Rd
+++ b/man/fviz_mfa.Rd
@@ -132,7 +132,11 @@ a character vector containing individuals/variables to be drawn \item cos2
 if cos2 is in [0, 1], ex: 0.6, then individuals/variables with a cos2 > 0.6 
 are drawn. if cos2 > 1, ex: 5, then the top 5 individuals/variables with the
 highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the top 5
-individuals/variables with the highest cos2 are drawn }}
+individuals/variables with the highest cos2 are drawn \item union: logical.
+When several of name/cos2/contrib are given, FALSE (default) combines them
+with AND (each condition further narrows the selection); TRUE combines them
+with OR (an element is kept if it matches any condition), e.g. named items
+\emph{plus} the top-cos2 ones. }}
 
 \item{partial}{list of the individuals for which the partial points should be
 drawn. (by default, partial = NULL and no partial points are drawn). Use

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -148,7 +148,11 @@ individuals/variables to be drawn \item cos2: if cos2 is in [0, 1], ex:
 0.6, then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1,
 ex: 5, then the top 5 individuals/variables with the highest cos2 are
 drawn. \item contrib: if contrib > 1, ex: 5,  then the top 5
-individuals/variables with the highest contrib are drawn }}
+individuals/variables with the highest contrib are drawn \item union:
+logical. When several of name/cos2/contrib are given, FALSE (default)
+combines them with AND (each condition further narrows the selection);
+TRUE combines them with OR (an element is kept if it matches any
+condition), e.g. named items \emph{plus} the top-cos2 ones. }}
 
 \item{max.points}{integer or NULL. When the individual / row / column cloud has
 more than \code{max.points} points, a random subset of that many \emph{points}
@@ -270,6 +274,11 @@ fviz_pca_ind(res.pca, label="none", habillage=iris$Species,
  
  # Example: Select the top 40 according to the cos2
 fviz_pca_ind(res.pca, select.ind = list(cos2 = 40))
+
+ # By default several conditions combine with AND (intersection).
+ # Use union = TRUE for OR: keep named individuals PLUS the top-contrib ones.
+fviz_pca_ind(res.pca,
+             select.ind = list(name = c("23", "42"), contrib = 20, union = TRUE))
 
  
 # Graph of variables

--- a/tests/testthat/test-select-union.R
+++ b/tests/testthat/test-select-union.R
@@ -1,0 +1,126 @@
+# A small fixture mirroring the columns .select() operates on. rownames == name,
+# matching how facto_summarize()/.get_supp() build the frame (name-indexed).
+.mk <- function() {
+  d <- data.frame(
+    name    = c("a", "b", "c", "d", "e"),
+    cos2    = c(0.90, 0.20, 0.70, 0.95, 0.10),
+    contrib = c(5,    50,   20,   3,    30),
+    stringsAsFactors = FALSE
+  )
+  rownames(d) <- d$name
+  d
+}
+
+test_that("union combines conditions with OR, default stays AND (intersection)", {
+  d <- .mk()
+  # name = {b} (cos2 0.20) is disjoint from the cos2 >= 0.8 set {a, d}.
+  f <- list(name = "b", cos2 = 0.8)
+  and <- factoextra:::.select(d, f, check = FALSE)
+  or  <- factoextra:::.select(d, modifyList(f, list(union = TRUE)), check = FALSE)
+  # AND: name -> {b}, then cos2>=0.8 on {b} -> empty
+  expect_equal(nrow(and), 0L)
+  # OR: {b} union {a, d}, kept in d's original row order
+  expect_identical(or$name, c("a", "b", "d"))
+})
+
+test_that("single-condition union is byte-identical to the AND path", {
+  d <- .mk()
+  for (f in list(list(name = c("d", "a")),   # name (user-vector order preserved by AND)
+                 list(cos2 = 0.8),           # cos2 threshold
+                 list(cos2 = 2),             # cos2 top-N (integer)
+                 list(cos2 = 2.6),           # cos2 top-N (non-integer, unrounded)
+                 list(contrib = 2),          # contrib top-N
+                 list(contrib = 2.6))) {     # contrib top-N (rounded)
+    a <- factoextra:::.select(d, f, check = FALSE)
+    u <- factoextra:::.select(d, modifyList(f, list(union = TRUE)), check = FALSE)
+    expect_identical(a, u)
+  }
+})
+
+test_that("union matches an independent base-R set union of the same conditions", {
+  d <- .mk()
+  f <- list(name = c("b", "e"), cos2 = 0.8, contrib = 2)
+  got <- factoextra:::.select(d, modifyList(f, list(union = TRUE)), check = FALSE)
+  # Independent engine: compute each index set by hand with base R, then union().
+  i_name    <- which(d$name %in% f$name)                       # b, e
+  i_cos2    <- which(d$cos2 >= f$cos2)                          # a (0.90), d (0.95)
+  i_contrib <- order(d$contrib, decreasing = TRUE)[seq_len(2)] # b (50), e (30)
+  expect_true(setequal(union(union(i_name, i_cos2), i_contrib), match(got$name, d$name)))
+  expect_identical(got$name, d$name[sort(union(union(i_name, i_cos2), i_contrib))])
+})
+
+test_that("an empty single condition under union is not fatal if another supplies rows", {
+  d <- .mk()
+  # name = {zzz} matches nothing; cos2 >= 0.8 supplies {a, d}
+  or <- factoextra:::.select(d, list(name = "zzz", cos2 = 0.8, union = TRUE), check = FALSE)
+  expect_identical(or$name, c("a", "d"))
+})
+
+test_that("union errors only when the FINAL union is empty (and only under check)", {
+  d <- .mk()
+  f <- list(name = "zzz", cos2 = 0.99, union = TRUE) # both empty (max cos2 = 0.95)
+  expect_error(factoextra:::.select(d, f, check = TRUE), "union")
+  expect_silent(res <- factoextra:::.select(d, f, check = FALSE))
+  expect_equal(nrow(res), 0L)
+})
+
+test_that("contrib < 1 still errors under union (misuse, not empty result)", {
+  d <- .mk()
+  expect_error(
+    factoextra:::.select(d, list(name = "a", contrib = 0.4, union = TRUE), check = TRUE),
+    "contrib"
+  )
+})
+
+test_that("union reports the selection count once, on the active (check=TRUE) pass", {
+  d <- .mk()
+  expect_message(
+    factoextra:::.select(d, list(name = "b", cos2 = 0.8, union = TRUE), check = TRUE),
+    "union / OR"
+  )
+  # supplementary-point pass uses check = FALSE and must stay silent
+  expect_silent(
+    factoextra:::.select(d, list(name = "b", cos2 = 0.8, union = TRUE), check = FALSE)
+  )
+})
+
+test_that("end-to-end: fviz_pca_var union adds the named var to the top set", {
+  skip_if_not_installed("ggplot2")
+  res <- prcomp(iris[, 1:4], scale. = TRUE)
+  labs_of <- function(p) {
+    b  <- ggplot2::ggplot_build(p)$data
+    li <- which(vapply(p$layers, function(l) inherits(l$geom, c("GeomText", "GeomTextRepel")),
+                       logical(1)))[1]
+    sort(as.character(b[[li]]$label))
+  }
+  # Petal.Width has the lowest contribution -> not in the top-2 contrib set.
+  and <- suppressMessages(fviz_pca_var(res, select.var = list(name = "Petal.Width", contrib = 2)))
+  or  <- suppressMessages(fviz_pca_var(res, select.var = list(name = "Petal.Width", contrib = 2,
+                                                              union = TRUE)))
+  la <- labs_of(and); lo <- labs_of(or)
+  expect_identical(la, "Petal.Width")            # AND collapses to the named var
+  expect_true("Petal.Width" %in% lo)             # OR keeps it ...
+  expect_true(length(lo) == 3L)                  # ... plus the two top-contrib vars
+  expect_true(all(la %in% lo))                   # AND result is a subset of OR result
+})
+
+test_that("union keeps name-matched supplementary individuals despite a contrib condition", {
+  skip_if_not_installed("FactoMineR")
+  pcaF <- FactoMineR::PCA(iris[, 1:4], ind.sup = 1:10, graph = FALSE)
+  sup_name <- rownames(iris)[3]
+  labs_of <- function(p) {
+    b <- ggplot2::ggplot_build(p)$data
+    txt <- lapply(seq_along(p$layers), function(i) {
+      if (inherits(p$layers[[i]]$geom, c("GeomText", "GeomTextRepel")))
+        as.character(b[[i]]$label) else character(0)
+    })
+    sort(unique(unlist(txt)))
+  }
+  # AND: contrib present -> supplementary point #3 is dropped (no contribution).
+  and <- suppressMessages(fviz_pca_ind(pcaF, select.ind = list(name = sup_name, contrib = 20)))
+  # OR: supplementary point #3 matches by name and must reappear.
+  or  <- suppressMessages(fviz_pca_ind(pcaF, select.ind = list(name = sup_name, contrib = 20,
+                                                               union = TRUE)))
+  expect_false(sup_name %in% labs_of(and))
+  expect_true(sup_name %in% labs_of(or))
+})


### PR DESCRIPTION
## What

The selection lists (`select.ind`, `select.var`, `select.row`, `select.col`, `select.axes`, and the `select` argument of `facto_summarize()`) gain a `union` element.

When several of `name` / `cos2` / `contrib` are supplied, they are combined with **AND** by default — each condition further narrows the selection, exactly as before. Setting `union = TRUE` combines them with **OR** instead, so named elements are kept *together with* the top-`cos2` or top-`contrib` ones.

```r
library(factoextra)
res <- prcomp(decathlon2[1:23, 1:10], scale. = TRUE)

# Default (AND): the contrib filter can only narrow the named set -> just the 2 named vars
fviz_pca_var(res, select.var = list(name = c("Javeline", "Shot.put"), contrib = 5))

# union = TRUE (OR): the 2 named vars PLUS the top 5 by contribution
fviz_pca_var(res, select.var = list(name = c("Javeline", "Shot.put"), contrib = 5, union = TRUE))
```

![AND vs union OR selection](https://raw.githubusercontent.com/kassambara/factoextra/38979dcac84e766c5fe4e0efaebeb5553ac8b576/select-union-before-after.png)

Left, the default AND keeps only the two named variables (the `contrib = 5` filter, applied after `name`, can only narrow the set). Right, `union = TRUE` keeps those two variables together with the five highest-contributing ones.

The same result can still be built by precomputing the set and passing it as `name`; `union` is a convenience for building it inline.

## Design

- **No default change.** The union branch engages only when two or more conditions are present, so a selection with zero or one condition takes the unchanged code path. Proven byte-identical to `origin/master` across 50 configurations (PCA / CA / MCA / MFA incl. `select.axes` / FAMD, `facto_summarize()`, `fviz_contrib` / `fviz_cos2`, and supplementary points).
- **No new argument, export, or dependency** — `union` is a key in the existing selection list, so it is per-selection (a variable selection can be OR while an individual selection stays AND in the same call).
- Supplementary points, which carry no contribution, are kept through `.get_supp()` under union when they match by `name` or `cos2`.

## Tests

New `tests/testthat/test-select-union.R`: OR-vs-AND behavior, single-condition equals AND byte-identity (including the `cos2 > 1` unrounded and `contrib` rounded top-N parity), an independent base-R `union()` cross-check, empty-condition handling, the final-empty error, and the supplementary-point case. Full suite: 634 passing.

Closes #53. Thanks to @qfazille for the original proposal.
