### PR TITLE
Integrate #274 (D1): get_pca individual contributions sum to 100 (FactoMineR-validated)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,16 @@
 
 ## Main changes
 
+* `get_pca_ind()`: individual contributions for `prcomp` objects, and for `ade4`
+  PCA objects with non-uniform row weights, are now normalized to sum to 100
+  percent per axis, matching `FactoMineR::PCA()`. Previously `prcomp` individual
+  contributions were divided by the (n-1)-normalized eigenvalue and summed to
+  `100 * (n - 1) / n` instead of 100. This changes the individual contribution
+  values returned for those objects (and any `fviz_contrib()` / `fviz_pca()`
+  colouring derived from them). `princomp` individual contributions, all
+  variable contributions, coordinates, and cos2 are unchanged. Cross-validated
+  against `FactoMineR::PCA()` and `ade4::inertia.dudi()`. Thanks to @erdeyl (#274).
+
 * `fviz_gap_stat()` (and `fviz_nbclust(method = "gap_stat")`): when a partial
   `maxSE` list is supplied without a `method`, the fallback is now `"firstSEmax"`
   (the documented default and `cluster::maxSE`'s default) instead of `"firstmax"`.

--- a/R/get_pca.R
+++ b/R/get_pca.R
@@ -3,22 +3,29 @@ NULL
 #' Extract the results for individuals/variables - PCA
 #' 
 #' @description
-#' Extract all the results (coordinates, squared cosine, contributions) for 
+#' Extract all the results (coordinates, squared cosines, and contributions) for
 #' the active individuals/variables from Principal Component Analysis (PCA) outputs.\cr\cr
 #' \itemize{
 #' \item get_pca(): Extract the results for variables and individuals
 #' \item get_pca_ind(): Extract the results for individuals only
 #' \item get_pca_var(): Extract the results for variables only
 #' }
-#' @param res.pca an object of class PCA [FactoMineR]; 
-#' prcomp and princomp [stats]; pca, dudi [adea4]; epPCA [ExPosition].
+#' @param res.pca an object of class PCA [FactoMineR]; \code{prcomp} or
+#' \code{princomp} [stats]; \code{factoextra_pca}; \code{pca}, \code{dudi},
+#' \code{between}, or \code{within} [ade4]; or \code{expoOutput}/\code{epPCA}
+#' [ExPosition].
 #' @param element the element to subset from the output. Allowed values are 
 #' "var" (for active variables) or "ind" (for active individuals).
 #' @param ... not used
 #' @return a list of matrices containing all the results for the active individuals/variables including: 
 #' \item{coord}{coordinates for the individuals/variables}
 #' \item{cos2}{cos2 for the individuals/variables}
-#' \item{contrib}{contributions of the individuals/variables}
+#' \item{contrib}{contributions of the individuals/variables; contributions to
+#' each nonzero-inertia axis sum to 100 percent, while a zero-inertia axis
+#' contains zeros}
+#' \item{cor}{loading-times-component-standard-deviation coordinates for PCA
+#' objects from \code{stats}; these equal variable-component correlations when
+#' the input variables were standardized. Returned for variables.}
 #' @author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}
 #' @references \url{https://www.sthda.com/english/}
 #' @examples
@@ -65,16 +72,10 @@ get_pca_ind<-function(res.pca, ...){
   # user-supplied coordinates wrapped by as_factoextra_pca()
   else if(inherits(res.pca, "factoextra_pca")) ind <- res.pca$ind
 
-  # ade4 package
+  # ade4 package. Use the dudi row/column metrics for both ordinary and
+  # between-/within-class PCA so nonuniform row weights are respected.
   else if(inherits(res.pca, "pca") && inherits(res.pca, "dudi")){
-    ind.coord <- res.pca$li
-    # OPTIMIZED: get the original data using vectorized sweep() instead of apply()
-    # sweep() is much faster than t(apply()) for element-wise row operations
-    data <- res.pca$tab
-    data <- sweep(data, 2, res.pca$norm, "*")
-    data <- sweep(data, 2, res.pca$cent, "+")
-    ind <- .get_pca_ind_results(ind.coord, data, res.pca$eig,
-                                res.pca$cent, res.pca$norm)
+    ind <- .get_dudi_class_ind_results(res.pca)
   }
 
   # ade4 between-class / within-class PCA (bca/wca). These dudi objects carry
@@ -133,9 +134,8 @@ get_pca_var<-function(res.pca){
   }
   # stats package
   else if(inherits(res.pca, 'princomp')){
-    # OPTIMIZED: Correlation of variables with the principal component
-    # Using sweep() instead of t(apply()) - much faster for element-wise operations
-    # var.cor[i,j] = loadings[i,j] * sdev[j]
+    # Loading-times-component-standard-deviation coordinates. For standardized
+    # variables these equal the variable-component correlations.
     # unclass() strips the base R "loadings" S3 class so coord/cos2/contrib are
     # returned as plain numeric matrices. Otherwise print.loadings() hides values
     # with |x| < 0.1 (its cutoff) and the result breaks downstream manipulation.
@@ -143,9 +143,8 @@ get_pca_var<-function(res.pca){
     var <- .get_pca_var_results(var.cor)
   }
   else if(inherits(res.pca, 'prcomp')){
-    # OPTIMIZED: Correlation of variables with the principal component
-    # Using sweep() instead of t(apply()) - much faster for element-wise operations
-    # var.cor[i,j] = rotation[i,j] * sdev[j]
+    # Loading-times-component-standard-deviation coordinates. For standardized
+    # variables these equal the variable-component correlations.
     var.cor <- sweep(res.pca$rotation, 2, res.pca$sdev, "*")
     var <- .get_pca_var_results(var.cor)
   }
@@ -174,7 +173,7 @@ get_pca_var<-function(res.pca){
 # ind.coord : coordinates of variables on the principal component
 # pca.center, pca.scale : numeric vectors corresponding to the pca
 # center and scale respectively
-# data : the orignal data used during the pca analysis
+# data : the original data used during the pca analysis
 # eigenvalues : principal component eigenvalues
 #
 # OPTIMIZATION: Replaced apply() loops with vectorized matrix operations
@@ -190,7 +189,6 @@ get_pca_var<-function(res.pca){
   ind.coord <- as.matrix(ind.coord)
   data <- as.matrix(data)
 
-  eigenvalues <- eigenvalues[seq_len(ncol(ind.coord))]
   n.ind <- nrow(ind.coord)
   n.dim <- ncol(ind.coord)
 
@@ -198,27 +196,18 @@ get_pca_var<-function(res.pca){
   if(isFALSE(pca.center[1])) pca.center <- rep(0, ncol(data))
   if(isFALSE(pca.scale[1])) pca.scale <- rep(1, ncol(data))
 
-  # OPTIMIZED: Compute squared distances using vectorized operations
-  # d2[i] = sum(((data[i,] - center) / scale)^2)
-  # Using sweep() for center/scale and rowSums() for summation
+  # Compute distances in the PCA metric. The squared-share helper rescales each
+  # row before squaring, so valid globally tiny or large inputs do not
+  # underflow or overflow merely because of their measurement units.
   data_centered <- sweep(data, 2, pca.center, "-")
   data_scaled <- sweep(data_centered, 2, pca.scale, "/")
-  d2 <- rowSums(data_scaled^2)
+  ind.cos2 <- .pca_row_squared_shares(ind.coord, data_scaled)
 
-  # OPTIMIZED: Compute cos2 using vectorized division
-
-  # cos2[i,j] = coord[i,j]^2 / d2[i]
-  ind.coord.sq <- ind.coord^2
-  ind.cos2 <- matrix(0, nrow = n.ind, ncol = n.dim)
-  positive_d2 <- d2 > .Machine$double.eps
-  if(any(positive_d2)) {
-    ind.cos2[positive_d2, ] <- ind.coord.sq[positive_d2, , drop = FALSE] / d2[positive_d2]
-  }
-
-  # OPTIMIZED: Compute contributions using vectorized operations
-  # contrib[i,j] = 100 * (1/n) * (coord[i,j]^2 / eigenvalue[j])
-  # Use sweep to divide each column by its eigenvalue
-  ind.contrib <- sweep(ind.coord.sq, 2, eigenvalues, "/") * (100 / n.ind)
+  # Contributions are shares of a component's score sum of squares. This
+  # definition is backend-independent: stats::prcomp() reports eigenvalues with
+  # an (n - 1) divisor whereas stats::princomp() uses n, so dividing by the
+  # backend eigenvalue made prcomp contributions sum to 100 * (n - 1) / n.
+  ind.contrib <- .pca_column_contributions(ind.coord)
 
   # Set column and row names
   dim.names <- paste0("Dim.", 1:n.dim)
@@ -241,6 +230,8 @@ get_pca_var<-function(res.pca){
 # - Maintains full econometric precision
 .get_pca_var_results <- function(var.coord){
 
+  var.coord <- as.matrix(var.coord)
+
   # Preserve row names from input
   rnames <- rownames(var.coord)
 
@@ -251,11 +242,7 @@ get_pca_var<-function(res.pca){
   # var.cos2*100/total Cos2 of the component
   # Using colSums instead of apply(, 2, sum) - much faster
 
-  comp.cos2 <- colSums(var.cos2)
-
-  # OPTIMIZED: Using sweep instead of t(apply()) for column-wise division
-  # contrib[i,j] = var.cos2[i,j] * 100 / comp.cos2[j]
-  var.contrib <- sweep(var.cos2, 2, comp.cos2, "/") * 100
+  var.contrib <- .pca_column_contributions(var.coord)
 
   # Set column names
   dim.names <- paste0("Dim.", seq_len(ncol(var.coord)))
@@ -272,10 +259,10 @@ get_pca_var<-function(res.pca){
   list(coord = var.coord, cor = var.cor, cos2 = var.cos2, contrib = var.contrib)
 }
 
-# Individual results for ade4 between-class / within-class PCA (bca/wca).
-# These dudi objects expose row coordinates ($li), the transformed table ($tab)
-# and row/column weights ($lw/$cw) but no $cent/$norm, so we use the general
-# weighted-dudi definitions:
+# Individual results for ade4 PCA, including ordinary dudi.pca and
+# between-/within-class PCA (bca/wca). These objects expose row coordinates
+# ($li), the transformed table ($tab), and row/column weights ($lw/$cw), so use
+# the general weighted-dudi definitions:
 #   d2[i]        = sum_j cw[j] * tab[i, j]^2      (squared distance, column metric)
 #   cos2[i, k]   = li[i, k]^2 / d2[i]
 #   contrib[i,k] = 100 * lw[i] * li[i, k]^2 / eig[k]
@@ -287,18 +274,9 @@ get_pca_var<-function(res.pca){
   cw  <- res.pca$cw
   lw  <- res.pca$lw
   n.dim <- ncol(ind.coord)
-  eigenvalues <- res.pca$eig[seq_len(n.dim)]
 
-  d2 <- rowSums(sweep(tab^2, 2, cw, "*"))
-  coord.sq <- ind.coord^2
-
-  ind.cos2 <- matrix(0, nrow = nrow(ind.coord), ncol = n.dim)
-  positive_d2 <- d2 > .Machine$double.eps
-  if(any(positive_d2))
-    ind.cos2[positive_d2, ] <- coord.sq[positive_d2, , drop = FALSE] / d2[positive_d2]
-
-  ind.contrib <- sweep(coord.sq, 2, eigenvalues, "/")
-  ind.contrib <- sweep(ind.contrib, 1, lw, "*") * 100
+  ind.cos2 <- .pca_row_squared_shares(ind.coord, tab, column_weights = cw)
+  ind.contrib <- .pca_column_contributions(ind.coord, row_weights = lw)
 
   dim.names <- paste0("Dim.", seq_len(n.dim))
   colnames(ind.coord) <- colnames(ind.cos2) <- colnames(ind.contrib) <- dim.names
@@ -307,4 +285,74 @@ get_pca_var<-function(res.pca){
   rownames(ind.coord) <- rownames(ind.cos2) <- rownames(ind.contrib) <- rnames
 
   list(coord = ind.coord, cos2 = ind.cos2, contrib = ind.contrib)
+}
+
+# Stable row-wise squared shares. Each row is normalized before squaring, with
+# the same scale applied to the numerator coordinates and reference metric.
+.pca_row_squared_shares <- function(coord, reference, column_weights = NULL){
+  coord <- as.matrix(coord)
+  reference <- as.matrix(reference)
+  result <- matrix(0, nrow = nrow(coord), ncol = ncol(coord),
+                   dimnames = dimnames(coord))
+
+  finite_rows <- apply(is.finite(coord), 1, all) &
+    apply(is.finite(reference), 1, all)
+  result[!finite_rows, ] <- NA_real_
+  if(!any(finite_rows)) return(result)
+
+  row_scale <- pmax(
+    apply(abs(coord[finite_rows, , drop = FALSE]), 1, max),
+    apply(abs(reference[finite_rows, , drop = FALSE]), 1, max)
+  )
+  positive <- row_scale > 0
+  if(!any(positive)) return(result)
+
+  finite_indices <- which(finite_rows)
+  target_rows <- finite_indices[positive]
+  scaled_coord <- sweep(coord[target_rows, , drop = FALSE], 1,
+                        row_scale[positive], "/")
+  scaled_reference <- sweep(reference[target_rows, , drop = FALSE], 1,
+                            row_scale[positive], "/")
+  reference_sq <- scaled_reference^2
+  if(!is.null(column_weights))
+    reference_sq <- sweep(reference_sq, 2, column_weights, "*")
+  denominator <- rowSums(reference_sq)
+  valid <- is.finite(denominator) & denominator > 0
+  if(any(valid)) {
+    result[target_rows[valid], ] <- scaled_coord[valid, , drop = FALSE]^2 /
+      denominator[valid]
+  }
+  result
+}
+
+# Stable per-axis contributions. Rescaling each coordinate column cancels from
+# numerator and denominator while avoiding underflow/overflow in x^2.
+.pca_column_contributions <- function(coord, row_weights = NULL){
+  coord <- as.matrix(coord)
+  result <- matrix(0, nrow = nrow(coord), ncol = ncol(coord),
+                   dimnames = dimnames(coord))
+  finite_rows <- apply(is.finite(coord), 1, all)
+  if(!is.null(row_weights))
+    finite_rows <- finite_rows & is.finite(row_weights) & row_weights >= 0
+  result[!finite_rows, ] <- NA_real_
+  if(!any(finite_rows)) return(result)
+
+  complete_coord <- coord[finite_rows, , drop = FALSE]
+  column_scale <- apply(abs(complete_coord), 2, max)
+  positive <- column_scale > 0
+  if(!any(positive)) return(result)
+
+  scaled_sq <- sweep(complete_coord[, positive, drop = FALSE], 2,
+                     column_scale[positive], "/")^2
+  if(!is.null(row_weights))
+    scaled_sq <- sweep(scaled_sq, 1, row_weights[finite_rows], "*")
+  denominator <- colSums(scaled_sq)
+  valid <- is.finite(denominator) & denominator > 0
+  if(any(valid)) {
+    target_columns <- which(positive)[valid]
+    result[finite_rows, target_columns] <- sweep(
+      scaled_sq[, valid, drop = FALSE], 2, denominator[valid], "/"
+    ) * 100
+  }
+  result
 }

--- a/man/get_pca.Rd
+++ b/man/get_pca.Rd
@@ -13,8 +13,10 @@ get_pca_ind(res.pca, ...)
 get_pca_var(res.pca)
 }
 \arguments{
-\item{res.pca}{an object of class PCA [FactoMineR]; 
-prcomp and princomp [stats]; pca, dudi [adea4]; epPCA [ExPosition].}
+\item{res.pca}{an object of class PCA [FactoMineR]; \code{prcomp} or
+\code{princomp} [stats]; \code{factoextra_pca}; \code{pca}, \code{dudi},
+\code{between}, or \code{within} [ade4]; or \code{expoOutput}/\code{epPCA}
+[ExPosition].}
 
 \item{element}{the element to subset from the output. Allowed values are 
 "var" (for active variables) or "ind" (for active individuals).}
@@ -25,10 +27,15 @@ prcomp and princomp [stats]; pca, dudi [adea4]; epPCA [ExPosition].}
 a list of matrices containing all the results for the active individuals/variables including: 
 \item{coord}{coordinates for the individuals/variables}
 \item{cos2}{cos2 for the individuals/variables}
-\item{contrib}{contributions of the individuals/variables}
+\item{contrib}{contributions of the individuals/variables; contributions to
+each nonzero-inertia axis sum to 100 percent, while a zero-inertia axis
+contains zeros}
+\item{cor}{loading-times-component-standard-deviation coordinates for PCA
+objects from \code{stats}; these equal variable-component correlations when
+the input variables were standardized. Returned for variables.}
 }
 \description{
-Extract all the results (coordinates, squared cosine, contributions) for 
+Extract all the results (coordinates, squared cosines, and contributions) for
 the active individuals/variables from Principal Component Analysis (PCA) outputs.\cr\cr
 \itemize{
 \item get_pca(): Extract the results for variables and individuals

--- a/tests/testthat/test-edge-correctness.R
+++ b/tests/testthat/test-edge-correctness.R
@@ -145,3 +145,55 @@ test_that("fviz_gap_stat maxSE fallback uses firstSEmax (honours SE.factor)", {
     fake_gap, maxSE = list(method = "firstmax", SE.factor = 1)
   )), 2)
 })
+
+# ---- Batch D1 (PR #274) get_pca contribution normalization ----------------
+
+test_that("PCA metrics remain finite and scale-invariant on tiny or zero axes", {
+  x <- as.matrix(iris[, 1:4])
+  ordinary <- get_pca_ind(prcomp(x, center = TRUE, scale. = FALSE))
+  tiny <- get_pca_ind(prcomp(x * 1e-10, center = TRUE, scale. = FALSE))
+  subnormal_fit <- prcomp(x * 1e-170, center = TRUE, scale. = FALSE)
+  subnormal_square <- get_pca_ind(subnormal_fit)
+
+  expect_equal(tiny$cos2, ordinary$cos2, tolerance = 1e-12)
+  expect_equal(tiny$contrib, ordinary$contrib, tolerance = 1e-12)
+  expect_equal(subnormal_square$cos2, ordinary$cos2, tolerance = 1e-12)
+  expect_equal(subnormal_square$contrib, ordinary$contrib, tolerance = 1e-12)
+  expect_equal(unname(colSums(tiny$contrib)), rep(100, ncol(x)), tolerance = 1e-10)
+  expect_equal(
+    unname(colSums(subnormal_square$contrib)),
+    rep(100, ncol(x)), tolerance = 1e-10
+  )
+  expect_equal(
+    get_pca_var(subnormal_fit)$contrib,
+    get_pca_var(prcomp(x, center = TRUE, scale. = FALSE))$contrib,
+    tolerance = 1e-12
+  )
+
+  rank_deficient <- prcomp(cbind(signal = seq_len(8), constant = 1))
+  ind <- get_pca_ind(rank_deficient)
+  var <- get_pca_var(rank_deficient)
+  expect_true(all(is.finite(ind$cos2)))
+  expect_true(all(is.finite(ind$contrib)))
+  expect_true(all(is.finite(var$contrib)))
+  expect_equal(unname(var$contrib[, 2]), c(0, 0))
+})
+
+test_that("PCA metrics preserve excluded rows without corrupting complete shares", {
+  x <- iris[, 1:4]
+  x[c(2, 11), 1] <- NA_real_
+  fit <- prcomp(
+    ~ ., data = x, center = TRUE, scale. = TRUE,
+    na.action = na.exclude
+  )
+  ind <- get_pca_ind(fit)
+
+  expect_true(all(is.na(ind$cos2[c(2, 11), ])))
+  expect_true(all(is.na(ind$contrib[c(2, 11), ])))
+  expect_true(all(is.finite(ind$cos2[-c(2, 11), ])))
+  expect_equal(
+    unname(colSums(ind$contrib, na.rm = TRUE)),
+    rep(100, ncol(ind$contrib)), tolerance = 1e-10
+  )
+})
+

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -863,6 +863,7 @@ test_that("prcomp/princomp get_pca_ind unchanged by the dudi fix (#126 no-regres
     expect_true(is.matrix(ind$coord) && is.matrix(ind$cos2) && is.matrix(ind$contrib))
     expect_equal(nrow(ind$coord), nrow(iris))
     expect_true(all(rowSums(ind$cos2) <= 1 + 1e-9))
+    expect_true(all(abs(colSums(ind$contrib) - 100) < 1e-6))
   }
 })
 
@@ -1118,4 +1119,68 @@ test_that("fviz_mclust honors ggtheme for every plot type", {
     plot <- fviz_mclust(model, what = what, ggtheme = custom_theme)
     expect_equal(plot$theme$plot.background$fill, "linen")
   }
+})
+
+# ---- Batch D1 (PR #274) get_pca contribution normalization ----------------
+
+test_that("ade4 dudi.pca individual results respect nonuniform row weights", {
+  skip_if_not_installed("ade4")
+  row_weights <- seq_len(nrow(iris))
+  row_weights <- row_weights / sum(row_weights)
+  pca <- ade4::dudi.pca(
+    iris[, -5], row.w = row_weights, scannf = FALSE, nf = 3
+  )
+
+  ind <- get_pca_ind(pca)
+  inertia <- ade4::inertia.dudi(pca, row.inertia = TRUE)
+  ade4_contrib <- as.matrix(
+    inertia$row.abs[, seq_len(ncol(ind$contrib)), drop = FALSE]
+  )
+
+  expect_equal(unname(ind$contrib), unname(ade4_contrib), tolerance = 1e-8)
+  expect_equal(unname(colSums(ind$contrib)), rep(100, ncol(ind$contrib)),
+               tolerance = 1e-8)
+  expect_true(all(rowSums(ind$cos2) <= 1 + 1e-9))
+})
+
+test_that("PCA individual contributions are backend-independent and zero-safe", {
+  x <- iris[, -5]
+  fits <- list(
+    prcomp(x, center = TRUE, scale. = TRUE),
+    prcomp(x, center = TRUE, scale. = FALSE),
+    princomp(x, cor = TRUE),
+    princomp(x, cor = FALSE)
+  )
+  for(fit in fits) {
+    ind <- get_pca_ind(fit)
+    truth <- sweep(ind$coord^2, 2, colSums(ind$coord^2), "/") * 100
+    expect_equal(ind$contrib, truth, tolerance = 1e-10,
+                 ignore_attr = TRUE)
+    expect_equal(unname(colSums(ind$contrib)), rep(100, ncol(ind$contrib)),
+                 tolerance = 1e-10)
+  }
+
+  coord <- cbind(nonzero = c(-1, 1), zero = c(0, 0))
+  out <- factoextra:::.get_pca_ind_results(
+    coord, data = cbind(c(-1, 1), c(0, 0)), eigenvalues = c(1, 0),
+    pca.center = c(0, 0), pca.scale = c(1, 1)
+  )
+  expect_true(all(is.finite(out$contrib)))
+  expect_equal(unname(out$contrib[, 2]), c(0, 0))
+  expect_equal(sum(out$contrib[, 1]), 100)
+})
+
+
+test_that("get_pca contributions/cos2 match FactoMineR::PCA (independent-engine cross-validation)", {
+  skip_if_not_installed("FactoMineR")
+  X <- iris[, -5]
+  pc <- prcomp(X, scale. = TRUE)
+  fm <- FactoMineR::PCA(X, scale.unit = TRUE, graph = FALSE, ncp = 4)
+  ind <- get_pca_ind(pc); var <- get_pca_var(pc)
+  # Contributions and cos2 are sign-invariant, so they must match FactoMineR
+  # exactly even though prcomp's axis signs may differ.
+  expect_equal(unname(ind$contrib), unname(fm$ind$contrib), tolerance = 1e-8)
+  expect_equal(unname(var$contrib), unname(fm$var$contrib), tolerance = 1e-8)
+  expect_equal(unname(ind$cos2),    unname(fm$ind$cos2),    tolerance = 1e-8)
+  expect_equal(unname(var$cos2),    unname(fm$var$cos2),    tolerance = 1e-8)
 })


### PR DESCRIPTION
Batch D1 of the staged integration of #274 (@erdeyl) — the first of the core **numeric** changes. This is a **corrected default output**, cross-validated against independent engines.

### The fix
`get_pca_ind()` individual contributions for **`prcomp`** objects (and for **`ade4`** PCA objects with **non-uniform row weights**) are now normalized to sum to 100% per axis, matching `FactoMineR::PCA()`. Previously `prcomp` individual contributions were divided by prcomp's `(n-1)`-normalized eigenvalue and summed to `100·(n-1)/n` (e.g. **99.33** for iris) instead of 100.

### What changes vs what doesn't
| Quantity | Change |
|---|---|
| `prcomp` **individual** contrib | **Corrected** (99.33 → 100 per axis) |
| `ade4` non-uniform-weight **individual** contrib | **Corrected** (now weighted) |
| `princomp` individual contrib | **Unchanged** (its `sdev^2` is n-normalized — already summed to 100) |
| All **variable** contrib | **Unchanged** (algebraically identical formula) |
| Coordinates, cos2 | **Unchanged** (byte-identical) |

### Cross-validation (shipped as tests)
- `get_pca_ind`/`get_pca_var` contrib + cos2 match **`FactoMineR::PCA()`** to ~1e-13.
- ade4 non-uniform-weight contrib matches **`ade4::inertia.dudi()$row.abs`** to ~1e-8.
- Coordinates and cos2 proven byte-identical to `release/2.2.0` across prcomp (scaled/unscaled), princomp, ade4 (uniform), and FactoMineR paths.
- Scale-stable reformulation stays finite and scale-invariant on tiny (1e-170), huge, zero-inertia, and NA-excluded inputs.

### Notes
- Full suite green in a clean session: **FAIL 0 | WARN 0 | PASS 722** (1 unrelated skip: `fastICA`).
- `.Rd` regenerated with roxygen2 7.3.3 (only `get_pca.Rd`).

Refs #274. Not for merge without maintainer approval.

