### PR TITLE
Integrate #274 (D2): correct Horn parallel analysis + truncated-spectrum warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,22 @@
   variable contributions, coordinates, and cos2 are unchanged. Cross-validated
   against `FactoMineR::PCA()` and `ade4::inertia.dudi()`. Thanks to @erdeyl (#274).
 
+* `fviz_eig(parallel = TRUE)` (Horn's parallel analysis, an opt-in overlay):
+  the simulated eigenvalue thresholds now use a corrected reference distribution.
+  Covariance PCA (`prcomp(scale. = FALSE)` / `princomp(cor = FALSE)`) previously
+  simulated unit-variance random data, giving statistically wrong thresholds; the
+  reference now matches the fitted object's marginal variances. Full-rank
+  correlation PCA is unaffected in distribution (parallel analysis is a
+  Monte-Carlo procedure, so exact threshold values depend on the seed);
+  rank-truncated or wide (n <= p) fits now simulate over the original variable
+  count. Fits whose reference distribution
+  cannot be reconstructed (uncentered fits, custom scale vectors, rank-truncated
+  covariance fits, ambiguous `princomp` `cor`) now error clearly instead of
+  returning misleading thresholds. Separately, `fviz_eig()` warns when a
+  FactoMineR PCA object stores an incomplete eigenvalue spectrum (refit with a
+  larger `ncp` for a complete scree plot). Cross-validated against an independent
+  Monte-Carlo reference. Thanks to @erdeyl (#274).
+
 * `fviz_gap_stat()` (and `fviz_nbclust(method = "gap_stat")`): when a partial
   `maxSE` list is supplied without a `method`, the fallback is now `"firstSEmax"`
   (the documented default and `cluster::maxSE`'s default) instead of `"firstmax"`.

--- a/R/eigenvalue.R
+++ b/R/eigenvalue.R
@@ -14,11 +14,20 @@
 #'  (HMFA) functions. \code{fviz_eig()} validates \code{ncp},
 #'  \code{parallel.iter}, and \code{parallel.seed} before plotting, accepting
 #'  integer-like numeric values while still rejecting fractional inputs.
+#'
+#'  Recent versions of \code{FactoMineR::PCA()} may retain only the number of
+#'  eigenvalues requested through its \code{ncp} argument. When the stored
+#'  eigenvalues do not account for the result's recorded total inertia,
+#'  \code{fviz_eig()} warns that the scree plot is incomplete. Refit the PCA
+#'  with a sufficiently large \code{ncp} to plot the complete spectrum.
+#'  \code{get_eig()} continues to return the eigenvalues stored in the object.
 #'  
 #'  
-#'@param X an object of class PCA, CA, MCA, FAMD, MFA and HMFA [FactoMineR]; prcomp 
-#'  and princomp [stats]; dudi, pca, coa and acm [ade4]; ca and mjca [ca 
-#'  package].
+#'@param X an object of class PCA, CA, MCA, FAMD, MFA, or HMFA [FactoMineR];
+#'  \code{prcomp} or \code{princomp} [stats]; \code{factoextra_pca};
+#'  \code{dudi}, \code{pca}, \code{coa}, \code{acm}, \code{between}, or
+#'  \code{within} [ade4]; \code{ca} or \code{mjca} [ca];
+#'  \code{correspondence} [MASS]; or \code{expoOutput} [ExPosition].
 #'@param choice a text specifying the data to be plotted. Allowed values are 
 #'  "variance" or "eigenvalue".
 #'@param geom a text specifying the geometry to be used for the graph. Allowed 
@@ -33,12 +42,19 @@
 #'  or points showing the information retained by each dimension.
 #'@param hjust horizontal adjustment of the labels.
 #'@param main,xlab,ylab plot main and axis titles.
-#'@param parallel logical value. If TRUE, adds a parallel analysis threshold line
-#'  (Horn's method) to help determine the number of components to retain. Components
-#'  with eigenvalues above this line are considered significant. Only works when
-#'  choice = "eigenvalue" and X is a prcomp or princomp object. Default is FALSE.
-#'@param parallel.color color of the parallel analysis threshold line. Default is "red".
-#'@param parallel.lty line type for the parallel analysis line. Default is "dashed".
+#'@param parallel logical value. If TRUE, adds a Horn parallel-analysis threshold
+#'  curve. Each point is the 95th percentile of the corresponding ordered
+#'  eigenvalue from independently simulated reference data. Components whose
+#'  eigenvalues exceed their component-specific thresholds are retained by the
+#'  parallel-analysis rule. Correlation PCA uses standardized reference data;
+#'  covariance PCA uses reconstructed marginal scales. This is available only
+#'  when \code{choice = "eigenvalue"} and \code{X} is a sufficiently complete
+#'  \code{prcomp} or \code{princomp} object. Mean centering is required;
+#'  \code{prcomp} also requires retained scores. Custom scaling and incomplete
+#'  covariance decompositions are rejected when their reference distribution
+#'  cannot be reconstructed. Default is FALSE.
+#'@param parallel.color color of the parallel-analysis threshold curve. Default is "red".
+#'@param parallel.lty line type for the parallel-analysis curve. Default is "dashed".
 #'@param parallel.iter a single positive integer giving the number of
 #'  iterations for parallel analysis simulation. Integer-like numeric values
 #'  are accepted. Default is 100.
@@ -75,8 +91,8 @@
 #' # Use only bar  or line plot: geom = "bar" or geom = "line"
 #' fviz_eig(res.pca, geom="line")
 #'
-#' # Parallel analysis (Horn's method) to determine number of components
-#' # Components with eigenvalues above the red line are significant
+#' # Parallel analysis (Horn's method) to determine the number of components
+#' # Retain components whose eigenvalues exceed their component-specific points
 #' fviz_eig(res.pca, choice = "eigenvalue", parallel = TRUE,
 #'          addlabels = TRUE, parallel.color = "red",
 #'          parallel.iter = 10, parallel.seed = 123)
@@ -146,6 +162,227 @@ get_eigenvalue <- function(X){
   get_eig(X)
 }
 
+.fm_pca_spectrum_truncated <- function(x, eig) {
+  sparse_classes <- c("sPCA", "sCA", "sMCA", "sMFA", "sHMFA")
+  if (!inherits(x, "PCA") || inherits(x, sparse_classes)) {
+    return(FALSE)
+  }
+
+  svd_info <- x[["svd"]]
+  if (!is.list(svd_info)) {
+    return(FALSE)
+  }
+  total_inertia <- svd_info[["sumvp"]]
+  if (!is.numeric(total_inertia) || length(total_inertia) != 1L ||
+        !is.finite(total_inertia) || total_inertia <= 0) {
+    return(FALSE)
+  }
+
+  if (!(is.matrix(eig) || is.data.frame(eig)) || ncol(eig) < 1L) {
+    return(FALSE)
+  }
+  eigenvalues <- eig[, 1L, drop = TRUE]
+  if (!is.numeric(eigenvalues) || length(eigenvalues) < 1L ||
+        any(!is.finite(eigenvalues))) {
+    return(FALSE)
+  }
+
+  captured_inertia <- sum(eigenvalues)
+  tolerance <- 1e-6 * total_inertia
+  isTRUE(total_inertia - captured_inertia > tolerance)
+}
+
+.warn_truncated_pca_spectrum <- function(n_eigenvalues) {
+  message <- paste0(
+    "This FactoMineR PCA result contains only ", n_eigenvalues,
+    " eigenvalues and does not include the complete spectrum. Refit the PCA ",
+    "with a larger `ncp` before drawing a complete scree plot."
+  )
+  warning(structure(
+    list(message = message, call = NULL),
+    class = c(
+      "factoextra_truncated_pca_spectrum", "warning", "condition"
+    )
+  ))
+}
+
+.princomp_uses_correlation <- function(X){
+  cor_arg <- NULL
+  if(!is.null(X[["call"]])) cor_arg <- X[["call"]][["cor"]]
+  if(is.null(cor_arg)) return(FALSE)
+  if((is.logical(cor_arg) || is.numeric(cor_arg)) &&
+     length(cor_arg) == 1L && !is.na(cor_arg) && is.finite(cor_arg) &&
+     cor_arg %in% c(0, 1)) return(as.logical(cor_arg))
+
+  # A non-unit stored scale proves that princomp standardized the variables.
+  # If every scale is one, a symbolic call (for example cor = use_cor) is
+  # ambiguous from the fitted object alone, so do not guess.
+  object_scale <- X[["scale"]]
+  if(is.numeric(object_scale) && length(object_scale) > 0L &&
+     all(is.finite(object_scale)) &&
+     any(abs(object_scale - 1) > sqrt(.Machine$double.eps))) return(TRUE)
+
+  stop(
+    "Cannot determine whether this princomp object used cor = TRUE or FALSE. ",
+    "Refit it with a literal cor argument before requesting parallel analysis."
+  )
+}
+
+.parallel_analysis_spec <- function(X){
+  if(inherits(X, "prcomp")){
+    scores <- X[["x"]]
+    rotation <- X[["rotation"]]
+    if(is.null(scores) || !is.matrix(scores))
+      stop("Parallel analysis requires a prcomp object fitted with retx = TRUE.")
+    if(is.null(rotation) || !is.matrix(rotation))
+      stop("The prcomp object has no usable rotation matrix.")
+
+    complete_scores <- scores[stats::complete.cases(scores), , drop = FALSE]
+    n_obs <- nrow(complete_scores)
+    n_var <- nrow(rotation)
+    eigenvalues <- as.numeric(X[["sdev"]])^2
+    n_components <- length(eigenvalues)
+    if(identical(X[["center"]], FALSE) || is.null(X[["center"]]))
+      stop("Parallel analysis requires a mean-centered prcomp fit.")
+    score_tolerance <- sqrt(.Machine$double.eps) *
+      max(abs(complete_scores))
+    if(any(abs(colMeans(complete_scores)) > score_tolerance))
+      stop("Parallel analysis requires a prcomp fit centered at the variable means.")
+    correlation <- !is.null(X[["scale"]]) && !identical(X[["scale"]], FALSE)
+
+    if(n_components < 1L || any(!is.finite(eigenvalues)) ||
+       any(eigenvalues < 0))
+      stop("The fitted PCA object has an invalid component spectrum.")
+
+    if(correlation){
+      tolerance <- sqrt(.Machine$double.eps) * max(1, n_var)
+      if(ncol(rotation) == n_components){
+        analyzed_var <- rowSums(sweep(rotation^2, 2, eigenvalues, "*"))
+        if(any(abs(analyzed_var - 1) > tolerance))
+          stop("Parallel analysis cannot reproduce a prcomp fit using a custom scale vector.")
+      } else if(abs(sum(eigenvalues) - n_var) > tolerance){
+        stop("Parallel analysis cannot verify correlation scaling for this truncated prcomp fit.")
+      }
+    }
+
+    marginal_sd <- rep(1, n_var)
+    if(!correlation){
+      retained <- ncol(rotation)
+      if(retained > n_components)
+        stop("The prcomp rotation contains more components than its eigenvalues.")
+
+      tolerance <- sqrt(.Machine$double.eps) * max(eigenvalues)
+      if(retained < n_components &&
+         any(eigenvalues[seq.int(retained + 1L, n_components)] > tolerance)){
+        stop(
+          "Parallel analysis cannot reconstruct marginal variances from this ",
+          "truncated covariance prcomp object. Refit without rank truncation or ",
+          "use scale. = TRUE."
+        )
+      }
+
+      weighted_rotation <- sweep(
+        rotation^2, 2, eigenvalues[seq_len(retained)], "*"
+      )
+      marginal_sd <- sqrt(pmax(rowSums(weighted_rotation), 0))
+    }
+
+    covariance_divisor <- n_obs - 1L
+  }
+  else if(inherits(X, "princomp")){
+    loadings <- as.matrix(unclass(X[["loadings"]]))
+    if(is.null(loadings) || length(dim(loadings)) != 2L)
+      stop("The princomp object has no usable loadings matrix.")
+
+    n_obs <- X[["n.obs"]]
+    if(is.null(n_obs) && !is.null(X[["scores"]])) n_obs <- nrow(X[["scores"]])
+    n_var <- nrow(loadings)
+    eigenvalues <- as.numeric(X[["sdev"]])^2
+    n_components <- length(eigenvalues)
+    correlation <- .princomp_uses_correlation(X)
+
+    if(n_components < 1L || any(!is.finite(eigenvalues)) ||
+       any(eigenvalues < 0))
+      stop("The fitted PCA object has an invalid component spectrum.")
+
+    marginal_sd <- rep(1, n_var)
+    if(!correlation){
+      if(ncol(loadings) != n_components)
+        stop(
+          "Parallel analysis cannot reconstruct marginal variances from this ",
+          "incomplete covariance princomp object."
+        )
+      marginal_sd <- sqrt(pmax(rowSums(sweep(
+        loadings^2, 2, eigenvalues, "*"
+      )), 0))
+    }
+
+    covariance_divisor <- n_obs
+  }
+  else stop("Parallel analysis supports only prcomp and princomp objects.")
+
+  if(length(n_obs) != 1L || !is.finite(n_obs) || n_obs < 2L ||
+     n_obs != round(n_obs))
+    stop("Parallel analysis requires a valid observation count of at least two.")
+  if(length(n_var) != 1L || !is.finite(n_var) || n_var < 1L ||
+     n_var != round(n_var))
+    stop("Parallel analysis requires a valid original variable count.")
+  if(n_components < 1L || n_components > min(n_obs, n_var) ||
+     any(!is.finite(eigenvalues)))
+    stop("The fitted PCA object has an invalid component spectrum.")
+  if(length(marginal_sd) != n_var || any(!is.finite(marginal_sd)))
+    stop("The fitted PCA object has invalid marginal scales.")
+
+  n_thresholds <- min(n_components, n_var, n_obs - 1L)
+  list(
+    n_obs = as.integer(n_obs), n_var = as.integer(n_var),
+    n_components = n_components, n_thresholds = n_thresholds,
+    correlation = correlation, marginal_sd = marginal_sd,
+    covariance_divisor = covariance_divisor
+  )
+}
+
+.parallel_analysis_threshold <- function(X, iterations, seed = NULL){
+  iterations <- .coerce_integerish(iterations, "iterations")
+  if(!is.null(seed))
+    seed <- .coerce_integerish(
+      seed, "seed", lower = 0L, upper = .Machine$integer.max,
+      value_label = "NULL or a single integer value"
+    )
+  spec <- .parallel_analysis_spec(X)
+
+  simulate <- function(){
+    sim_eigs <- matrix(
+      NA_real_, nrow = iterations, ncol = spec$n_thresholds
+    )
+    for(i in seq_len(iterations)){
+      random_data <- matrix(
+        stats::rnorm(spec$n_obs * spec$n_var),
+        nrow = spec$n_obs, ncol = spec$n_var
+      )
+      if(spec$correlation){
+        random_data <- scale(random_data, center = TRUE, scale = TRUE)
+        divisor <- spec$n_obs - 1L
+      } else {
+        random_data <- sweep(random_data, 2, spec$marginal_sd, "*")
+        random_data <- scale(random_data, center = TRUE, scale = FALSE)
+        divisor <- spec$covariance_divisor
+      }
+      values <- svd(random_data, nu = 0, nv = 0)$d^2 / divisor
+      if(length(values) < spec$n_thresholds ||
+         any(!is.finite(values[seq_len(spec$n_thresholds)])))
+        stop("A parallel-analysis simulation produced an invalid spectrum.")
+      sim_eigs[i, ] <- values[seq_len(spec$n_thresholds)]
+    }
+    unname(apply(
+      sim_eigs, 2, stats::quantile, probs = 0.95, names = FALSE
+    ))
+  }
+
+  if(is.null(seed)) simulate()
+  else .with_preserved_seed(seed, simulate())
+}
+
 #' @rdname eigenvalue
 #' @export
 fviz_eig<-function(X, choice=c("variance", "eigenvalue"), geom=c("bar", "line"),
@@ -160,6 +397,9 @@ fviz_eig<-function(X, choice=c("variance", "eigenvalue"), geom=c("bar", "line"),
   ncp <- .coerce_integerish(ncp, "ncp")
 
   eig <- get_eigenvalue(X)
+  if (.fm_pca_spectrum_truncated(X, eig)) {
+    .warn_truncated_pca_spectrum(nrow(eig))
+  }
   eig <-eig[seq_len(min(ncp, nrow(eig))), , drop=FALSE]
   
   choice <- choice[1]
@@ -206,61 +446,34 @@ fviz_eig<-function(X, choice=c("variance", "eigenvalue"), geom=c("bar", "line"),
   # Add parallel analysis line (Horn's method) if requested
   if(parallel && choice == "eigenvalue") {
     parallel.iter <- .coerce_integerish(parallel.iter, "parallel.iter")
-
-    compute_parallel_threshold <- function(n_obs, n_var, fit_fn){
-      sim_eigs <- matrix(NA_real_, nrow = parallel.iter, ncol = n_var)
-      for(i in seq_len(parallel.iter)) {
-        random_data <- matrix(stats::rnorm(n_obs * n_var), nrow = n_obs, ncol = n_var)
-        sim_eigs[i, ] <- fit_fn(random_data)
-      }
-      apply(sim_eigs, 2, function(x) stats::quantile(x, 0.95))
-    }
-
-    # Parallel analysis requires the original data, available from prcomp/princomp
-    if(inherits(X, "prcomp") && !is.null(X$x)) {
-      n_obs <- nrow(X$x)
-      n_var <- ncol(X$x)
-      if(is.null(parallel.seed)) {
-        parallel_threshold <- compute_parallel_threshold(
-          n_obs, n_var, fit_fn = function(random_data) stats::prcomp(random_data, scale. = TRUE)$sdev^2
-        )
-      } else {
-        parallel_threshold <- .with_preserved_seed(parallel.seed, {
-          compute_parallel_threshold(
-            n_obs, n_var, fit_fn = function(random_data) stats::prcomp(random_data, scale. = TRUE)$sdev^2
-          )
-        })
-      }
-      parallel_threshold <- parallel_threshold[seq_len(min(ncp, length(parallel_threshold)))]
-      df.parallel <- data.frame(dim = factor(seq_along(parallel_threshold)),
-                                 threshold = parallel_threshold)
-      p <- p + geom_line(data = df.parallel, aes(x = .data[["dim"]], y = .data[["threshold"]]),
-                         color = parallel.color, linetype = parallel.lty, linewidth = 0.8) +
-               geom_point(data = df.parallel, aes(x = .data[["dim"]], y = .data[["threshold"]]),
-                          color = parallel.color, shape = 4, size = 2)
-    } else if(inherits(X, "princomp") && !is.null(X$scores)) {
-      n_obs <- nrow(X$scores)
-      n_var <- ncol(X$scores)
-      if(is.null(parallel.seed)) {
-        parallel_threshold <- compute_parallel_threshold(
-          n_obs, n_var, fit_fn = function(random_data) stats::princomp(random_data, cor = TRUE)$sdev^2
-        )
-      } else {
-        parallel_threshold <- .with_preserved_seed(parallel.seed, {
-          compute_parallel_threshold(
-            n_obs, n_var, fit_fn = function(random_data) stats::princomp(random_data, cor = TRUE)$sdev^2
-          )
-        })
-      }
-      parallel_threshold <- parallel_threshold[seq_len(min(ncp, length(parallel_threshold)))]
-      df.parallel <- data.frame(dim = factor(seq_along(parallel_threshold)),
-                                 threshold = parallel_threshold)
-      p <- p + geom_line(data = df.parallel, aes(x = .data[["dim"]], y = .data[["threshold"]]),
-                         color = parallel.color, linetype = parallel.lty, linewidth = 0.8) +
-               geom_point(data = df.parallel, aes(x = .data[["dim"]], y = .data[["threshold"]]),
-                          color = parallel.color, shape = 4, size = 2)
+    supported <- (inherits(X, "prcomp") && !is.null(X[["x"]])) ||
+      (inherits(X, "princomp") &&
+         (!is.null(X[["n.obs"]]) || !is.null(X[["scores"]])))
+    if(!supported){
+      warning(
+        "Parallel analysis requires a prcomp object fitted with retx = TRUE ",
+        "or a princomp object with an observation count. Skipping."
+      )
     } else {
-      warning("Parallel analysis requires prcomp or princomp objects with score data. Skipping.")
+      parallel_threshold <- .parallel_analysis_threshold(
+        X, parallel.iter, parallel.seed
+      )
+      parallel_threshold <- parallel_threshold[
+        seq_len(min(ncp, length(parallel_threshold)))
+      ]
+      df.parallel <- data.frame(
+        dim = factor(seq_along(parallel_threshold)),
+        threshold = parallel_threshold
+      )
+      p <- p + geom_line(
+        data = df.parallel,
+        aes(x = .data[["dim"]], y = .data[["threshold"]]),
+        color = parallel.color, linetype = parallel.lty, linewidth = 0.8
+      ) + geom_point(
+        data = df.parallel,
+        aes(x = .data[["dim"]], y = .data[["threshold"]]),
+        color = parallel.color, shape = 4, size = 2
+      )
     }
   } else if(parallel && choice != "eigenvalue") {
     warning("Parallel analysis only works with choice = 'eigenvalue'. Skipping.")

--- a/man/eigenvalue.Rd
+++ b/man/eigenvalue.Rd
@@ -37,9 +37,11 @@ fviz_eig(
 fviz_screeplot(...)
 }
 \arguments{
-\item{X}{an object of class PCA, CA, MCA, FAMD, MFA and HMFA [FactoMineR]; prcomp 
-and princomp [stats]; dudi, pca, coa and acm [ade4]; ca and mjca [ca 
-package].}
+\item{X}{an object of class PCA, CA, MCA, FAMD, MFA, or HMFA [FactoMineR];
+\code{prcomp} or \code{princomp} [stats]; \code{factoextra_pca};
+\code{dudi}, \code{pca}, \code{coa}, \code{acm}, \code{between}, or
+\code{within} [ade4]; \code{ca} or \code{mjca} [ca];
+\code{correspondence} [MASS]; or \code{expoOutput} [ExPosition].}
 
 \item{choice}{a text specifying the data to be plotted. Allowed values are 
 "variance" or "eigenvalue".}
@@ -68,14 +70,21 @@ or points showing the information retained by each dimension.}
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 
-\item{parallel}{logical value. If TRUE, adds a parallel analysis threshold line
-(Horn's method) to help determine the number of components to retain. Components
-with eigenvalues above this line are considered significant. Only works when
-choice = "eigenvalue" and X is a prcomp or princomp object. Default is FALSE.}
+\item{parallel}{logical value. If TRUE, adds a Horn parallel-analysis threshold
+curve. Each point is the 95th percentile of the corresponding ordered
+eigenvalue from independently simulated reference data. Components whose
+eigenvalues exceed their component-specific thresholds are retained by the
+parallel-analysis rule. Correlation PCA uses standardized reference data;
+covariance PCA uses reconstructed marginal scales. This is available only
+when \code{choice = "eigenvalue"} and \code{X} is a sufficiently complete
+\code{prcomp} or \code{princomp} object. Mean centering is required;
+\code{prcomp} also requires retained scores. Custom scaling and incomplete
+covariance decompositions are rejected when their reference distribution
+cannot be reconstructed. Default is FALSE.}
 
-\item{parallel.color}{color of the parallel analysis threshold line. Default is "red".}
+\item{parallel.color}{color of the parallel-analysis threshold curve. Default is "red".}
 
-\item{parallel.lty}{line type for the parallel analysis line. Default is "dashed".}
+\item{parallel.lty}{line type for the parallel-analysis curve. Default is "dashed".}
 
 \item{parallel.iter}{a single positive integer giving the number of
 iterations for parallel analysis simulation. Integer-like numeric values
@@ -108,6 +117,13 @@ Eigenvalues correspond to the amount of the variation explained
  (HMFA) functions. \code{fviz_eig()} validates \code{ncp},
  \code{parallel.iter}, and \code{parallel.seed} before plotting, accepting
  integer-like numeric values while still rejecting fractional inputs.
+
+ Recent versions of \code{FactoMineR::PCA()} may retain only the number of
+ eigenvalues requested through its \code{ncp} argument. When the stored
+ eigenvalues do not account for the result's recorded total inertia,
+ \code{fviz_eig()} warns that the scree plot is incomplete. Refit the PCA
+ with a sufficiently large \code{ncp} to plot the complete spectrum.
+ \code{get_eig()} continues to return the eigenvalues stored in the object.
 }
 \examples{
 # Principal Component Analysis
@@ -127,8 +143,8 @@ fviz_eig(res.pca, choice = "eigenvalue", addlabels=TRUE)
 # Use only bar  or line plot: geom = "bar" or geom = "line"
 fviz_eig(res.pca, geom="line")
 
-# Parallel analysis (Horn's method) to determine number of components
-# Components with eigenvalues above the red line are significant
+# Parallel analysis (Horn's method) to determine the number of components
+# Retain components whose eigenvalues exceed their component-specific points
 fviz_eig(res.pca, choice = "eigenvalue", parallel = TRUE,
          addlabels = TRUE, parallel.color = "red",
          parallel.iter = 10, parallel.seed = 123)

--- a/tests/testthat/test-eigenvalue-spectrum.R
+++ b/tests/testthat/test-eigenvalue-spectrum.R
@@ -1,0 +1,112 @@
+test_that("fviz_eig warns for a truncated FactoMineR PCA spectrum", {
+  skip_if_not_installed("FactoMineR")
+
+  complete <- FactoMineR::PCA(
+    decathlon2[1:23, 1:10], ncp = 10, graph = FALSE
+  )
+  truncated <- complete
+  truncated$eig <- truncated$eig[1:5, , drop = FALSE]
+  truncated$svd$sumvp <- sum(complete$eig[, 1])
+
+  expect_warning(
+    fviz_eig(truncated),
+    "does not include the complete spectrum",
+    class = "factoextra_truncated_pca_spectrum"
+  )
+  expect_no_warning(fviz_eig(complete))
+  expect_no_warning(fviz_eig(complete, ncp = 2))
+
+  stored <- get_eigenvalue(truncated)
+  expect_equal(
+    unname(as.matrix(stored)),
+    unname(as.matrix(truncated$eig))
+  )
+})
+
+test_that("fviz_eig recognizes truncated spectra produced by FactoMineR", {
+  skip_if_not_installed("FactoMineR")
+
+  truncated <- FactoMineR::PCA(
+    decathlon2[1:23, 1:10], graph = FALSE
+  )
+  eig <- get_eigenvalue(truncated)
+  skip_if_not(
+    factoextra:::.fm_pca_spectrum_truncated(truncated, eig),
+    "this FactoMineR version does not record detectable truncation"
+  )
+
+  expect_warning(
+    fviz_eig(truncated),
+    "does not include the complete spectrum",
+    class = "factoextra_truncated_pca_spectrum"
+  )
+})
+
+test_that("alternate PCA backends do not trigger truncation warnings", {
+  set.seed(29)
+  x <- matrix(rnorm(80), ncol = 4)
+
+  expect_no_warning(fviz_eig(prcomp(x)))
+  expect_no_warning(fviz_eig(princomp(x)))
+
+  custom <- as_factoextra_pca(
+    ind.coord = prcomp(x)$x,
+    eig = prcomp(x)$sdev^2
+  )
+  expect_no_warning(fviz_eig(custom))
+})
+
+test_that("rank-deficient complete FactoMineR PCA spectra do not warn", {
+  skip_if_not_installed("FactoMineR")
+
+  x <- data.frame(
+    a = seq_len(20),
+    b = rep(c(-1, 1), 10),
+    c = seq_len(20) + rep(c(-1, 1), 10),
+    d = seq_len(20)
+  )
+  complete <- FactoMineR::PCA(x, ncp = 4, graph = FALSE)
+
+  expect_no_warning(fviz_eig(complete))
+})
+
+test_that("sparse and ade4 PCA classes do not trigger FactoMineR warnings", {
+  skip_if_not_installed("FactoMineR")
+
+  sparse_like <- FactoMineR::PCA(
+    decathlon2[1:23, 1:10], graph = FALSE
+  )
+  class(sparse_like) <- c("sPCA", class(sparse_like))
+  expect_no_warning(fviz_eig(sparse_like))
+
+  skip_if_not_installed("ade4")
+  data(meaudret, package = "ade4")
+  pca <- ade4::dudi.pca(meaudret$env, scannf = FALSE, nf = 3)
+  group <- meaudret$design$season
+  between <- ade4::bca(pca, group, scannf = FALSE, nf = 2)
+  within <- ade4::wca(pca, group, scannf = FALSE, nf = 2)
+
+  expect_no_warning(fviz_eig(between))
+  expect_no_warning(fviz_eig(within))
+})
+
+test_that("malformed optional FactoMineR metadata does not add failures", {
+  skip_if_not_installed("FactoMineR")
+
+  template <- FactoMineR::PCA(iris[, 1:4], ncp = 4, graph = FALSE)
+  variants <- list(
+    no_svd = within(template, svd <- NULL),
+    null = within(template, svd$sumvp <- NULL),
+    missing = within(template, svd$sumvp <- NA_real_),
+    infinite = within(template, svd$sumvp <- Inf),
+    zero = within(template, svd$sumvp <- 0),
+    negative = within(template, svd$sumvp <- -1),
+    character = within(template, svd$sumvp <- "4"),
+    vector = within(template, svd$sumvp <- c(4, 4)),
+    missing_eigenvalue = within(template, eig[1, 1] <- NA_real_)
+  )
+
+  for (object in variants) {
+    expect_no_warning(fviz_eig(object))
+  }
+})

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -1184,3 +1184,139 @@ test_that("get_pca contributions/cos2 match FactoMineR::PCA (independent-engine 
   expect_equal(unname(ind$cos2),    unname(fm$ind$cos2),    tolerance = 1e-8)
   expect_equal(unname(var$cos2),    unname(fm$var$cos2),    tolerance = 1e-8)
 })
+
+# ---- Batch D2 (PR #274) Horn parallel analysis ----------------------------
+
+test_that("Horn thresholds use the original prcomp variable dimension", {
+  reference_threshold <- function(n_obs, n_var, iterations, seed){
+    set.seed(seed)
+    simulated <- matrix(NA_real_, nrow = iterations,
+                        ncol = min(n_obs - 1L, n_var))
+    for(i in seq_len(iterations)){
+      random_data <- matrix(rnorm(n_obs * n_var), nrow = n_obs,
+                            ncol = n_var)
+      simulated[i, ] <- eigen(
+        cor(random_data), symmetric = TRUE, only.values = TRUE
+      )$values[seq_len(ncol(simulated))]
+    }
+    unname(apply(simulated, 2, quantile, probs = 0.95, names = FALSE))
+  }
+
+  set.seed(301)
+  x <- matrix(rnorm(80 * 6), nrow = 80, ncol = 6)
+  truncated <- prcomp(x, center = TRUE, scale. = TRUE, rank. = 2)
+  seed <- 17
+  iterations <- 7
+
+  got <- factoextra:::.parallel_analysis_threshold(
+    truncated, iterations = iterations, seed = seed
+  )
+  expected <- reference_threshold(nrow(x), ncol(x), iterations, seed)
+
+  expect_equal(ncol(truncated$rotation), 2)
+  expect_equal(length(got), ncol(x))
+  expect_equal(got, expected, tolerance = 1e-12)
+
+  set.seed(302)
+  wide <- matrix(rnorm(8 * 12), nrow = 8, ncol = 12)
+  wide_fit <- prcomp(wide, center = TRUE, scale. = TRUE)
+  wide_got <- factoextra:::.parallel_analysis_threshold(
+    wide_fit, iterations = iterations, seed = seed
+  )
+  wide_expected <- reference_threshold(
+    nrow(wide), ncol(wide), iterations, seed
+  )
+  expect_equal(length(wide_got), min(nrow(wide) - 1L, ncol(wide)))
+  expect_equal(wide_got, wide_expected, tolerance = 1e-12)
+})
+
+test_that("Horn prcomp analysis fails closed when preprocessing is unrecoverable", {
+  set.seed(305)
+  x <- matrix(rnorm(60 * 4), nrow = 60, ncol = 4)
+
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(x, center = FALSE, scale. = TRUE)
+    ),
+    "mean-centered"
+  )
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(x, center = TRUE, scale. = c(1, 2, 3, 4))
+    ),
+    "custom scale"
+  )
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(x, center = TRUE, scale. = TRUE, retx = FALSE)
+    ),
+    "retx = TRUE"
+  )
+
+  tiny <- x * 1e-10
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(tiny, center = rep(0, ncol(tiny)), scale. = FALSE)
+    ),
+    "centered at the variable means"
+  )
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(tiny, center = TRUE, scale. = FALSE, rank. = 1)
+    ),
+    "truncated covariance prcomp"
+  )
+
+  x_na <- as.data.frame(x)
+  x_na[c(2, 11), 1] <- NA_real_
+  fit_na <- prcomp(
+    ~ ., data = x_na, center = TRUE, scale. = TRUE,
+    na.action = na.exclude
+  )
+  spec_na <- factoextra:::.parallel_analysis_spec(fit_na)
+  expect_equal(spec_na$n_obs, sum(complete.cases(fit_na$x)))
+})
+
+
+test_that("Horn covariance-PCA thresholds use reconstructed marginal variances", {
+  set.seed(11)
+  x <- cbind(a = rnorm(120, sd = 10), b = rnorm(120, sd = 5), c = rnorm(120, sd = 1))
+  fit <- prcomp(x, center = TRUE, scale. = FALSE)   # covariance PCA
+  seed <- 7; iterations <- 6
+  got <- factoextra:::.parallel_analysis_threshold(fit, iterations = iterations,
+                                                   seed = seed)
+  # Independent reference: marginal SDs taken from the DATA (not the fit),
+  # matched RNG, covariance eigenvalues via eigen(cov()).
+  marg_sd <- apply(x, 2, stats::sd)
+  reference <- function(n, p, marg_sd, iterations, seed){
+    set.seed(seed)
+    sim <- matrix(NA_real_, iterations, p)
+    for(i in seq_len(iterations)){
+      rd <- sweep(matrix(rnorm(n * p), n, p), 2, marg_sd, "*")
+      sim[i, ] <- eigen(cov(rd), symmetric = TRUE, only.values = TRUE)$values
+    }
+    unname(apply(sim, 2, quantile, probs = 0.95, names = FALSE))
+  }
+  expected <- reference(nrow(x), ncol(x), marg_sd, iterations, seed)
+  expect_equal(unname(got), expected, tolerance = 1e-8)
+  # The heteroscedastic spectrum must be reflected: a unit-variance regression
+  # would return ~1 for every component.
+  expect_gt(got[1], 50)
+})
+
+test_that("Horn princomp path: correlation/covariance thresholds and ambiguous cor", {
+  X <- iris[, -5]
+  pr_cor <- princomp(X, cor = TRUE)
+  pr_cov <- princomp(X, cor = FALSE)
+  expect_length(factoextra:::.parallel_analysis_threshold(pr_cor, 6, seed = 1),
+                ncol(X))
+  expect_true(all(is.finite(
+    factoextra:::.parallel_analysis_threshold(pr_cov, 6, seed = 1)
+  )))
+  # cor recorded as a symbol with a unit stored scale is genuinely ambiguous.
+  ambiguous <- pr_cor
+  ambiguous$call[["cor"]] <- quote(use_flag)
+  ambiguous$scale <- rep(1, ncol(X))
+  expect_error(factoextra:::.parallel_analysis_spec(ambiguous),
+               "Cannot determine")
+})


