### PR TITLE
Integrate #274 (1/7): documentation corrections and clarifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -89,6 +89,12 @@
   already depends on.
 * Fixed a typo in the default title of `fviz_cos2()` / `fviz_contrib()` for
   quantitative variables ("quantitive" -> "quantitative").
+* Clarified and corrected documentation across several help pages: the
+  contribution-based selection help now says "highest contributions" (was
+  "highest cos2"), `fviz_famd()`'s `habillage` help refers to a FAMD (not MFA)
+  object, the ExPosition class name is spelled `expoOutput` in `fviz_ca()` /
+  `fviz_mca()`, and the `clean_lock_files()` example is now self-contained.
+  Thanks to @erdeyl (#274).
 
 # factoextra 2.1.0
 

--- a/R/eclust.R
+++ b/R/eclust.R
@@ -39,12 +39,12 @@ NULL
 #'   "agnes" or "diana". Ignored when \code{x} is already a \code{"dist"} object.
 #' @param hc_method the agglomeration method to be used (?hclust): "ward.D", 
 #'   "ward.D2", "single", "complete", "average", ...
-#' @param gap_maxSE a list containing the parameters (method and SE.factor) for 
-#'   determining the location of the maximum of the gap statistic (Read the 
-#'   documentation ?cluster::maxSE).
+#' @param gap_maxSE a list containing the \code{method} and \code{SE.factor}
+#'   parameters passed to \code{\link[cluster]{maxSE}}. The default is
+#'   \code{list(method = "firstSEmax", SE.factor = 1)}.
 #' @param nboot integer, number of Monte Carlo ("bootstrap") samples. Used only 
-#'   for determining the number of clusters using gap statistic.
-#' @param verbose logical value. If TRUE, the result of progress is printed.
+#'   for determining the number of clusters using the gap statistic.
+#' @param verbose logical value. If TRUE, progress information is printed.
 #' @param seed integer used for seeding the random number generator.
 #' @param ... other arguments to be passed to FUNcluster.
 #' @return Returns an object of class "eclust" containing the result of the 
@@ -58,7 +58,7 @@ NULL
 #'   width of each cluster) and $avg.width (average width of all clusters)
 #'   \item size: the size of clusters \item data: a matrix containing the
 #'   original or the standardized data (if stand = TRUE) } The "eclust" class
-#'   has method for fviz_silhouette(), fviz_dend(), fviz_cluster().
+#'   has methods for fviz_silhouette(), fviz_dend(), and fviz_cluster().
 #' @seealso \code{\link{fviz_silhouette}}, \code{\link{fviz_dend}}, 
 #'   \code{\link{fviz_cluster}}
 #' @author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}

--- a/R/facto_summarize.R
+++ b/R/facto_summarize.R
@@ -16,9 +16,9 @@ NULL
 #'   "var" or "ind" for PCA; and 'quanti.var', 'quali.var', 'quali.sup',
 #'   'group' or 'ind' for FAMD, MFA and HMFA.
 #' @param result the result to be extracted for the element. Possible values are
-#'   the combination of c("cos2", "contrib", "coord")
+#'   any combination of \code{c("coord", "cos2", "contrib")}.
 #' @param group.names a vector containing the name of the groups (by default, 
-#'   NULL and the group are named group.1, group.2 and so on).
+#'   NULL and the groups are named group.1, group.2, and so on).
 #' @param node.level a single number indicating the HMFA node level.
 #' @param axes a numeric vector specifying the axes of interest. Values must be
 #'   positive integer indices within the available dimensions. Default values
@@ -29,13 +29,13 @@ NULL
 #'   vector containing variable names to be selected \item cos2: if cos2 is in 
 #'   [0, 1], ex: 0.6, then variables with a cos2 > 0.6 are selected. if cos2 > 
 #'   1, ex: 5, then the top 5 variables with the highest cos2 are selected \item
-#'   contrib: if contrib > 1, ex: 5,  then the top 5 variables with the highest 
-#'   cos2 are selected. }
-#' @return A data frame containing the (total) coord, cos2 and the contribution 
-#'   for the axes.
+#'   contrib: if contrib > 1, ex: 5, then the top 5 variables with the highest
+#'   contributions are selected. }
+#' @return A data frame containing the requested coordinates and the cos2 and
+#'   contribution metrics aggregated over the requested axes.
 #' @details If length(axes) > 1, then the columns contrib and cos2 correspond to
 #'   the total contributions and total cos2 of the axes. In this case, the 
-#'   column coord is calculated as x^2 + y^2 + ...+; x, y, ... are the 
+#'   column coord is calculated as x^2 + y^2 + ...; x, y, ... are the
 #'   coordinates of the points on the specified axes.
 #' @author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}
 #' @references \url{https://www.sthda.com/english/}

--- a/R/fviz_add.R
+++ b/R/fviz_add.R
@@ -14,8 +14,8 @@
 #' @param pointsize the size of points
 #' @param shape point shape when geom ="point"
 #' @param linetype the linetype to be used when geom ="arrow"
-#' @param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'   labels or not. The old \code{jitter} argument is kept for backward
+#' @param repel logical; whether to use ggrepel to avoid overplotting text
+#'   labels. The old \code{jitter} argument is kept for backward
 #'   compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #' @param font.family character vector specifying font family.
 #' @param ... Additional arguments, not used

--- a/R/fviz_ca.R
+++ b/R/fviz_ca.R
@@ -6,7 +6,7 @@ NULL
 #'  Component Analysis (PCA) suited to analyze frequencies formed by two 
 #'  categorical variables. fviz_ca() provides ggplot2-based elegant 
 #'  visualization of CA outputs from the R functions: CA [in FactoMineR], ca [in
-#'  ca], coa [in ade4], correspondence [in MASS] and expOutput/epCA [in
+#'  ca], coa [in ade4], correspondence [in MASS] and expoOutput/epCA [in
 #'  ExPosition]. Read more: 
 #'  \href{https://www.sthda.com/english/articles/31-principal-component-methods-in-r-practical-guide/113-ca-correspondence-analysis-in-r-essentials/}{Correspondence
 #'   Analysis}
@@ -16,7 +16,7 @@ NULL
 #'  variables \item fviz_ca(): An alias of fviz_ca_biplot() }
 #'  
 #'@param X an object of class CA [FactoMineR], ca [ca], coa [ade4]; 
-#'  correspondence [MASS] and expOutput/epCA [ExPosition].
+#'  correspondence [MASS] and expoOutput/epCA [ExPosition].
 #'@param axes a numeric vector of length 2 specifying the dimensions to be 
 #'  plotted.
 #'@param shape.row,shape.col the point shapes to be used for row/column 
@@ -29,27 +29,27 @@ NULL
 #'   respectively. Default is geom.row = c("point", "text), geom.col =
 #'   c("point", "text").
 #'@param label a character vector specifying the elements to be labelled. 
-#'  Default value is "all". Allowed values are "none" or the combination of 
+#'  Default value is "all". Allowed values are "all", "none", or a combination of
 #'  c("row", "row.sup", "col", "col.sup"). Use "col" to label only active column
 #'  variables; "col.sup" to label only supplementary columns; etc
 #'@param invisible a character value specifying the elements to be hidden on the
-#'  plot. Default value is "none". Allowed values are the combination of 
+#'  plot. Default value is "none". Allowed values are "all", "none", or a combination of
 #'  c("row", "row.sup","col", "col.sup").
 #'@param title the title of the graph
 #'@param col.col,col.row color for column/row points. The default values are 
 #'  "red" and "blue", respectively. Can be a continuous variable or a factor
-#'  variable. Allowed values include also : "cos2", "contrib", "coord", "x" or
+#'  variable. Allowed values also include "cos2", "contrib", "coord", "x", and
 #'  "y". In this case, the colors for row/column variables are automatically
 #'  controlled by their qualities ("cos2"), contributions ("contrib"),
 #'  coordinates (x^2 + y^2, "coord"), x values("x") or y values("y")
-#'@param alpha.col,alpha.row controls the transparency of colors. The value can 
-#'  variate from 0 (total transparency) to 1 (no transparency). Default value is
-#'  1. Allowed values include also : "cos2", "contrib", "coord", "x" or "y" as 
+#'@param alpha.col,alpha.row controls the transparency of colors. The value
+#'  ranges from 0 (total transparency) to 1 (no transparency). Default value is
+#'  1. Allowed values also include "cos2", "contrib", "coord", "x", and "y", as
 #'  for the arguments col.col and col.row.
 #'@param col.col.sup,col.row.sup colors for the supplementary column and row 
 #'  points, respectively.
-#'@param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'  labels or not. The old \code{jitter} argument is kept for backward
+#'@param repel logical; whether to use ggrepel to avoid overplotting text
+#'  labels. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #'@param select.col,select.row a selection of columns/rows to be drawn. Allowed 
 #'  values are NULL or a list containing the arguments name, cos2 or contrib: 
@@ -109,12 +109,12 @@ NULL
 #' 
 #' # Biplot of rows and columns
 #' # ++++++++++++++++++++++++++
-#' # Symetric Biplot of rows and columns
+#' # Symmetric biplot of rows and columns
 #' fviz_ca_biplot(res.ca)
 #' 
-#' # Asymetric biplot, use arrows for columns
+#' # Asymmetric biplot, use arrows for columns
 #' fviz_ca_biplot(res.ca, map ="rowprincipal",
-#'  arrow = c(FALSE, TRUE))
+#'  arrows = c(FALSE, TRUE))
 #'  
 #' # Keep only the labels for row points
 #' fviz_ca_biplot(res.ca, label ="row")

--- a/R/fviz_famd.R
+++ b/R/fviz_famd.R
@@ -2,7 +2,7 @@
 NULL
 #' Visualize Factor Analysis of Mixed Data
 #' 
-#' @description Factor analysis of mixed data (FAMD) is, a particular case of 
+#' @description Factor analysis of mixed data (FAMD) is a particular case of
 #'   MFA, used to analyze a data set containing both quantitative and
 #'   qualitative variables. fviz_famd() provides ggplot2-based elegant
 #'   visualization of FAMD outputs from the R function: FAMD [FactoMineR].\cr\cr
@@ -18,12 +18,12 @@ NULL
 #' @param choice The graph to plot in fviz_famd_var(). Allowed values include
 #'   one of c("var", "quanti.var", "quali.var", "quali.sup").
 #' @param habillage an optional factor variable for coloring the observations by
-#'   groups. Default value is "none". If X is an MFA object from FactoMineR 
+#'   groups. Default value is "none". If X is a FAMD object from FactoMineR
 #'   package, habillage can also specify the index of the factor variable in the
 #'   data.
 #' @param col.ind,col.var color for individuals and variables, respectively. Can
-#'   be a continuous variable or a factor variable. Possible values include also
-#'   : "cos2", "contrib", "coord", "x" or "y". In this case, the colors for
+#'   be a continuous variable or a factor variable. Possible values also include
+#'   "cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 #'   individuals/variables are automatically controlled by their qualities
 #'   ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 , "coord"), x
 #'   values("x") or y values("y"). To use automatic coloring (by cos2, contrib,
@@ -32,8 +32,8 @@ NULL
 #' @param col.quali.var color for qualitative variables in fviz_famd_ind(). 
 #'   Default is "black".
 #' @param alpha.ind,alpha.var controls the transparency of individuals and 
-#'   variables, respectively. The value can variate from 0 (total transparency) 
-#'   to 1 (no transparency). Default value is 1. Possible values include also : 
+#'   variables, respectively. The value can vary from 0 (total transparency)
+#'   to 1 (no transparency). Default value is 1. Possible values also include
 #'   "cos2", "contrib", "coord", "x" or "y". In this case, the transparency for 
 #'   individual/variable colors are automatically controlled by their qualities 
 #'   ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 , "coord"), x 
@@ -48,14 +48,14 @@ NULL
 #'   then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5,
 #'   then the top 5 individuals/variables with the highest cos2 are drawn. \item
 #'   contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with
-#'   the highest cos2 are drawn \item union: logical. When several of
+#'   the highest contributions are drawn \item union: logical. When several of
 #'   name/cos2/contrib are given, FALSE (default) combines them with AND (each
 #'   condition further narrows the selection); TRUE combines them with OR (an
 #'   element is kept if it matches any condition), e.g. named items \emph{plus}
 #'   the top-cos2 ones. }
 #' @param ... Arguments to be passed to the function fviz()
-#' @param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'   labels or not. The old \code{jitter} argument is kept for backward
+#' @param repel logical; whether to use ggrepel to avoid overplotting text
+#'   labels. The old \code{jitter} argument is kept for backward
 #'   compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #' @return a ggplot
 #' @author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}

--- a/R/fviz_hmfa.R
+++ b/R/fviz_hmfa.R
@@ -2,7 +2,7 @@
 NULL
 #'Visualize Hierarchical Multiple Factor Analysis
 #'
-#'@description Hierarchical Multiple Factor Analysis (HMFA) is, an extension of
+#'@description Hierarchical Multiple Factor Analysis (HMFA) is an extension of
 #'  MFA, used in a situation where the data are organized into a hierarchical
 #'  structure.  fviz_hmfa() provides ggplot2-based elegant visualization of HMFA
 #'  outputs from the R function: HMFA [FactoMineR].\cr\cr \itemize{
@@ -19,7 +19,7 @@ NULL
 #'  data.
 #'@param col.ind,col.var color for individuals, partial individuals and 
 #'  variables, respectively. Can be a continuous variable or a factor variable.
-#'  Possible values include also : "cos2", "contrib", "coord", "x" or "y". In
+#'  Possible values also include "cos2", "contrib", "coord", "x", and "y". In
 #'  this case, the colors for individuals/variables are automatically controlled
 #'  by their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 +
 #'  y^2 , "coord"), x values("x") or y values("y"). To use automatic coloring
@@ -27,9 +27,9 @@ NULL
 #'@param col.partial color for partial individuals. By default, points are 
 #'  colored according to the groups.
 #'@param alpha.ind,alpha.var controls the transparency of individual, partial 
-#'  individual and variable, respectively. The value can variate from 0 (total 
+#'  individual and variable, respectively. The value can vary from 0 (total
 #'  transparency) to 1 (no transparency). Default value is 1. Possible values 
-#'  include also : "cos2", "contrib", "coord", "x" or "y". In this case, the 
+#'  also include "cos2", "contrib", "coord", "x", and "y". In this case, the
 #'  transparency for individual/variable colors are automatically controlled by 
 #'  their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 
 #'  , "coord"), x values("x") or y values("y"). To use this, make sure that 
@@ -37,7 +37,7 @@ NULL
 #'@param shape.ind,shape.var point shapes of individuals and variables, 
 #'  respectively.
 #'@param group.names a vector containing the name of the groups (by default, 
-#'  NULL and the group are named group.1, group.2 and so on).
+#'  NULL and the groups are named group.1, group.2, and so on).
 #'@param node.level a single number indicating the HMFA node level to plot.
 #'@param title the title of the graph
 #'@param select.ind,select.var a selection of individuals and variables to be 
@@ -47,7 +47,7 @@ NULL
 #'  then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
 #'  then the top 5 individuals/variables with the highest cos2 are drawn. \item 
 #'  contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-#'  the highest cos2 are drawn }
+#'  the highest contributions are drawn }
 #'@param choice the graph to plot. Allowed values include one of c("quanti.var",
 #'  "quali.var", "group") for plotting quantitative variables, qualitative 
 #'  variables and group of variables, respectively.
@@ -56,8 +56,8 @@ NULL
 #'  drawn. (by default, partial = NULL and no partial points are drawn). Use
 #'  partial = "all" to visualize partial points for all individuals.
 #'@param col.var.sup color for supplementary variables.
-#'@param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'  labels or not. The old \code{jitter} argument is kept for backward
+#'@param repel logical; whether to use ggrepel to avoid overplotting text
+#'  labels. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #'@return a ggplot
 #'@author Fabian Mundt \email{f.mundt@inventionate.de}

--- a/R/fviz_mca.R
+++ b/R/fviz_mca.R
@@ -5,7 +5,7 @@ NULL
 #'@description Multiple Correspondence Analysis (MCA) is an extension of simple 
 #'  CA to analyse a data table containing more than two categorical variables. 
 #'  fviz_mca() provides ggplot2-based elegant visualization of MCA outputs from 
-#'  the R functions: MCA [in FactoMineR], acm [in ade4], and expOutput/epMCA [in
+#'  the R functions: MCA [in FactoMineR], acm [in ade4], and expoOutput/epMCA [in
 #'  ExPosition]. Read more: 
 #'  \href{https://www.sthda.com/english/articles/31-principal-component-methods-in-r-practical-guide/114-mca-multiple-correspondence-analysis-in-r-essentials/}{Multiple
 #'   Correspondence Analysis Essentials.}
@@ -13,37 +13,37 @@ NULL
 #'  \itemize{ \item fviz_mca_ind(): Graph of individuals \item fviz_mca_var():
 #'  Graph of variables \item fviz_mca_biplot(): Biplot of individuals and
 #'  variables \item fviz_mca(): An alias of fviz_mca_biplot() }
-#'@param X an object of class MCA [FactoMineR], acm [ade4] and expOutput/epMCA
+#'@param X an object of class MCA [FactoMineR], acm [ade4] and expoOutput/epMCA
 #'  [ExPosition].
 #'@inheritParams fviz_pca
 #' @param geom.ind,geom.var as \code{geom} but for individuals and variables,
 #'   respectively. Default is geom.ind = c("point", "text), geom.var =
 #'   c("point", "text").
 #'@param label a text specifying the elements to be labelled. Default value is 
-#'  "all". Allowed values are "none" or the combination of c("ind", 
+#'  "all". Allowed values are "all", "none", or a combination of c("ind",
 #'  "ind.sup","var", "quali.sup",  "quanti.sup"). "ind" can be used to label 
 #'  only active individuals. "ind.sup" is for supplementary individuals. "var" 
 #'  is for active variable categories. "quali.sup" is for supplementary 
 #'  qualitative variable categories. "quanti.sup" is for quantitative 
 #'  supplementary variables.
 #'@param invisible a text specifying the elements to be hidden on the plot. 
-#'  Default value is "none". Allowed values are the combination of c("ind", 
+#'  Default value is "none". Allowed values are "all", "none", or a combination of c("ind",
 #'  "ind.sup","var", "quali.sup",  "quanti.sup").
 #'@param habillage an optional factor variable for coloring the observations by 
 #'  groups. Default value is "none". If X is an MCA object from FactoMineR 
 #'  package, habillage can also specify the index of the factor variable in the 
 #'  data.
 #'@param col.ind,col.var color for individuals and variables, respectively. Can 
-#'  be a continuous variable or a factor variable. Possible values include also
-#'  : "cos2", "contrib", "coord", "x" or "y". In this case, the colors for
+#'  be a continuous variable or a factor variable. Possible values also include
+#'  "cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 #'  individuals/variables are automatically controlled by their qualities
 #'  ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 , "coord"), x
 #'  values("x") or y values("y"). To use automatic coloring (by cos2, contrib,
 #'  ....), make sure that habillage ="none".
 #'@param alpha.ind,alpha.var controls the transparency of individual and 
-#'  variable colors, respectively. The value can variate from 0 (total 
+#'  variable colors, respectively. The value can vary from 0 (total
 #'  transparency) to 1 (no transparency). Default value is 1. Possible values 
-#'  include also : "cos2", "contrib", "coord", "x" or "y". In this case, the 
+#'  also include "cos2", "contrib", "coord", "x", and "y". In this case, the
 #'  transparency for individual/variable colors are automatically controlled by 
 #'  their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 
 #'  , "coord"), x values("x") or y values("y"). To use this, make sure that 
@@ -56,8 +56,8 @@ NULL
 #'  individuals / biplot map as correlation arrows (see the Details section).
 #'  Default \code{FALSE} leaves the map unchanged. Used by \code{fviz_mca_ind()}
 #'  and \code{fviz_mca_biplot()}.
-#'@param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'  labels or not. The old \code{jitter} argument is kept for backward
+#'@param repel logical; whether to use ggrepel to avoid overplotting text
+#'  labels. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #'@param choice the graph to plot. Allowed values include: i) "var" and 
 #'  "mca.cor" for plotting the correlation between variables and principal 
@@ -78,8 +78,8 @@ NULL
 #'  the top-cos2 ones. }
 #'@inheritParams ggpubr::ggpar
 #'@inheritParams fviz
-#'@param ... Additional arguments. \itemize{ \item in fviz_mca_ind(), 
-#'  fviz_mca_var() and fviz_mca_cor(): Additional arguments are passed to the 
+#'@param ... Additional arguments. \itemize{ \item in fviz_mca_ind() and
+#'  fviz_mca_var() (including \code{choice = "mca.cor"}): Additional arguments are passed to the
 #'  functions fviz() and ggpubr::ggpar(). \item in fviz_mca_biplot() and 
 #'  fviz_mca(): Additional arguments are passed to fviz_mca_ind() and 
 #'  fviz_mca_var().}
@@ -319,5 +319,3 @@ fviz_mca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
 fviz_mca <- function(X, ...){
   fviz_mca_biplot(X, ...)
 }
-
-

--- a/R/fviz_mfa.R
+++ b/R/fviz_mfa.R
@@ -27,7 +27,7 @@ NULL
 #'  data.
 #'@param col.ind,col.var,col.axes color for individuals, variables and col.axes 
 #'  respectively. Can be a continuous variable or a factor variable. Possible
-#'  values include also : "cos2", "contrib", "coord", "x" or "y". In this case,
+#'  values also include "cos2", "contrib", "coord", "x", and "y". In this case,
 #'  the colors for individuals/variables are automatically controlled by their
 #'  qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 ,
 #'  "coord"), x values("x") or y values("y"). To use automatic coloring (by
@@ -36,9 +36,9 @@ NULL
 #'  colored according to the groups.
 #'@param col.var.sup color for supplementary variables.
 #'@param alpha.ind,alpha.var,alpha.axes controls the transparency of individual,
-#'  variable, group and axes colors, respectively. The value can variate from 0 
+#'  variable, group and axes colors, respectively. The value can vary from 0
 #'  (total transparency) to 1 (no transparency). Default value is 1. Possible 
-#'  values include also : "cos2", "contrib", "coord", "x" or "y". In this case, 
+#'  values also include "cos2", "contrib", "coord", "x", and "y". In this case,
 #'  the transparency for individual/variable colors are automatically controlled
 #'  by their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + 
 #'  y^2 , "coord"), x values("x") or y values("y"). To use this, make sure that 
@@ -55,14 +55,14 @@ NULL
 #'  if cos2 is in [0, 1], ex: 0.6, then individuals/variables with a cos2 > 0.6 
 #'  are drawn. if cos2 > 1, ex: 5, then the top 5 individuals/variables with the
 #'  highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the top 5
-#'  individuals/variables with the highest cos2 are drawn \item union: logical.
+#'  individuals/variables with the highest contributions are drawn \item union: logical.
 #'  When several of name/cos2/contrib are given, FALSE (default) combines them
 #'  with AND (each condition further narrows the selection); TRUE combines them
 #'  with OR (an element is kept if it matches any condition), e.g. named items
 #'  \emph{plus} the top-cos2 ones. }
 #'@param ... Arguments to be passed to the function fviz()
-#'@param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'  labels or not. The old \code{jitter} argument is kept for backward
+#'@param repel logical; whether to use ggrepel to avoid overplotting text
+#'  labels. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #'@param partial list of the individuals for which the partial points should be
 #'  drawn. (by default, partial = NULL and no partial points are drawn). Use

--- a/R/fviz_silhouette.R
+++ b/R/fviz_silhouette.R
@@ -1,10 +1,10 @@
 #' @include eigenvalue.R get_pca.R hcut.R
  NULL
 #'Visualize Silhouette Information from Clustering
-#'@description Silhouette (Si) analysis is a cluster validation approach that
-#'  measures how well an observation is clustered and it estimates the average
-#'  distance between clusters. fviz_silhouette() provides ggplot2-based elegant
-#'  visualization of silhouette information from i) the result of
+#'@description Silhouette (Si) analysis compares an observation's average
+#'  dissimilarity within its assigned cluster with its average dissimilarity to
+#'  the nearest alternative cluster. \code{fviz_silhouette()} provides a
+#'  ggplot2-based visualization of silhouette information from i) the result of
 #'  \code{\link[cluster]{silhouette}}(), \code{\link[cluster]{pam}}(),
 #'  \code{\link[cluster]{clara}}() and \code{\link[cluster]{fanny}}() [in
 #'  cluster package]; ii) \code{\link{eclust}}() and \code{\link{hcut}}() [in
@@ -14,24 +14,26 @@
 #'  Read more: 
 #'  \href{https://www.datanovia.com/en/lessons/cluster-validation-statistics-must-know-methods/}{Clustering
 #'   Validation Statistics}.
-#'@details - Observations with a large silhouhette Si (almost 1) are very well 
+#'@details - Observations with a large silhouette Si (almost 1) are very well
 #'  clustered.
 #'  
 #'  - A small Si (around 0) means that the observation lies between two
 #'  clusters.
 #'  
-#'  - Observations with a negative Si are probably placed in the wrong cluster.
+#'  - A negative Si means that the observation is, on average, closer to another
+#'  cluster than to its assigned cluster.
 #'
 #'  - Silhouette plots require at least two clusters and available silhouette
 #'  widths.
 #'  
-#'@param sil.obj an object of class silhouette: pam, clara, fanny [in cluster
-#'  package]; eclust and hcut [in factoextra]. For \code{eclust} and
+#'@param sil.obj an object of class \code{silhouette}, \code{pam},
+#'  \code{clara}, or \code{fanny} [cluster], or \code{eclust} or \code{hcut}
+#'  [factoextra]. For \code{eclust} and
 #'  \code{hcut}, silhouette information must be available, which requires at
 #'  least two clusters.
 #'@param label logical value. If true, x axis tick labels are shown
-#'@param print.summary logical value. If true a summary of cluster silhouettes 
-#'  are printed in fviz_silhouette().
+#'@param print.summary logical value. If TRUE, a summary of cluster silhouettes
+#'  is printed by \code{fviz_silhouette()}.
 #' @param ... other arguments to be passed to the function ggpubr::ggpar().
 #'  
 #'@return a ggplot2 object.

--- a/R/get_ca.R
+++ b/R/get_ca.R
@@ -13,7 +13,7 @@ NULL
 #' @param res.ca an object of class CA [FactoMineR], ca [ca], coa [ade4];
 #'  correspondence [MASS].
 #' @param element the element to subset from the output. Possible values are "row" or "col".
-#' @return a list of matrices containing the results for the active rows/columns including : 
+#' @return a list of matrices containing the results for the active rows/columns, including:
 #' \item{coord}{coordinates for the rows/columns}
 #' \item{cos2}{cos2 for the rows/columns}
 #' \item{contrib}{contributions of the rows/columns}
@@ -225,4 +225,3 @@ get_ca_row <- function(res.ca){
   class(row)<-c("factoextra", "ca_row")
   return(row)
 }
-

--- a/R/get_famd.R
+++ b/R/get_famd.R
@@ -14,7 +14,7 @@ NULL
 #' @param element the element to subset from the output. Possible values are
 #'   "ind", "var", "quanti.var", "quali.var" or "quali.sup".
 #' @return a list of matrices containing the results for the active 
-#' individuals and variables, including : 
+#' individuals and variables, including:
 #' \item{coord}{coordinates of individuals/variables.}
 #' \item{cos2}{cos2 values representing the quality of representation on the factor map.}
 #' \item{contrib}{contributions of individuals / variables to the principal components.}

--- a/R/get_hmfa.R
+++ b/R/get_hmfa.R
@@ -7,15 +7,15 @@ NULL
 #' variable categories/groups/partial axes from Hierarchical Multiple Factor
 #' Analysis (HMFA) outputs.\cr\cr \itemize{ \item get_hmfa(): Extract the
 #' results for variables and individuals \item get_hmfa_ind(): Extract the
-#' results for individuals only \item get_mfa_var(): Extract the results for
-#' variables (quantitatives, qualitatives and groups) 
+#' results for individuals only \item get_hmfa_var(): Extract the results for
+#' quantitative variables, qualitative variables, and groups
 #' \item get_hmfa_partial(): Extract the results for partial.node. }
 #' 
 #' @param res.hmfa an object of class HMFA [FactoMineR].
 #' @param element the element to subset from the output. Possible values are
 #'   "ind", "quanti.var", "quali.var", "group" or "partial.node".
 #' @return a list of matrices containing the results for the active 
-#'   individuals, variables, groups and partial nodes, including : 
+#'   individuals, variables, groups, and partial nodes, including:
 #'   \item{coord}{coordinates} \item{cos2}{cos2} 
 #'   \item{contrib}{contributions}
 #' @author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}

--- a/R/get_mca.R
+++ b/R/get_mca.R
@@ -19,7 +19,7 @@ NULL
 #'   between variables and principal dimensions, and "quanti.sup" for
 #'   quantitative supplementary variables in FactoMineR MCA results.
 #' @return a list of matrices containing the results for the active 
-#'   individuals/variable categories including : \item{coord}{coordinates for 
+#'   individuals/variable categories, including: \item{coord}{coordinates for
 #'   the individuals/variable categories} \item{cos2}{cos2 for the 
 #'   individuals/variable categories} \item{contrib}{contributions of the 
 #'   individuals/variable categories} \item{inertia}{inertia of the 

--- a/R/get_mfa.R
+++ b/R/get_mfa.R
@@ -8,7 +8,8 @@ NULL
 #' \itemize{
 #' \item get_mfa(): Extract the results for variables and individuals
 #' \item get_mfa_ind(): Extract the results for individuals only
-#' \item get_mfa_var(): Extract the results for variables (quantitatives, qualitatives and groups)
+#' \item get_mfa_var(): Extract the results for quantitative variables,
+#' qualitative variables, and groups
 #' \item get_mfa_partial_axes(): Extract the results for partial axes only
 #' }   
 #'     
@@ -18,7 +19,8 @@ NULL
 #'   "ind", "quanti.var", "quali.var", "quali.sup", "group" or
 #'   "partial.axes".
 #' @return a list of matrices containing the results for the active 
-#' individuals/quantitative variable categories/qualitative variable categories/groups/partial axes including : 
+#' individuals, quantitative variables, qualitative variable categories, groups,
+#' and partial axes, including:
 #' \item{coord}{coordinates for the individuals/quantitative variable categories/qualitative variable categories/groups/partial axes}
 #' \item{cos2}{cos2 for the individuals/quantitative variable categories/qualitative variable categories/groups/partial axes}
 #' \item{contrib}{contributions of the individuals/quantitative variable categories/qualitative variable categories/groups/partial axes}

--- a/R/hkmeans.R
+++ b/R/hkmeans.R
@@ -21,7 +21,7 @@
 #' @param iter.max the maximum number of iterations allowed for k-means.
 #' @param km.algorithm the algorithm to be used for kmeans (see ?kmeans).
 #' @details 
-#' The procedure is as follow:   
+#' The procedure is as follows:
 #'      
 #' 1. Compute hierarchical clustering
 #'    

--- a/R/print.factoextra.R
+++ b/R/print.factoextra.R
@@ -8,7 +8,7 @@
 #' @examples
 #'  data(iris)
 #'  res.pca <- prcomp(iris[, -5],  scale = TRUE)
-#'  ind <- get_pca_ind(res.pca, data = iris[, -5])
+#'  ind <- get_pca_ind(res.pca)
 #'  print(ind)
 #'  
 #' @export

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,20 +22,20 @@
 #' @param lib Library path to check. Default is the first library in .libPaths().
 #' @param ask Logical. If TRUE (default), asks for confirmation before removing.
 #'
-#' @return Invisibly returns TRUE if files were removed, FALSE otherwise.
+#' @return Invisibly returns \code{TRUE} only when every discovered lock
+#'   directory is removed. Returns \code{FALSE} when no lock directories are
+#'   found, removal is declined, or any removal fails.
 #' @keywords internal
 #'
 #' @examples
-#' \dontrun{
-#' # Remove factoextra lock file
-#' clean_lock_files()
-#'
-#' # Remove all lock files
-#' clean_lock_files("all")
-#'
-#' # Remove without confirmation
-#' clean_lock_files(ask = FALSE)
-#' }
+#' # Use a temporary library so the example cannot affect installed packages.
+#' example_lib <- tempfile("factoextra-lock-example-")
+#' example_lock <- file.path(example_lib, "00LOCK-factoextra")
+#' dir.create(example_lock, recursive = TRUE)
+#' clean_locks <- getFromNamespace("clean_lock_files", "factoextra")
+#' clean_locks(lib = example_lib, ask = FALSE)
+#' stopifnot(!dir.exists(example_lock))
+#' unlink(example_lib, recursive = TRUE)
 clean_lock_files <- function(package = "factoextra", lib = .libPaths()[1], ask = TRUE) {
 
   if (package == "all") {

--- a/man/clean_lock_files.Rd
+++ b/man/clean_lock_files.Rd
@@ -15,7 +15,9 @@ Default is "factoextra". Use "all" to remove all lock files.}
 \item{ask}{Logical. If TRUE (default), asks for confirmation before removing.}
 }
 \value{
-Invisibly returns TRUE if files were removed, FALSE otherwise.
+Invisibly returns \code{TRUE} only when every discovered lock
+  directory is removed. Returns \code{FALSE} when no lock directories are
+  found, removal is declined, or any removal fails.
 }
 \description{
 Removes stale lock directories that can prevent package installation.
@@ -25,15 +27,13 @@ removed when installation completes. If installation is interrupted (e.g., by
 closing R or a crash), these lock files may remain and block future installations.
 }
 \examples{
-\dontrun{
-# Remove factoextra lock file
-clean_lock_files()
-
-# Remove all lock files
-clean_lock_files("all")
-
-# Remove without confirmation
-clean_lock_files(ask = FALSE)
-}
+# Use a temporary library so the example cannot affect installed packages.
+example_lib <- tempfile("factoextra-lock-example-")
+example_lock <- file.path(example_lib, "00LOCK-factoextra")
+dir.create(example_lock, recursive = TRUE)
+clean_locks <- getFromNamespace("clean_lock_files", "factoextra")
+clean_locks(lib = example_lib, ask = FALSE)
+stopifnot(!dir.exists(example_lock))
+unlink(example_lib, recursive = TRUE)
 }
 \keyword{internal}

--- a/man/eclust.Rd
+++ b/man/eclust.Rd
@@ -61,14 +61,14 @@ FUNcluster is a hierarchical clustering function such as one of "hclust",
 \item{hc_method}{the agglomeration method to be used (?hclust): "ward.D", 
 "ward.D2", "single", "complete", "average", ...}
 
-\item{gap_maxSE}{a list containing the parameters (method and SE.factor) for 
-determining the location of the maximum of the gap statistic (Read the 
-documentation ?cluster::maxSE).}
+\item{gap_maxSE}{a list containing the \code{method} and \code{SE.factor}
+parameters passed to \code{\link[cluster]{maxSE}}. The default is
+\code{list(method = "firstSEmax", SE.factor = 1)}.}
 
 \item{nboot}{integer, number of Monte Carlo ("bootstrap") samples. Used only 
-for determining the number of clusters using gap statistic.}
+for determining the number of clusters using the gap statistic.}
 
