### PR TITLE
Integrate #274 (3/7): scoped bug fixes + gap-stat maxSE fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,17 @@
   convenience for building it inline. The default (no `union`, or `union = FALSE`)
   is unchanged. Thanks to @qfazille (#53).
 
+## Main changes
+
+* `fviz_gap_stat()` (and `fviz_nbclust(method = "gap_stat")`): when a partial
+  `maxSE` list is supplied without a `method`, the fallback is now `"firstSEmax"`
+  (the documented default and `cluster::maxSE`'s default) instead of `"firstmax"`.
+  This only affects callers who pass, e.g., `maxSE = list(SE.factor = 2)` with no
+  `method`; the previous `"firstmax"` fallback silently ignored the `SE.factor`
+  they set (that rule does not use it). Default calls and calls that pass a
+  `method` are unchanged. `eclust()`'s internal gap default is aligned for
+  consistency. Thanks to @erdeyl (#274).
+
 ## Minor changes
 
 * `fviz_dend()`: corrected the documentation of the `type` argument, which listed
@@ -101,6 +112,25 @@
   `k.max`; `fviz_dend()` validates `k`/`h` against the tree; `get_clust_tendency()`
   checks `n` and requires finite data; and `as_factoextra_pca()` validates
   `scale.unit` and the supplied eigenvalues. Valid calls are unaffected.
+  Thanks to @erdeyl (#274).
+
+## Bug fixes
+
+* `fviz_ca_biplot()` / `fviz_ca()`: `invisible = "col.sup"` now hides
+  supplementary columns (the column branch was keyed off the row-supplementary
+  flag, so supplementary columns stayed visible). Thanks to @erdeyl (#274).
+* `fviz_mclust()` now applies the `ggtheme` argument to every plot type
+  (`"classification"`, `"uncertainty"`, `"BIC"`); it previously ignored it and
+  always used `theme_classic()`. The default is unchanged. Thanks to @erdeyl (#274).
+* `fviz_cluster()` now aligns a named clustering to the plotted data by row name
+  when both carry complete, unique, matching names, so points are not
+  mis-coloured when `data` is ordered differently from the clustering; it also
+  accepts a `clustering` component (as produced by `pam()`/`clara()`) in a custom
+  `list(data=, clustering=)` object. Assignments that do not line up by name are
+  used positionally, as before. Thanks to @erdeyl (#274).
+* `invisible = "all"` now hides all plotted elements (it was silently accepted
+  but had no effect); on the individual and variable maps, a selection by `name`
+  that includes names not present now warns instead of silently dropping them.
   Thanks to @erdeyl (#274).
 
 # factoextra 2.1.0

--- a/R/eclust.R
+++ b/R/eclust.R
@@ -231,7 +231,7 @@ eclust <- function(x, FUNcluster = c("kmeans", "pam", "clara", "fanny", "hclust"
 
 # Compute gap stat and get k
 .gap_stat <- function(x, fun_clust, k.max = 10, nboot = 100,
-                   gap_maxSE = list(method = "firstmax", SE.factor = 1),
+                   gap_maxSE = list(method = "firstSEmax", SE.factor = 1),
                    verbose = interactive(), ...)
   {
   gap_stat <- cluster::clusGap(x, fun_clust, K.max = k.max,  B = nboot, 

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -9,13 +9,13 @@ NULL
 #'  "text"). Use "point" (to show only points); "text" to show only labels; 
 #'  c("point", "text") or c("arrow", "text") to show both types.
 #'@param label a text specifying the elements to be labelled. Default value is 
-#'  "all". Allowed values are "none" or the combination of c("ind", "ind.sup", 
+#'  "all". Allowed values are "all", "none", or a combination of c("ind", "ind.sup",
 #'  "quali", "var", "quanti.sup", "group.sup"). "ind" can be used to label only 
 #'  active individuals. "ind.sup" is for supplementary individuals. "quali" is 
 #'  for supplementary qualitative variables. "var" is for active variables. 
 #'  "quanti.sup" is for quantitative supplementary variables.
 #'@param invisible a text specifying the elements to be hidden on the plot. 
-#'  Default value is "none". Allowed values are the combination of c("ind", 
+#'  Default value is "none". Allowed values are "all", "none", or a combination of c("ind",
 #'  "ind.sup", "quali", "var", "quanti.sup", "group.sup").
 #'@param labelsize font size for the labels
 #'@param pointsize the size of points
@@ -24,8 +24,8 @@ NULL
 #'@param arrow.linetype linetype of the variable arrows (e.g. "solid",
 #'  "dashed", "dotted"). Default is "solid".
 #'@param title the title of the graph
-#'@param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'  labels or not. The old \code{jitter} argument is kept for backward
+#'@param repel logical; whether to use ggrepel to avoid overplotting text
+#'  labels. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #'@param habillage an optional factor variable for coloring the observations by 
 #'  groups. Default value is "none". If X is a PCA object from FactoMineR 
@@ -72,8 +72,8 @@ NULL
 #'  \code{fviz_pca_var}, \code{fviz_pca_biplot}).
 #'@param axes.linetype linetype of x and y axes.
 #'@param color color to be used for the specified geometries (point, text). Can 
-#'  be a continuous variable or a factor variable. Possible values include also 
-#'  : "cos2", "contrib", "coord", "x" or "y". In this case, the colors for 
+#'  be a continuous variable or a factor variable. Possible values also include
+#'  "cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 #'  individuals/variables are automatically controlled by their qualities of 
 #'  representation ("cos2"), contributions ("contrib"), coordinates (x^2+y^2, 
 #'  "coord"), x values ("x") or y values ("y"). To use automatic coloring (by 
@@ -81,8 +81,8 @@ NULL
 #'@param fill same as the argument \code{color}, but for point fill color. 
 #'  Useful when pointshape = 21, for example.
 #'@param alpha controls the transparency of individual and variable colors, 
-#'  respectively. The value can variate from 0 (total transparency) to 1 (no 
-#'  transparency). Default value is 1. Possible values include also : "cos2", 
+#'  respectively. The value can vary from 0 (total transparency) to 1 (no
+#'  transparency). Default value is 1. Possible values also include "cos2",
 #'  "contrib", "coord", "x" or "y". In this case, the transparency for the 
 #'  individual/variable colors are automatically controlled by their qualities 
 #'  ("cos2"), contributions ("contrib"), coordinates (x^2+y^2, "coord"), x 
@@ -278,14 +278,41 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   }
   # Selection
   df.all <- df
+  # Resolve supplementary elements before validating selection names so a name
+  # that belongs only to a supplementary point is not reported as a typo.
+  esup <- .define_element_sup(
+    X, element, geom = geom, lab = lab, hide = hide,
+    col.row.sup = col.row.sup, col.col.sup = col.col.sup, ...
+  )
   if(!is.null(select) && !is.null(select$name) && .factominer_needs_category_map(facto.class, element)){
     select$name <- map_factominer_legacy_names(X, select$name, element = element)
+  }
+  if(!is.null(select) && !is.null(select$name)){
+    valid_selection_names <- as.character(df$name)
+    if(!is.null(esup$name)){
+      for(sup_element in esup$name){
+        sup_data <- tryCatch(
+          .get_supp(X, element = sup_element, axes = axes, result = "coord"),
+          error = function(e) NULL
+        )
+        if(!is.null(sup_data))
+          valid_selection_names <- c(valid_selection_names,
+                                     as.character(sup_data$name))
+      }
+    }
+    unmatched <- unique(setdiff(as.character(select$name),
+                                unique(valid_selection_names)))
+    if(length(unmatched))
+      warning("Selection name(s) not found: ",
+              paste0('"', unmatched, '"', collapse = ", "), ".",
+              call. = FALSE)
   }
   if(!is.null(select) && !is.null(select$contrib) && !("contrib" %in% colnames(df))
      && !isTRUE(select$union)){
     stop("Contributions are not available for element = '", element, "'.")
   }
-  if(!is.null(select)) df <- .select(df, select)
+  if(!is.null(select))
+    df <- .select(df, select, warn_unmatched = FALSE)
   
   # Special cases: data transformation
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -453,8 +480,6 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   # Supplementary elements: available only for FactoMineR
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   scale. <- ifelse(is.null(extra_args$scale.), 1, extra_args$scale.)
-  esup <- .define_element_sup(X, element, geom = geom, lab = lab, hide = hide,
-                              col.row.sup = col.row.sup, col.col.sup = col.col.sup,...) 
   ca_map = extra_args$map
   if(element == "mca.cor") ca_map = NULL
   
@@ -676,7 +701,7 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   # CA
   else if(element == "row" && inherits(X, c("CA", "ca")) && !hide$row.sup)
     res <- list(name = "row.sup", addlabel = (lab$row.sup && "text" %in% geom))
-  else if(element == "col" && inherits(X, c("CA", "ca")) && !hide$row.sup)
+  else if(element == "col" && inherits(X, c("CA", "ca")) && !hide$col.sup)
     res <- list(name = "col.sup", addlabel = (lab$col.sup && "text" %in% geom))
   else if(element == "group" && inherits(X, "MFA") && !hide$group.sup)
     res <- list(name = "group", addlabel = (lab$group.sup && "text" %in% geom))

--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -8,13 +8,16 @@
 #'  using principal components if ncol(data) > 2. An ellipse is drawn around
 #'  each cluster. When \code{stand = TRUE}, the plotting data must remain
 #'  finite after scaling.
-#'@param object an object of class "partition" created by the functions pam(),
-#'  clara() or fanny() in cluster package; "kmeans" [in stats package]; "dbscan"
-#'  [in fpc package]; "Mclust" [in mclust]; "hkmeans", "eclust" [in factoextra].
-#'  Possible value are also any list object with data and cluster components
-#'  (e.g.: object = list(data = mydata, cluster = myclust)).
-#'@param data the data that has been used for clustering. Required only when
-#'  object is a class of kmeans or dbscan.
+#'@param object an object of class "partition" created by \code{pam()},
+#'  \code{clara()}, or \code{fanny()} [cluster]; "kmeans" [stats]; "dbscan"
+#'  [fpc]; "Mclust" [mclust]; or "hkmeans" or "eclust" [factoextra]. A custom
+#'  list may instead contain \code{data} plus either \code{cluster} or
+#'  \code{clustering}. When the assignments and the data both carry complete,
+#'  unique, matching names, the assignments are aligned to the data rows by name;
+#'  otherwise they are used in their given (positional) order.
+#'@param data the data used for clustering. It is required for kmeans and dbscan
+#'  objects, and for partition or hcut objects fitted from dissimilarities when
+#'  those objects do not retain the original observations.
 #'@param choose.vars a character vector containing variables to be considered
 #'  for plotting.
 #'@param stand logical value; if TRUE, data is standardized before principal
@@ -25,8 +28,8 @@
 #'@param geom a text specifying the geometry to be used for the graph. Allowed
 #'  values are the combination of c("point", "text"). Use "point" (to show only
 #'  points);  "text" to show only labels; c("point", "text") to show both types.
-#'@param repel a boolean, whether to use ggrepel to avoid overplotting text
-#'  labels or not. The old \code{jitter} argument is kept for backward
+#'@param repel logical; whether to use ggrepel to avoid overplotting text
+#'  labels. The old \code{jitter} argument is kept for backward
 #'  compatibility and is converted to \code{repel = TRUE} with a deprecation warning.
 #'@param show.clust.cent logical; if TRUE, shows cluster centers
 #'@param ellipse logical value; if TRUE, draws outline around points of each
@@ -103,13 +106,13 @@
 #' # PAM clustering
 #' # ++++++++++++++++++++
 #' requireNamespace("cluster", quietly = TRUE)
-#' pam.res <- pam(iris.scaled, 3)
+#' pam.res <- cluster::pam(iris.scaled, 3)
 #'  # Visualize pam clustering
 #' fviz_cluster(pam.res, geom = "point", ellipse.type = "norm")
 #'
 #' # Hierarchical clustering
 #' # ++++++++++++++++++++++++
-#' # Use hcut() which compute hclust and cut the tree
+#' # Use hcut(), which computes hclust and cuts the tree
 #' hc.cut <- hcut(iris.scaled, k = 3, hc_method = "complete")
 #' # Visualize dendrogram
 #' fviz_dend(hc.cut, show_labels = FALSE, rect = TRUE)
@@ -187,20 +190,7 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
     # `data=`. pam()/fanny() fitted on a dissimilarity matrix store no
     # coordinates (object$data is NULL), so the original data is needed for the
     # 2-D layout; the cluster assignments still come from the object (#128).
-    if(!is.null(object$data)) data <- object$data
-    else if(!is.null(data)){
-      # Align the object's clustering to the supplied data's rows by name, so
-      # points are not silently mis-coloured if `data` is ordered differently
-      # from the dissimilarity. Error on a genuine set mismatch.
-      cl <- object$clustering
-      if(!is.null(cl) && !is.null(names(cl)) && !is.null(rownames(data))){
-        if(!setequal(names(cl), rownames(data)))
-          stop("The row names of `data` do not match the observations used to ",
-               "build the clustering. Pass the same data used for the ",
-               "dissimilarity matrix.", call. = FALSE)
-        object$clustering <- cl[rownames(data)]
-      }
-    }
+    if(!is.null(object[["data"]])) data <- object[["data"]]
     if(is.null(data))
       stop("This clustering has no stored data (e.g. pam()/fanny() on a ",
            "dissimilarity matrix). Supply the original data via 'data=' - it is ",
@@ -213,12 +203,12 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
   } 
   # Object from mclust package
   else if(inherits(object, "Mclust")) {
-    object$cluster <- object$classification
-    data <- object$data
+    object[["cluster"]] <- object[["classification"]]
+    data <- object[["data"]]
   }
   # HCPC in FactoMineR
   else if(inherits(object, "HCPC")) {
-    object$cluster <- object$call$X$clust
+    object[["cluster"]] <- object$call$X$clust
     data <- res.hcpc <- object
     stand <- FALSE # to avoid trying to standardize HCPC results
 #     data <- object$data.clust[, -ncol(object$data.clust), drop = FALSE]
@@ -231,9 +221,9 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
     else data <- object$data
   }
   # Any obects containing data and cluster elements
-  else if(!is.null(object$data) && !is.null(object$cluster)){
-    data <- object$data
-    cluster <- object$cluster
+  else if(!is.null(object[["data"]]) &&
+          (!is.null(object[["cluster"]]) || !is.null(object[["clustering"]]))){
+    data <- object[["data"]]
   }
   else stop("Can't handle an object of class ", paste(class(object), collapse = ", "))
   
@@ -245,7 +235,19 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
     if(anyNA(data))
       stop("Scaling produced NA values. Check for constant columns or non-finite values.")
   }
-  cluster <- as.factor(object$cluster)
+  cluster <- .cluster_assignments(object)
+  if(inherits(data, c("matrix", "data.frame"))){
+    observation_names <- rownames(data)
+    n_obs <- nrow(data)
+  } else if(inherits(data, "HCPC")){
+    observation_names <- rownames(data$call$X)
+    n_obs <- nrow(data$call$X)
+  } else {
+    observation_names <- NULL
+    n_obs <- length(cluster)
+  }
+  cluster <- .align_cluster_assignments(cluster, observation_names, n_obs)
+  cluster <- as.factor(cluster)
   
   pca_performed <- FALSE
   

--- a/R/fviz_mclust.R
+++ b/R/fviz_mclust.R
@@ -36,18 +36,18 @@ fviz_mclust <- function(object,
   what <- match.arg(what)
   if(what == "classification")
     p <- fviz_cluster(object, ellipse.type = ellipse.type, ellipse.level =ellipse.level,
-                      ggtheme = theme_classic(), ...)+
+                      ggtheme = ggtheme, ...)+
     labs(subtitle = "Classification")
   if(what == "uncertainty")
     p <- fviz_cluster(object, ellipse.type = ellipse.type, ellipse.level =ellipse.level,
-                      ggtheme = theme_classic(), geom = "none", ...)+
+                      ggtheme = ggtheme, geom = "none", ...)+
     geom_point(aes(size = uncertainty, color = cluster))+
     scale_size(range =c(0, 2))+
     labs(subtitle = "Uncertainty")+
     # FIX: ggplot2 3.3.4+ deprecation - use "none" instead of FALSE for guides()
     # See: https://github.com/kassambara/factoextra/issues/179
     guides(size = "none")
-  else if(what == "BIC") p <- fviz_mclust_bic(object, ggtheme = theme_classic(),  ...)
+  else if(what == "BIC") p <- fviz_mclust_bic(object, ggtheme = ggtheme,  ...)
   
   return(p)
 }
@@ -117,4 +117,3 @@ fviz_mclust_bic <- function(object, model.names = NULL, shape = 19, color = "mod
     guides(color = guide_legend(nrow=5,byrow=TRUE))
   else p + theme(legend.position = legend)
 }
-

--- a/R/fviz_nbclust.R
+++ b/R/fviz_nbclust.R
@@ -319,7 +319,7 @@ fviz_gap_stat <- function(gap_stat,  linecolor = "steelblue",
   # NULL keeps the historical behavior of marking the optimum; FALSE omits it.
   if(is.null(mark_optimal)) mark_optimal <- TRUE
   if(is.list(maxSE)){
-    if(is.null(maxSE$method)) maxSE$method = "firstmax"
+    if(is.null(maxSE$method)) maxSE$method = "firstSEmax"
     if(is.null(maxSE$SE.factor)) maxSE$SE.factor = 1
   }
   else stop("The argument maxSE must be a list containing the parameters method and SE.factor")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -72,6 +72,40 @@ NULL
   force(expr)
 }
 
+.cluster_assignments <- function(object){
+  cluster <- object[["cluster"]]
+  if(is.null(cluster)) cluster <- object[["clustering"]]
+  if(is.null(cluster))
+    stop("The clustering object has no `cluster` or `clustering` assignments.",
+         call. = FALSE)
+  cluster
+}
+
+.align_cluster_assignments <- function(cluster, observation_names, n_obs){
+  if(length(cluster) != n_obs)
+    stop("Cluster assignments and plotted observations do not match in length (",
+         length(cluster), " versus ", n_obs, ").",
+         call. = FALSE)
+
+  cluster_names <- names(cluster)
+  # Reorder the clustering to the data's row order ONLY when both sides carry
+  # complete, unique, matching names. Otherwise keep the positional order (the
+  # historical behaviour), so a clustering whose names do not line up with `data`
+  # still plots positionally instead of erroring. This fixes the reordering
+  # mis-colouring (#128) when names match, without regressing inputs that used to
+  # plot.
+  aligns_by_name <-
+    !is.null(cluster_names) && any(nzchar(cluster_names)) &&
+    length(cluster_names) == n_obs && !anyNA(cluster_names) &&
+    all(nzchar(cluster_names)) &&
+    !is.null(observation_names) && length(observation_names) == n_obs &&
+    !anyNA(observation_names) && all(nzchar(observation_names)) &&
+    !anyDuplicated(cluster_names) && !anyDuplicated(observation_names) &&
+    setequal(cluster_names, observation_names)
+  if(aligns_by_name) cluster <- cluster[observation_names]
+  cluster
+}
+
 # Pick row indices for a downsampled plot (used by max.points).
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # n          : total number of rows
@@ -617,16 +651,24 @@ NULL
 # - name: is a character vector containing row names of interest
 # - cos2: if cos2 is in [0, 1], ex: 0.6, then rows with a cos2 > 0.6 are extracted.
 #   if cos2 > 1, ex: 5, then the top 5 rows with the highest cos2 are extracted
-# - contrib: if contrib > 1, ex: 5,  then the top 5 rows with the highest cos2 are extracted
+# - contrib: if contrib > 1, ex: 5, then the top 5 rows with the highest contributions are extracted
 # - union: logical. When several of name/cos2/contrib are supplied, FALSE (default) combines
 #   them with AND (each condition narrows the survivors of the previous one - the historical
 #   behavior); TRUE combines them with OR (an element is kept if it matches ANY condition).
 #   union has an effect only when >= 2 conditions are present; with 0 or 1 condition the AND
 #   path below runs unchanged, so a single-condition selection is byte-identical to before.
 # check: if TRUE, check the data after filtering
-.select <- function(d, filter = NULL, check= TRUE){
+.select <- function(d, filter = NULL, check = TRUE, warn_unmatched = FALSE){
 
   if(!is.null(filter)){
+
+    if(warn_unmatched && !is.null(filter$name)){
+      unmatched <- setdiff(filter$name, d$name)
+      if(length(unmatched))
+        warning("Selection name(s) not found: ",
+                paste0('"', unmatched, '"', collapse = ", "), ".",
+                call. = FALSE)
+    }
 
     # Number of active selection conditions (union is a modifier, not a condition)
     n_cond <- sum(!is.null(filter$name), !is.null(filter$cos2), !is.null(filter$contrib))
@@ -674,7 +716,6 @@ NULL
     if(!is.null(filter$name)){
       name <- filter$name
       common <- intersect(name, d$name)
-      diff <- setdiff(name, d$name)
       d <- d[common, , drop = FALSE]
     }
 
@@ -875,7 +916,7 @@ NULL
   )
   .warn_unknown_elements(invisible, c("all", "none", element), "invisible")
   for(el in element){
-    if(el %in% invisible) hide[[el]] <- TRUE
+    if("all" %in% invisible || el %in% invisible) hide[[el]] <- TRUE
     else hide[[el]] <- FALSE
   }
   hide

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -63,14 +63,14 @@ value is "auto". Allowed values are the combination of c("point", "arrow",
 c("point", "text") or c("arrow", "text") to show both types.}
 
 \item{label}{a text specifying the elements to be labelled. Default value is 
-"all". Allowed values are "none" or the combination of c("ind", "ind.sup", 
+"all". Allowed values are "all", "none", or a combination of c("ind", "ind.sup",
 "quali", "var", "quanti.sup", "group.sup"). "ind" can be used to label only 
 active individuals. "ind.sup" is for supplementary individuals. "quali" is 
 for supplementary qualitative variables. "var" is for active variables. 
 "quanti.sup" is for quantitative supplementary variables.}
 
 \item{invisible}{a text specifying the elements to be hidden on the plot. 
-Default value is "none". Allowed values are the combination of c("ind", 
+Default value is "none". Allowed values are "all", "none", or a combination of c("ind",
 "ind.sup", "quali", "var", "quanti.sup", "group.sup").}
 
 \item{labelsize}{font size for the labels}
@@ -117,8 +117,8 @@ fill color. Use alpha = 0 for no fill color.}
 added to the plot.}
 
 \item{color}{color to be used for the specified geometries (point, text). Can 
-be a continuous variable or a factor variable. Possible values include also 
-: "cos2", "contrib", "coord", "x" or "y". In this case, the colors for 
+be a continuous variable or a factor variable. Possible values also include
+"cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 individuals/variables are automatically controlled by their qualities of 
 representation ("cos2"), contributions ("contrib"), coordinates (x^2+y^2, 
 "coord"), x values ("x") or y values ("y"). To use automatic coloring (by 
@@ -128,8 +128,8 @@ cos2, contrib, ....), make sure that habillage ="none".}
 Useful when pointshape = 21, for example.}
 
 \item{alpha}{controls the transparency of individual and variable colors, 
-respectively. The value can variate from 0 (total transparency) to 1 (no 
-transparency). Default value is 1. Possible values include also : "cos2", 
+respectively. The value can vary from 0 (total transparency) to 1 (no
+transparency). Default value is 1. Possible values also include "cos2",
 "contrib", "coord", "x" or "y". In this case, the transparency for the 
 individual/variable colors are automatically controlled by their qualities 
 ("cos2"), contributions ("contrib"), coordinates (x^2+y^2, "coord"), x 
@@ -157,8 +157,8 @@ matches any condition), e.g. named items \emph{plus} the top-cos2 ones. }}
 
 \item{axes.linetype}{linetype of x and y axes.}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{col.circle}{a color for the correlation circle. Used only when X is a 

--- a/man/fviz_cluster.Rd
+++ b/man/fviz_cluster.Rd
@@ -34,14 +34,17 @@ fviz_cluster(
 )
 }
 \arguments{
-\item{object}{an object of class "partition" created by the functions pam(),
-clara() or fanny() in cluster package; "kmeans" [in stats package]; "dbscan"
-[in fpc package]; "Mclust" [in mclust]; "hkmeans", "eclust" [in factoextra].
-Possible value are also any list object with data and cluster components
-(e.g.: object = list(data = mydata, cluster = myclust)).}
+\item{object}{an object of class "partition" created by \code{pam()},
+\code{clara()}, or \code{fanny()} [cluster]; "kmeans" [stats]; "dbscan"
+[fpc]; "Mclust" [mclust]; or "hkmeans" or "eclust" [factoextra]. A custom
+list may instead contain \code{data} plus either \code{cluster} or
+\code{clustering}. When the assignments and the data both carry complete,
+unique, matching names, the assignments are aligned to the data rows by name;
+otherwise they are used in their given (positional) order.}
 
-\item{data}{the data that has been used for clustering. Required only when
-object is a class of kmeans or dbscan.}
+\item{data}{the data used for clustering. It is required for kmeans and dbscan
+objects, and for partition or hcut objects fitted from dissimilarities when
+those objects do not retain the original observations.}
 
 \item{choose.vars}{a character vector containing variables to be considered
 for plotting.}
@@ -57,8 +60,8 @@ plotted.}
 values are the combination of c("point", "text"). Use "point" (to show only
 points);  "text" to show only labels; c("point", "text") to show both types.}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{show.clust.cent}{logical; if TRUE, shows cluster centers}
@@ -159,13 +162,13 @@ fviz_cluster(km.res, iris[, -5], geom = "text")
 # PAM clustering
 # ++++++++++++++++++++
 requireNamespace("cluster", quietly = TRUE)
-pam.res <- pam(iris.scaled, 3)
+pam.res <- cluster::pam(iris.scaled, 3)
  # Visualize pam clustering
 fviz_cluster(pam.res, geom = "point", ellipse.type = "norm")
 
 # Hierarchical clustering
 # ++++++++++++++++++++++++
-# Use hcut() which compute hclust and cut the tree
+# Use hcut(), which computes hclust and cuts the tree
 hc.cut <- hcut(iris.scaled, k = 3, hc_method = "complete")
 # Visualize dendrogram
 fviz_dend(hc.cut, show_labels = FALSE, rect = TRUE)

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -90,8 +90,8 @@ variables.}
 respectively. Default is geom.ind = c("point", "text), geom.var = 
 c("arrow", "text").}
 
-\item{repel}{a boolean, whether to use ggrepel to avoid overplotting text
-labels or not. The old \code{jitter} argument is kept for backward
+\item{repel}{logical; whether to use ggrepel to avoid overplotting text
+labels. The old \code{jitter} argument is kept for backward
 compatibility and is converted to \code{repel = TRUE} with a deprecation warning.}
 
 \item{habillage}{an optional factor variable for coloring the observations by

--- a/tests/testthat/test-edge-correctness.R
+++ b/tests/testthat/test-edge-correctness.R
@@ -37,3 +37,111 @@ test_that("fviz_dend validates k against the number of leaves", {
   expect_error(fviz_dend(hc, k = 1, rect = TRUE), "in \\[2, 5\\]")
   expect_s3_class(fviz_dend(hc, k = 1), "ggplot")
 })
+
+# ---- Batch C (PR #274) scoped bug fixes -------------------------------------
+
+test_that("fviz_cluster aligns exact named assignments, falls back to positional", {
+  set.seed(901)
+  x <- scale(USArrests)
+  km <- kmeans(x, centers = 3, nstart = 10)
+  reordered <- x[rev(seq_len(nrow(x))), , drop = FALSE]
+
+  # Exact, unique, matching names on both sides -> aligned by name.
+  p <- fviz_cluster(km, data = reordered, stand = FALSE, geom = "point",
+                    ellipse = FALSE, show.clust.cent = FALSE)
+  got <- setNames(as.character(p$data$cluster), p$data$name)
+  expect_equal(unname(got[rownames(reordered)]),
+               as.character(km$cluster[rownames(reordered)]))
+
+  # Non-regression: names that do not line up are used positionally (they still
+  # plot, as they did before this change) rather than erroring.
+  mismatched <- reordered; rownames(mismatched)[1] <- "not-an-observation"
+  expect_s3_class(fviz_cluster(km, data = mismatched, stand = FALSE,
+                               geom = "point", ellipse = FALSE), "ggplot")
+  duplicated <- reordered; rownames(duplicated)[1] <- rownames(duplicated)[2]
+  expect_s3_class(fviz_cluster(km, data = duplicated, stand = FALSE,
+                               geom = "point", ellipse = FALSE), "ggplot")
+  partially_named <- km; names(partially_named$cluster)[1] <- ""
+  expect_s3_class(fviz_cluster(partially_named, data = reordered, stand = FALSE,
+                               geom = "point", ellipse = FALSE), "ggplot")
+
+  # A genuine length mismatch is still a clear error.
+  short <- list(data = x[1:4, 1:2, drop = FALSE], cluster = 1:3)
+  expect_error(fviz_cluster(short, stand = FALSE), "do not match in length")
+
+  # `clustering` is accepted; when both are present, `cluster` wins.
+  both <- list(data = x[, 1:2, drop = FALSE],
+               cluster = setNames(rep(1L, nrow(x)), rownames(x)),
+               clustering = setNames(rep(2L, nrow(x)), rownames(x)))
+  both_plot <- fviz_cluster(both, stand = FALSE, geom = "point", ellipse = FALSE,
+                            show.clust.cent = FALSE)
+  expect_true(all(as.character(both_plot$data$cluster) == "1"))
+
+  clustering_only <- list(data = x[, 1:2, drop = FALSE],
+                          clustering = setNames(rep(3L, nrow(x)), rownames(x)))
+  expect_s3_class(fviz_cluster(clustering_only, stand = FALSE, geom = "point",
+                               ellipse = FALSE), "ggplot")
+})
+
+test_that("supplementary CA columns and invisible = all use the right flags", {
+  lab <- factoextra:::.label("all")
+  visible <- factoextra:::.define_element_sup(
+    structure(list(), class = "CA"), "col", "point", lab,
+    factoextra:::.hide("none")
+  )
+  hidden <- factoextra:::.define_element_sup(
+    structure(list(), class = "CA"), "col", "point", lab,
+    factoextra:::.hide("col.sup")
+  )
+  expect_identical(visible$name, "col.sup")
+  expect_null(hidden$name)
+  expect_true(all(unlist(factoextra:::.hide("all"))))
+
+  pca <- prcomp(iris[, -5], scale. = TRUE)
+  p <- fviz_pca_ind(pca, invisible = "all")
+  primary_geoms <- vapply(p$layers, function(layer) {
+    inherits(layer$geom, c("GeomPoint", "GeomText", "GeomTextRepel"))
+  }, logical(1))
+  expect_false(any(primary_geoms))
+})
+
+test_that("selection warns about unmatched names without dropping matches", {
+  # The plot path warns (esup-aware), keeping the matched names.
+  pca <- prcomp(iris[, -5], scale. = TRUE)
+  expect_warning(
+    p <- fviz_pca_ind(pca, select.ind = list(name = c("1", "typo")), geom = "point"),
+    "Selection name.*typo"
+  )
+  expect_true("1" %in% as.character(p$data$name))
+  expect_false("typo" %in% as.character(p$data$name))
+
+  # .select itself is silent by default (no leak into fviz_contrib/fviz_cos2),
+  # and warns only when explicitly asked (warn_unmatched = TRUE).
+  d <- data.frame(name = c("a", "b", "c"), cos2 = c(0.9, 0.2, 0.8),
+                  contrib = c(5, 3, 1), row.names = c("a", "b", "c"))
+  expect_silent(factoextra:::.select(d, list(name = c("a", "typo"))))
+  expect_warning(
+    selected <- factoextra:::.select(d, list(name = c("a", "typo")),
+                                     warn_unmatched = TRUE),
+    "Selection name.*typo"
+  )
+  expect_identical(selected$name, "a")
+})
+
+test_that("fviz_gap_stat maxSE fallback uses firstSEmax (honours SE.factor)", {
+  fake_gap <- structure(list(Tab = cbind(
+    gap = c(1, 1.5, 1.4), SE.sim = c(0.1, 0.6, 0.1)
+  )), class = "clusGap")
+  vline <- function(p){
+    layer <- Filter(function(x) inherits(x$geom, "GeomVline"), p$layers)[[1]]
+    layer$data$xintercept
+  }
+  # default call: firstSEmax (unchanged)
+  expect_equal(vline(fviz_gap_stat(fake_gap)), 1)
+  # partial list without method: NOW falls back to firstSEmax (was firstmax -> 2)
+  expect_equal(vline(fviz_gap_stat(fake_gap, maxSE = list(SE.factor = 1))), 1)
+  # explicit method is still honoured
+  expect_equal(vline(fviz_gap_stat(
+    fake_gap, maxSE = list(method = "firstmax", SE.factor = 1)
+  )), 2)
+})

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -1103,3 +1103,19 @@ test_that("hcut()/hkmeans() let the NATIVE k > n error surface (chooseGCM revdep
                "elements of 'k' must be between 1 and 11")
   expect_error(hkmeans(x, k = 100), "elements of 'k' must be between 1 and 11")
 })
+
+test_that("fviz_mclust honors ggtheme for every plot type", {
+  skip_if_not_installed("mclust")
+  suppressPackageStartupMessages(library(mclust))
+  on.exit(detach("package:mclust", unload = FALSE), add = TRUE)
+
+  set.seed(4)
+  model <- Mclust(iris[, -5], G = 2:4, verbose = FALSE)
+  custom_theme <- ggplot2::theme_minimal() +
+    ggplot2::theme(plot.background = ggplot2::element_rect(fill = "linen"))
+
+  for (what in c("classification", "uncertainty", "BIC")) {
+    plot <- fviz_mclust(model, what = what, ggtheme = custom_theme)
+    expect_equal(plot$theme$plot.background$fill, "linen")
+  }
+})


### PR DESCRIPTION
Third batch of the staged integration of #274 (@erdeyl). Scoped bug fixes, plus one announced default change (see below).

### Bug fixes
- **`fviz_ca_biplot()` / `fviz_ca()`** — `invisible = "col.sup"` now hides supplementary columns (the column branch was keyed off the *row*-supplementary flag, so they stayed visible).
- **`fviz_mclust()`** — applies the `ggtheme` argument to every plot type (`"classification"`, `"uncertainty"`, `"BIC"`) instead of always using `theme_classic()`. Default unchanged.
- **`fviz_cluster()`** — aligns a named clustering to the plotted data by row name when both carry complete, unique, matching names (so points aren't mis-coloured when `data` is ordered differently); also accepts a `clustering` component in a custom `list(data=, clustering=)`. Assignments that don't line up by name are used **positionally, exactly as before** — no previously-working plot becomes an error.
- **`invisible = "all"`** now hides all elements (it was silently accepted but did nothing); a name selection on the individual/variable maps now warns about names that aren't present instead of silently dropping them.

### Announced default change
- **`fviz_gap_stat()` / `fviz_nbclust(method = "gap_stat")` maxSE fallback** — when a caller passes a partial `maxSE` list *without* a `method` (e.g. `maxSE = list(SE.factor = 2)`), the fallback is now **`firstSEmax`** (the documented default and `cluster::maxSE`'s default) instead of `firstmax`. The old `firstmax` fallback silently ignored the `SE.factor` the caller set (that rule doesn't use it). **Default calls and calls that pass a `method` are unchanged.** `eclust()`'s internal gap default is aligned for consistency. A regression test pins the new behaviour.

### Notes
- Standard `fviz_ca` / `fviz_pca` / `fviz_cluster` / `fviz_mclust` output is **byte-identical to `release/2.2.0`** (verified across 13 standard configurations, including kmeans/pam/hcut/HCPC/Mclust and habillage).
- A test is added for every fix; each one fails if its fix is reverted.
- Two deliberate choices vs the source PR, made for non-regression: cluster-label alignment falls back to positional (never errors on un-matchable names), and the internal name-selection warning does not fire through `fviz_contrib()`/`fviz_cos2()`.
- Full suite green in a clean session: **FAIL 0 | WARN 0 | PASS 687** (1 unrelated skip: `fastICA`). `.Rd` regenerated with roxygen2 7.3.3.

Refs #274. Not for merge without maintainer approval.