### PR DESCRIPTION
Batch D2 of the staged integration of #274 (@erdeyl). Rewrites the **opt-in** Horn parallel-analysis overlay in `fviz_eig(parallel = TRUE)`, plus a truncated-spectrum warning. Numeric change, cross-validated against independent engines.

### What changes (only the `parallel = TRUE` overlay + the new warning)
- **Covariance PCA** (`prcomp(scale. = FALSE)` / `princomp(cor = FALSE)`): previously simulated unit-variance reference data → statistically wrong thresholds. Now reconstructs the fit's marginal variances. (Genuine correctness fix — e.g. ~95× different on the leading component for heteroscedastic data.)
- **Full-rank correlation PCA**: unaffected in distribution (byte-identical thresholds at a matched seed). Rank-truncated / wide (n ≤ p) fits now simulate over the original variable count.
- **Fail-closed**: fits whose reference distribution can't be reconstructed (uncentered, custom scale vector, `retx = FALSE`, rank-truncated covariance, ambiguous `princomp` `cor`) now error clearly instead of returning misleading thresholds.
- **Truncated-spectrum warning**: `fviz_eig()` warns when a FactoMineR PCA stores an incomplete eigenvalue spectrum (refit with a larger `ncp`).

### Cross-validation (shipped as tests)
- Correlation thresholds vs an independent `eigen(cor())` Monte Carlo: agree ≤0.35%; matched-seed test to 1e-12.
- **Covariance** thresholds vs an independent `eigen(cov())` reference (marginal SDs taken from the data): matched-seed to ~1e-8; a unit-variance regression would return ~1 per component and fail.
- princomp correlation/covariance paths tested; ambiguous-`cor` errors tested.

### Notes
- **Default path** (`parallel = FALSE`) and `get_eig()` / `get_eigenvalue()` are **byte-identical** to `release/2.2.0` (verified across 72 digests: FactoMineR PCA/CA/MCA, prcomp, princomp, ade4, ca).
- The truncated-spectrum test **skips gracefully** on FactoMineR versions that retain full spectra — no CI fragility.
- Full suite green in a clean session: **FAIL 0 | WARN 0 | PASS 758** (2 unrelated/graceful skips). `.Rd` regenerated with roxygen2 7.3.3 (only `eigenvalue.Rd`).

Refs #274. Not for merge without maintainer approval.