-\item{verbose}{logical value. If TRUE, the result of progress is printed.}
+\item{verbose}{logical value. If TRUE, progress information is printed.}
 
 \item{seed}{integer used for seeding the random number generator.}
 
@@ -86,7 +86,7 @@ Returns an object of class "eclust" containing the result of the
   width of each cluster) and $avg.width (average width of all clusters)
   \item size: the size of clusters \item data: a matrix containing the
   original or the standardized data (if stand = TRUE) } The "eclust" class
-  has method for fviz_silhouette(), fviz_dend(), fviz_cluster().
+  has methods for fviz_silhouette(), fviz_dend(), and fviz_cluster().
 }
 \description{
 Provides a convenient workflow for clustering analyses and

--- a/man/facto_summarize.Rd
+++ b/man/facto_summarize.Rd
@@ -26,10 +26,10 @@ and princomp [stats]; dudi, pca, coa and acm [ade4]; ca [ca package]; expoOutput
 \item{node.level}{a single number indicating the HMFA node level.}
 
 \item{group.names}{a vector containing the name of the groups (by default, 
-NULL and the group are named group.1, group.2 and so on).}
+NULL and the groups are named group.1, group.2, and so on).}
 
 \item{result}{the result to be extracted for the element. Possible values are
-the combination of c("cos2", "contrib", "coord")}
+any combination of \code{c("coord", "cos2", "contrib")}.}
 
 \item{axes}{a numeric vector specifying the axes of interest. Values must be
 positive integer indices within the available dimensions. Default values
@@ -41,12 +41,12 @@ NULL, cos2 = NULL, contrib = NULL): \itemize{ \item name: is a character
 vector containing variable names to be selected \item cos2: if cos2 is in 
 [0, 1], ex: 0.6, then variables with a cos2 > 0.6 are selected. if cos2 > 
 1, ex: 5, then the top 5 variables with the highest cos2 are selected \item
-contrib: if contrib > 1, ex: 5,  then the top 5 variables with the highest 
-cos2 are selected. }}
+contrib: if contrib > 1, ex: 5, then the top 5 variables with the highest
+contributions are selected. }}
 }
 \value{
-A data frame containing the (total) coord, cos2 and the contribution 
-  for the axes.
+A data frame containing the requested coordinates and the cos2 and
+  contribution metrics aggregated over the requested axes.
 }
 \description{
 Subset and summarize the results of Principal Component
@@ -60,7 +60,7 @@ Subset and summarize the results of Principal Component
 \details{
 If length(axes) > 1, then the columns contrib and cos2 correspond to
   the total contributions and total cos2 of the axes. In this case, the 
-  column coord is calculated as x^2 + y^2 + ...+; x, y, ... are the 
+  column coord is calculated as x^2 + y^2 + ...; x, y, ... are the
   coordinates of the points on the specified axes.
 }
 \examples{

--- a/man/fviz_add.Rd
+++ b/man/fviz_add.Rd
@@ -42,8 +42,8 @@ Allowed values are "point" or "arrow" or "text"}
 
 \item{linetype}{the linetype to be used when geom ="arrow"}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{font.family}{character vector specifying font family.}

--- a/man/fviz_ca.Rd
+++ b/man/fviz_ca.Rd
@@ -55,7 +55,7 @@ fviz_ca(X, ...)
 }
 \arguments{
 \item{X}{an object of class CA [FactoMineR], ca [ca], coa [ade4]; 
-correspondence [MASS] and expOutput/epCA [ExPosition].}
+correspondence [MASS] and expoOutput/epCA [ExPosition].}
 
 \item{axes}{a numeric vector of length 2 specifying the dimensions to be 
 plotted.}
