### PR TITLE
ci: run R-CMD-check on release/** branches

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
 
 name: R-CMD-check
 


### PR DESCRIPTION
Small infra change so the staged integration of #274 gets full CI.

`R-CMD-check` currently triggers only for `main`/`master`. This adds `release/**` to both the `push` and `pull_request` branch filters, so PRs and pushes on `release/2.2.0` (and future release branches) run the same checks. Additive only — `main`/`master` triggers are unchanged; no job or matrix change.

Recommend merging this first so the batch PRs (starting with #275) get CI.

Refs #274.