@@ -76,8 +76,8 @@ variables. Default values are 19 for rows and 17 for columns.}
 "symmetric", "rowprincipal", "colprincipal", "symbiplot", "rowgab", 
 "colgab", "rowgreen" and "colgreen". See details}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{...}{Additional arguments. \itemize{ \item in fviz_ca_row() and 
@@ -87,7 +87,7 @@ arguments are passed to fviz_ca_row() and fviz_ca_col().}}
 
 \item{col.col, col.row}{color for column/row points. The default values are 
 "red" and "blue", respectively. Can be a continuous variable or a factor
-variable. Allowed values include also : "cos2", "contrib", "coord", "x" or
+variable. Allowed values also include "cos2", "contrib", "coord", "x", and
 "y". In this case, the colors for row/column variables are automatically
 controlled by their qualities ("cos2"), contributions ("contrib"),
 coordinates (x^2 + y^2, "coord"), x values("x") or y values("y")}
@@ -95,9 +95,9 @@ coordinates (x^2 + y^2, "coord"), x values("x") or y values("y")}
 \item{col.col.sup, col.row.sup}{colors for the supplementary column and row 
 points, respectively.}
 
-\item{alpha.col, alpha.row}{controls the transparency of colors. The value can 
-variate from 0 (total transparency) to 1 (no transparency). Default value is
-1. Allowed values include also : "cos2", "contrib", "coord", "x" or "y" as 
+\item{alpha.col, alpha.row}{controls the transparency of colors. The value
+ranges from 0 (total transparency) to 1 (no transparency). Default value is
+1. Allowed values also include "cos2", "contrib", "coord", "x", and "y", as
 for the arguments col.col and col.row.}
 
 \item{select.col, select.row}{a selection of columns/rows to be drawn. Allowed 
@@ -113,12 +113,12 @@ with OR (an element is kept if it matches any condition), e.g. named items
 \emph{plus} the top-cos2 ones. }}
 
 \item{label}{a character vector specifying the elements to be labelled. 
-Default value is "all". Allowed values are "none" or the combination of 
+Default value is "all". Allowed values are "all", "none", or a combination of
 c("row", "row.sup", "col", "col.sup"). Use "col" to label only active column
 variables; "col.sup" to label only supplementary columns; etc}
 
 \item{invisible}{a character value specifying the elements to be hidden on the
-plot. Default value is "none". Allowed values are the combination of 
+plot. Default value is "none". Allowed values are "all", "none", or a combination of
 c("row", "row.sup","col", "col.sup").}
 
 \item{arrows}{Vector of two logicals specifying if the plot should contain 
@@ -135,7 +135,7 @@ Correspondence analysis (CA) is an extension of Principal
  Component Analysis (PCA) suited to analyze frequencies formed by two 
  categorical variables. fviz_ca() provides ggplot2-based elegant 
  visualization of CA outputs from the R functions: CA [in FactoMineR], ca [in
- ca], coa [in ade4], correspondence [in MASS] and expOutput/epCA [in
+ ca], coa [in ade4], correspondence [in MASS] and expoOutput/epCA [in
  ExPosition]. Read more: 
  \href{https://www.sthda.com/english/articles/31-principal-component-methods-in-r-practical-guide/113-ca-correspondence-analysis-in-r-essentials/}{Correspondence
   Analysis}
@@ -179,12 +179,12 @@ res.ca <- CA(housetasks, graph=FALSE)
 
 # Biplot of rows and columns
 # ++++++++++++++++++++++++++
-# Symetric Biplot of rows and columns
+# Symmetric biplot of rows and columns
 fviz_ca_biplot(res.ca)
 
-# Asymetric biplot, use arrows for columns
+# Asymmetric biplot, use arrows for columns
 fviz_ca_biplot(res.ca, map ="rowprincipal",
- arrow = c(FALSE, TRUE))
+ arrows = c(FALSE, TRUE))
  
 # Keep only the labels for row points
 fviz_ca_biplot(res.ca, label ="row")

--- a/man/fviz_famd.Rd
+++ b/man/fviz_famd.Rd
@@ -53,12 +53,12 @@ values are the combination of \code{c("point", "arrow", "text")}. Use
 texts. Using \code{c("arrow", "text")} is sensible only for the graph of 
 variables.}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{habillage}{an optional factor variable for coloring the observations by
-groups. Default value is "none". If X is an MFA object from FactoMineR 
+groups. Default value is "none". If X is a FAMD object from FactoMineR
 package, habillage can also specify the index of the factor variable in the
 data.}
 
@@ -75,8 +75,8 @@ case a basic color palette is created using the function
 individuals when habillage != "none".}
 
 \item{col.ind, col.var}{color for individuals and variables, respectively. Can
-be a continuous variable or a factor variable. Possible values include also
-: "cos2", "contrib", "coord", "x" or "y". In this case, the colors for
+be a continuous variable or a factor variable. Possible values also include
+"cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 individuals/variables are automatically controlled by their qualities
 ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 , "coord"), x
 values("x") or y values("y"). To use automatic coloring (by cos2, contrib,
@@ -85,8 +85,8 @@ values("x") or y values("y"). To use automatic coloring (by cos2, contrib,
 \item{col.ind.sup}{color for supplementary individuals}
 
 \item{alpha.ind, alpha.var}{controls the transparency of individuals and 
-variables, respectively. The value can variate from 0 (total transparency) 
-to 1 (no transparency). Default value is 1. Possible values include also : 
+variables, respectively. The value can vary from 0 (total transparency)
+to 1 (no transparency). Default value is 1. Possible values also include
 "cos2", "contrib", "coord", "x" or "y". In this case, the transparency for 
 individual/variable colors are automatically controlled by their qualities 
 ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 , "coord"), x 
@@ -106,7 +106,7 @@ individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5,
 then the top 5 individuals/variables with the highest cos2 are drawn. \item
 contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with
-the highest cos2 are drawn \item union: logical. When several of
+the highest contributions are drawn \item union: logical. When several of
 name/cos2/contrib are given, FALSE (default) combines them with AND (each
 condition further narrows the selection); TRUE combines them with OR (an
 element is kept if it matches any condition), e.g. named items \emph{plus}
@@ -126,7 +126,7 @@ one of c("var", "quanti.var", "quali.var", "quali.sup").}
 a ggplot
 }
 \description{
-Factor analysis of mixed data (FAMD) is, a particular case of 
+Factor analysis of mixed data (FAMD) is a particular case of
   MFA, used to analyze a data set containing both quantitative and
   qualitative variables. fviz_famd() provides ggplot2-based elegant
   visualization of FAMD outputs from the R function: FAMD [FactoMineR].\cr\cr

--- a/man/fviz_hmfa.Rd
+++ b/man/fviz_hmfa.Rd
@@ -65,8 +65,8 @@ values are the combination of \code{c("point", "arrow", "text")}. Use
 texts. Using \code{c("arrow", "text")} is sensible only for the graph of 
 variables.}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{habillage}{an optional factor variable for coloring the observations by 
@@ -82,7 +82,7 @@ respectively.}
 
 \item{col.ind, col.var}{color for individuals, partial individuals and 
 variables, respectively. Can be a continuous variable or a factor variable.
-Possible values include also : "cos2", "contrib", "coord", "x" or "y". In
+Possible values also include "cos2", "contrib", "coord", "x", and "y". In
 this case, the colors for individuals/variables are automatically controlled
 by their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 +
 y^2 , "coord"), x values("x") or y values("y"). To use automatic coloring
@@ -91,9 +91,9 @@ y^2 , "coord"), x values("x") or y values("y"). To use automatic coloring
 \item{col.ind.sup}{color for supplementary individuals}
 
 \item{alpha.ind, alpha.var}{controls the transparency of individual, partial 
-individual and variable, respectively. The value can variate from 0 (total 
+individual and variable, respectively. The value can vary from 0 (total
 transparency) to 1 (no transparency). Default value is 1. Possible values 
-include also : "cos2", "contrib", "coord", "x" or "y". In this case, the 
+also include "cos2", "contrib", "coord", "x", and "y". In this case, the
 transparency for individual/variable colors are automatically controlled by 
 their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 
 , "coord"), x values("x") or y values("y"). To use this, make sure that 
@@ -106,7 +106,7 @@ individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
 then the top 5 individuals/variables with the highest cos2 are drawn. \item 
 contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-the highest cos2 are drawn }}
+the highest contributions are drawn }}
 
 \item{partial}{list of the individuals for which the partial points should be
 drawn. (by default, partial = NULL and no partial points are drawn). Use
@@ -116,7 +116,7 @@ partial = "all" to visualize partial points for all individuals.}
 colored according to the groups.}
 
 \item{group.names}{a vector containing the name of the groups (by default, 
-NULL and the group are named group.1, group.2 and so on).}
+NULL and the groups are named group.1, group.2, and so on).}
 
 \item{node.level}{a single number indicating the HMFA node level to plot.}
 
@@ -134,7 +134,7 @@ variables and group of variables, respectively.}
 a ggplot
 }
 \description{
-Hierarchical Multiple Factor Analysis (HMFA) is, an extension of
+Hierarchical Multiple Factor Analysis (HMFA) is an extension of
  MFA, used in a situation where the data are organized into a hierarchical
  structure.  fviz_hmfa() provides ggplot2-based elegant visualization of HMFA
  outputs from the R function: HMFA [FactoMineR].\cr\cr \itemize{

--- a/man/fviz_mca.Rd
+++ b/man/fviz_mca.Rd
@@ -67,7 +67,7 @@ fviz_mca_biplot(
 fviz_mca(X, ...)
 }
 \arguments{
-\item{X}{an object of class MCA [FactoMineR], acm [ade4] and expOutput/epMCA
+\item{X}{an object of class MCA [FactoMineR], acm [ade4] and expoOutput/epMCA
 [ExPosition].}
 
 \item{axes}{a numeric vector of length 2 specifying the dimensions to be 
@@ -84,8 +84,8 @@ variables.}
 respectively. Default is geom.ind = c("point", "text), geom.var =
 c("point", "text").}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{habillage}{an optional factor variable for coloring the observations by 
@@ -106,8 +106,8 @@ case a basic color palette is created using the function
 individuals when habillage != "none".}
 
 \item{col.ind, col.var}{color for individuals and variables, respectively. Can 
-be a continuous variable or a factor variable. Possible values include also
-: "cos2", "contrib", "coord", "x" or "y". In this case, the colors for
+be a continuous variable or a factor variable. Possible values also include
+"cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 individuals/variables are automatically controlled by their qualities
 ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 , "coord"), x
 values("x") or y values("y"). To use automatic coloring (by cos2, contrib,
@@ -116,9 +116,9 @@ values("x") or y values("y"). To use automatic coloring (by cos2, contrib,
 \item{col.ind.sup}{color for supplementary individuals}
 
 \item{alpha.ind, alpha.var}{controls the transparency of individual and 
-variable colors, respectively. The value can variate from 0 (total 
+variable colors, respectively. The value can vary from 0 (total
 transparency) to 1 (no transparency). Default value is 1. Possible values 
-include also : "cos2", "contrib", "coord", "x" or "y". In this case, the 
+also include "cos2", "contrib", "coord", "x", and "y". In this case, the
 transparency for individual/variable colors are automatically controlled by 
 their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 
 , "coord"), x values("x") or y values("y"). To use this, make sure that 
@@ -152,8 +152,8 @@ and \code{fviz_mca_biplot()}.}
 \item{col.quanti.sup, col.quali.sup}{a color for the quantitative/qualitative
 supplementary variables.}
 
-\item{...}{Additional arguments. \itemize{ \item in fviz_mca_ind(), 
-fviz_mca_var() and fviz_mca_cor(): Additional arguments are passed to the 
+\item{...}{Additional arguments. \itemize{ \item in fviz_mca_ind() and
+fviz_mca_var() (including \code{choice = "mca.cor"}): Additional arguments are passed to the
 functions fviz() and ggpubr::ggpar(). \item in fviz_mca_biplot() and 
 fviz_mca(): Additional arguments are passed to fviz_mca_ind() and 
 fviz_mca_var().}}
@@ -164,7 +164,7 @@ dimensions; ii) "var.cat" for variable categories and iii) "quanti.sup" for
 the supplementary quantitative variables.}
 
 \item{label}{a text specifying the elements to be labelled. Default value is 
-"all". Allowed values are "none" or the combination of c("ind", 
+"all". Allowed values are "all", "none", or a combination of c("ind",
 "ind.sup","var", "quali.sup",  "quanti.sup"). "ind" can be used to label 
 only active individuals. "ind.sup" is for supplementary individuals. "var" 
 is for active variable categories. "quali.sup" is for supplementary 
@@ -172,7 +172,7 @@ qualitative variable categories. "quanti.sup" is for quantitative
 supplementary variables.}
 
 \item{invisible}{a text specifying the elements to be hidden on the plot. 
-Default value is "none". Allowed values are the combination of c("ind", 
+Default value is "none". Allowed values are "all", "none", or a combination of c("ind",
 "ind.sup","var", "quali.sup",  "quanti.sup").}
 
 \item{arrows}{Vector of two logicals specifying if the plot should contain 
@@ -188,7 +188,7 @@ a ggplot
 Multiple Correspondence Analysis (MCA) is an extension of simple 
  CA to analyse a data table containing more than two categorical variables. 
  fviz_mca() provides ggplot2-based elegant visualization of MCA outputs from 
- the R functions: MCA [in FactoMineR], acm [in ade4], and expOutput/epMCA [in
+ the R functions: MCA [in FactoMineR], acm [in ade4], and expoOutput/epMCA [in
  ExPosition]. Read more: 
  \href{https://www.sthda.com/english/articles/31-principal-component-methods-in-r-practical-guide/114-mca-multiple-correspondence-analysis-in-r-essentials/}{Multiple
   Correspondence Analysis Essentials.}

--- a/man/fviz_mfa.Rd
+++ b/man/fviz_mfa.Rd
@@ -79,8 +79,8 @@ values are the combination of \code{c("point", "arrow", "text")}. Use
 texts. Using \code{c("arrow", "text")} is sensible only for the graph of 
 variables.}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{habillage}{an optional factor variable for coloring the observations by 
@@ -102,7 +102,7 @@ individuals when habillage != "none".}
 
 \item{col.ind, col.var, col.axes}{color for individuals, variables and col.axes 
 respectively. Can be a continuous variable or a factor variable. Possible
-values include also : "cos2", "contrib", "coord", "x" or "y". In this case,
+values also include "cos2", "contrib", "coord", "x", and "y". In this case,
 the colors for individuals/variables are automatically controlled by their
 qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + y^2 ,
 "coord"), x values("x") or y values("y"). To use automatic coloring (by
@@ -111,9 +111,9 @@ cos2, contrib, ....), make sure that habillage ="none".}
 \item{col.ind.sup}{color for supplementary individuals}
 
 \item{alpha.ind, alpha.var, alpha.axes}{controls the transparency of individual,
-variable, group and axes colors, respectively. The value can variate from 0 
+variable, group and axes colors, respectively. The value can vary from 0
 (total transparency) to 1 (no transparency). Default value is 1. Possible 
-values include also : "cos2", "contrib", "coord", "x" or "y". In this case, 
+values also include "cos2", "contrib", "coord", "x", and "y". In this case,
 the transparency for individual/variable colors are automatically controlled
 by their qualities ("cos2"), contributions ("contrib"), coordinates (x^2 + 
 y^2 , "coord"), x values("x") or y values("y"). To use this, make sure that 
@@ -132,7 +132,7 @@ a character vector containing individuals/variables to be drawn \item cos2
 if cos2 is in [0, 1], ex: 0.6, then individuals/variables with a cos2 > 0.6 
 are drawn. if cos2 > 1, ex: 5, then the top 5 individuals/variables with the
 highest cos2 are drawn. \item contrib if contrib > 1, ex: 5,  then the top 5
-individuals/variables with the highest cos2 are drawn \item union: logical.
+individuals/variables with the highest contributions are drawn \item union: logical.
 When several of name/cos2/contrib are given, FALSE (default) combines them
 with AND (each condition further narrows the selection); TRUE combines them
 with OR (an element is kept if it matches any condition), e.g. named items

--- a/man/fviz_silhouette.Rd
+++ b/man/fviz_silhouette.Rd
@@ -7,15 +7,16 @@
 fviz_silhouette(sil.obj, label = FALSE, print.summary = TRUE, ...)
 }
 \arguments{
-\item{sil.obj}{an object of class silhouette: pam, clara, fanny [in cluster
-package]; eclust and hcut [in factoextra]. For \code{eclust} and
+\item{sil.obj}{an object of class \code{silhouette}, \code{pam},
+\code{clara}, or \code{fanny} [cluster], or \code{eclust} or \code{hcut}
+[factoextra]. For \code{eclust} and
 \code{hcut}, silhouette information must be available, which requires at
 least two clusters.}
 
 \item{label}{logical value. If true, x axis tick labels are shown}
 
-\item{print.summary}{logical value. If true a summary of cluster silhouettes 
-are printed in fviz_silhouette().}
+\item{print.summary}{logical value. If TRUE, a summary of cluster silhouettes
+is printed by \code{fviz_silhouette()}.}
 
 \item{...}{other arguments to be passed to the function ggpubr::ggpar().}
 }
@@ -23,10 +24,10 @@ are printed in fviz_silhouette().}
 a ggplot2 object.
 }
 \description{
-Silhouette (Si) analysis is a cluster validation approach that
- measures how well an observation is clustered and it estimates the average
- distance between clusters. fviz_silhouette() provides ggplot2-based elegant
- visualization of silhouette information from i) the result of
+Silhouette (Si) analysis compares an observation's average
+ dissimilarity within its assigned cluster with its average dissimilarity to
+ the nearest alternative cluster. \code{fviz_silhouette()} provides a
+ ggplot2-based visualization of silhouette information from i) the result of
  \code{\link[cluster]{silhouette}}(), \code{\link[cluster]{pam}}(),
  \code{\link[cluster]{clara}}() and \code{\link[cluster]{fanny}}() [in
  cluster package]; ii) \code{\link{eclust}}() and \code{\link{hcut}}() [in
@@ -38,13 +39,14 @@ Silhouette (Si) analysis is a cluster validation approach that
   Validation Statistics}.
 }
 \details{
-- Observations with a large silhouhette Si (almost 1) are very well 
+- Observations with a large silhouette Si (almost 1) are very well
  clustered.
  
  - A small Si (around 0) means that the observation lies between two
  clusters.
  
- - Observations with a negative Si are probably placed in the wrong cluster.
+ - A negative Si means that the observation is, on average, closer to another
+ cluster than to its assigned cluster.
 
  - Silhouette plots require at least two clusters and available silhouette
  widths.

--- a/man/get_ca.Rd
+++ b/man/get_ca.Rd
@@ -19,7 +19,7 @@ correspondence [MASS].}
 \item{element}{the element to subset from the output. Possible values are "row" or "col".}
 }
 \value{
-a list of matrices containing the results for the active rows/columns including : 
+a list of matrices containing the results for the active rows/columns, including:
 \item{coord}{coordinates for the rows/columns}
 \item{cos2}{cos2 for the rows/columns}
 \item{contrib}{contributions of the rows/columns}

--- a/man/get_famd.Rd
+++ b/man/get_famd.Rd
@@ -26,7 +26,7 @@ get_famd_var(
 }
 \value{
 a list of matrices containing the results for the active 
-individuals and variables, including : 
+individuals and variables, including:
 \item{coord}{coordinates of individuals/variables.}
 \item{cos2}{cos2 values representing the quality of representation on the factor map.}
 \item{contrib}{contributions of individuals / variables to the principal components.}

--- a/man/get_hmfa.Rd
+++ b/man/get_hmfa.Rd
@@ -26,7 +26,7 @@ get_hmfa_partial(res.hmfa)
 }
 \value{
 a list of matrices containing the results for the active 
-  individuals, variables, groups and partial nodes, including : 
+  individuals, variables, groups, and partial nodes, including:
   \item{coord}{coordinates} \item{cos2}{cos2} 
   \item{contrib}{contributions}
 }
@@ -36,8 +36,8 @@ contributions) for the active individuals/quantitative variables/qualitative
 variable categories/groups/partial axes from Hierarchical Multiple Factor
 Analysis (HMFA) outputs.\cr\cr \itemize{ \item get_hmfa(): Extract the
 results for variables and individuals \item get_hmfa_ind(): Extract the
-results for individuals only \item get_mfa_var(): Extract the results for
-variables (quantitatives, qualitatives and groups) 
+results for individuals only \item get_hmfa_var(): Extract the results for
+quantitative variables, qualitative variables, and groups
 \item get_hmfa_partial(): Extract the results for partial.node. }
 }
 \examples{

--- a/man/get_mca.Rd
+++ b/man/get_mca.Rd
@@ -22,7 +22,7 @@ quantitative supplementary variables in FactoMineR MCA results.}
 }
 \value{
 a list of matrices containing the results for the active 
-  individuals/variable categories including : \item{coord}{coordinates for 
+  individuals/variable categories, including: \item{coord}{coordinates for
   the individuals/variable categories} \item{cos2}{cos2 for the 
   individuals/variable categories} \item{contrib}{contributions of the 
   individuals/variable categories} \item{inertia}{inertia of the 

--- a/man/get_mfa.Rd
+++ b/man/get_mfa.Rd
@@ -30,7 +30,8 @@ get_mfa_partial_axes(res.mfa)
 }
 \value{
 a list of matrices containing the results for the active 
-individuals/quantitative variable categories/qualitative variable categories/groups/partial axes including : 
+individuals, quantitative variables, qualitative variable categories, groups,
+and partial axes, including:
 \item{coord}{coordinates for the individuals/quantitative variable categories/qualitative variable categories/groups/partial axes}
 \item{cos2}{cos2 for the individuals/quantitative variable categories/qualitative variable categories/groups/partial axes}
 \item{contrib}{contributions of the individuals/quantitative variable categories/qualitative variable categories/groups/partial axes}
@@ -42,7 +43,8 @@ for the active individuals/quantitative variables/qualitative variable categorie
 \itemize{
 \item get_mfa(): Extract the results for variables and individuals
 \item get_mfa_ind(): Extract the results for individuals only
-\item get_mfa_var(): Extract the results for variables (quantitatives, qualitatives and groups)
+\item get_mfa_var(): Extract the results for quantitative variables,
+qualitative variables, and groups
 \item get_mfa_partial_axes(): Extract the results for partial axes only
 }
 }

--- a/man/hkmeans.Rd
+++ b/man/hkmeans.Rd
@@ -61,7 +61,7 @@ the hierarchical clustering and the k-means methods. The procedure is explained 
 }
 }
 \details{
-The procedure is as follow:   
+The procedure is as follows:
      
 1. Compute hierarchical clustering
    

--- a/man/print.factoextra.Rd
+++ b/man/print.factoextra.Rd
@@ -17,7 +17,7 @@ Print method for an object of class factoextra
 \examples{
  data(iris)
  res.pca <- prcomp(iris[, -5],  scale = TRUE)
- ind <- get_pca_ind(res.pca, data = iris[, -5])
+ ind <- get_pca_ind(res.pca)
  print(ind)
  
 }


### PR DESCRIPTION
First batch of the staged integration of #274 (@erdeyl). Documentation only — no change to executable behavior.

### What's in this batch
Roxygen documentation, examples, and the regenerated `.Rd` for 17 help pages that #274 changed only in documentation:

- Contribution-based selection help now reads **"highest contributions"** (previously a copy of the cos2 wording) in `facto_summarize()`, `fviz_contrib()`/`fviz_cos2()`, and the FAMD/MFA/HMFA extractors.
- `fviz_famd()`'s `habillage` help refers to a **FAMD** object (was "MFA").
- ExPosition class name spelled **`expoOutput`** in `fviz_ca()` / `fviz_mca()`; the `fviz_ca()` example uses the real **`arrows`** argument (was `arrow`, which was silently ignored).
- `clean_lock_files()` example is now **self-contained** (runs in a temporary library instead of `\dontrun{}`).
- Assorted wording and `@return`/`@param` clarifications across `get_*` / `fviz_*`.

### Notes
- **Executable code is byte-identical to `release/2.2.0`** for every touched file (verified by stripping roxygen comments and diffing against base — zero non-comment differences).
- `.Rd` regenerated with **roxygen2 7.3.3** (our current toolchain; `RoxygenNote` unchanged). Unrelated pre-existing `.Rd` staleness was deliberately left out of this batch.
- Full suite green in a clean session: **FAIL 0 | WARN 0 | PASS 634** (1 unrelated skip: `fastICA` not installed).
- Both changed examples (`print.factoextra`, `clean_lock_files`) run under the current code.

This is a docs-only change, so there is no figure/output to show.

Part of the review split described in #274. Not for merge without maintainer approval.

Refs #274.
