### PR TITLE
Integrate #274 (D4): recover tidymodels recipe/workflow PCA correlations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,20 @@
   variable contributions, coordinates, and cos2 are unchanged. Cross-validated
   against `FactoMineR::PCA()` and `ade4::inertia.dudi()`. Thanks to @erdeyl (#274).
 
+* `as_factoextra_pca()` recipe / workflow methods (tidymodels): variable-component
+  correlations and cos2 are now recovered from the full PCA inertia, so they match
+  `FactoMineR::PCA()` of the same data even when `step_pca()` keeps only a few
+  components (previously the cos2 was normalized within the retained subspace and
+  matched only when all components were kept). `scale.unit` is set to `TRUE` only
+  when every PCA input is both centered and unit-scaled at the PCA boundary.
+  When the inputs are not provably centered (e.g. a bare `step_pca()`), the
+  variable-component correlations cannot be recovered: the scores, eigenvalues
+  and variable coordinates are still returned (so `fviz_pca_ind()` / `fviz_eig()`
+  and the variable arrows keep working), but the correlation circle is omitted
+  and a warning is issued (add `step_center()` / `step_normalize()`, or set
+  `step_pca(options = list(center = TRUE))`, to recover them). Cross-validated
+  against `FactoMineR::PCA()`. Thanks to @erdeyl (#274).
+
 * `get_clust_tendency()`: the Hopkins statistic now samples the observed points
   **without replacement** (the previous code sampled with replacement, which could
   draw the same observation more than once), counts a duplicated row as a valid

--- a/R/as_factoextra.R
+++ b/R/as_factoextra.R
@@ -79,8 +79,9 @@ NULL
 #' pca <- prcomp(iris[, -5], scale. = TRUE)
 #' obj2 <- as_factoextra_pca(
 #'   ind.coord = pca$x,
-#'   var.coord = pca$rotation,
-#'   eig       = pca$sdev^2
+#'   var.coord = sweep(pca$rotation, 2, pca$sdev, "*"),
+#'   eig       = pca$sdev^2,
+#'   scale.unit = TRUE
 #' )
 #' fviz_pca_biplot(obj2, label = "var", col.ind = "steelblue")
 #'
@@ -170,12 +171,18 @@ as_factoextra_pca.default <- function(ind.coord, var.coord = NULL, eig = NULL,
 #' \code{tidy(step, type = "coef")}, and the \emph{full} set of eigenvalues from
 #' \code{tidy(step, type = "variance")} (so the scree plot and axis percentages are
 #' honest even when \code{num_comp} keeps only a few components). Variable
-#' coordinates are the true variable-component correlations (loading times the
-#' square root of the eigenvalue), and \code{scale.unit} is set to \code{TRUE} when
-#' a \code{step_normalize()}/\code{step_scale()} precedes the PCA, so the
-#' correlation circle is drawn only when it is meaningful. Variable coordinates,
-#' cos2 and contributions, and the eigenvalue percentages, match a full
-#' \code{FactoMineR::PCA()} of the same (scaled) data regardless of how many
+#' coordinates are loading times the square root of the eigenvalue. Exact
+#' variable-component correlations and cos2 are recovered from the full PCA
+#' inertia when every PCA input is provably centered. When the inputs are not
+#' provably centered (e.g. a bare \code{step_pca()} with no centering), the
+#' correlations cannot be recovered: the scores, eigenvalues and variable
+#' coordinates are still returned (so \code{fviz_pca_ind()}, \code{fviz_eig()} and
+#' the variable arrows work), but the correlation circle is omitted and a warning
+#' is issued. \code{scale.unit} is set to \code{TRUE} only when every
+#' PCA input is both centered and unit-scaled at the PCA boundary; partial scaling
+#' therefore does not draw a correlation circle. For fully normalized data,
+#' variable coordinates, correlations, cos2 and contributions, and the eigenvalue
+#' percentages match a full \code{FactoMineR::PCA()} regardless of how many
 #' components \code{step_pca()} keeps; the \emph{individual} cos2 is computed over
 #' the retained components (it equals the full-space cos2 only when all components
 #' are kept). The two-dimensional plots (\code{fviz_pca_ind()},
@@ -191,7 +198,8 @@ as_factoextra_pca.recipe <- function(ind.coord, ...){
   .fe_need("recipes")
   ex <- .fe_extract_recipe_pca(ind.coord, scores = NULL)
   as_factoextra_pca.default(ind.coord = ex$scores, var.coord = ex$var.coord,
-                            var.cos2 = ex$var.cos2, eig = ex$eig,
+                            var.cos2 = ex$var.cos2, var.cor = ex$var.cor,
+                            eig = ex$eig,
                             scale.unit = ex$scale.unit)
 }
 
@@ -216,7 +224,8 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
   mold <- workflows::extract_mold(wf)
   ex <- .fe_extract_recipe_pca(rec, scores = as.matrix(mold$predictors))
   as_factoextra_pca.default(ind.coord = ex$scores, var.coord = ex$var.coord,
-                            var.cos2 = ex$var.cos2, eig = ex$eig,
+                            var.cos2 = ex$var.cos2, var.cor = ex$var.cor,
+                            eig = ex$eig,
                             scale.unit = ex$scale.unit)
 }
 
@@ -232,7 +241,7 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
 # Extract scores / loadings / eigenvalues from a prepped recipe whose dimension
 # reduction is step_pca(). `scores` may be supplied (fitted-workflow path, from the
 # mold) to avoid bake(new_data = NULL), which fails when the training set was not
-# retained. Returns a list(scores, var.coord, eig, scale.unit).
+# retained. Returns a list(scores, var.coord, var.cor, var.cos2, eig, scale.unit).
 .fe_extract_recipe_pca <- function(rec, scores = NULL){
   if(!isTRUE(recipes::fully_trained(rec)))
     stop("The recipe is not prepped. Call prep() on it first.", call. = FALSE)
@@ -269,23 +278,29 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
   load_long <- recipes::tidy(rec, id = st$id, type = "coef")
   all_comp  <- unique(load_long$component)
   all_comp  <- all_comp[order(suppressWarnings(as.integer(gsub("\\D", "", all_comp))))]
+  if(k < 1L || k > length(all_comp))
+    stop("The fitted step_pca() retained an invalid number of components.",
+         call. = FALSE)
   load_comp <- all_comp[seq_len(k)]
   terms <- unique(load_long$terms)
-  loadings <- matrix(NA_real_, nrow = length(terms), ncol = k,
-                     dimnames = list(terms, score_comp))
-  for(j in seq_len(k)){
-    cj <- load_long[load_long$component == load_comp[j], ]
-    loadings[cj$terms, j] <- cj$value
+  full.loadings <- matrix(NA_real_, nrow = length(terms), ncol = length(all_comp),
+                          dimnames = list(terms, all_comp))
+  for(j in seq_along(all_comp)){
+    cj <- load_long[load_long$component == all_comp[j], ]
+    full.loadings[cj$terms, j] <- cj$value
   }
+  loadings <- full.loadings[, seq_len(k), drop = FALSE]
+  colnames(loadings) <- score_comp
 
   # Eigenvalues: the FULL set (all components) for an honest scree / percentages.
   var_long <- recipes::tidy(rec, id = st$id, type = "variance")
   vv  <- var_long[var_long$terms == "variance", , drop = FALSE]
   eig <- vv$value[order(vv$component)]
+  if(length(eig) < ncol(full.loadings))
+    stop("Could not recover the full eigenvalue set from the fitted step_pca().",
+         call. = FALSE)
 
-  # Variable coordinates = variable-component correlations = loading * sqrt(eig)
-  # (matches FactoMineR's var$coord); valid as a correlation circle only when the
-  # predictors were scaled before PCA.
+  # Variable coordinates use the ordinary PCA loading * component-SD definition.
   var.coord <- sweep(loadings, 2, sqrt(eig[seq_len(k)]), "*")
 
   # Scores: from the mold (workflow) or the baked training data (recipe).
@@ -301,19 +316,92 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
     scores <- scores[, score_comp, drop = FALSE]
   }
 
-  # Correlation circle only when a scaling step precedes the PCA.
+  # Variable-component correlations require provably centered PCA inputs.
+  # Preprocessing state is tracked in recipe order and unknown value-changing
+  # steps reset the proof; an internal prcomp center/scale option, when present,
+  # is applied at the PCA boundary. When correlations cannot be recovered
+  # (uncentered inputs, or a zero-inertia variable), we still return the scores,
+  # eigenvalues and variable coordinates - so fviz_pca_ind()/fviz_eig()/
+  # fviz_pca_var() work - but omit the recovered correlations/cos2 and the
+  # correlation circle (scale.unit = FALSE), with a one-time warning.
   pca_pos <- which(is_pca)
-  scaled  <- any(vapply(rec$steps[seq_len(pca_pos - 1L)], inherits, logical(1),
-                        c("step_normalize", "step_scale")))
+  prep.state <- .fe_recipe_pca_preprocessing(rec, pca_pos, st)
 
-  # On scaled data a variable is fully represented (its total squared correlation
-  # is 1), so its cos2 on each axis is exactly the squared correlation. Supplying
-  # it makes fviz_pca_var()'s cos2 match FactoMineR at any num_comp, instead of the
-  # default within-retained-subspace normalization.
-  var.cos2 <- if(scaled) var.coord^2 else NULL
+  var.cor <- NULL
+  var.cos2 <- NULL
+  scale.unit <- FALSE
+  can.recover <- prep.state$centered
+  if(can.recover){
+    full.var.coord <- sweep(full.loadings, 2,
+                            sqrt(eig[seq_len(ncol(full.loadings))]), "*")
+    var.inertia <- rowSums(full.var.coord^2)
+    if(any(!is.finite(var.inertia)) || any(var.inertia <= 0)) can.recover <- FALSE
+  }
+  if(can.recover){
+    var.cor <- sweep(var.coord, 1, sqrt(var.inertia), "/")
+    var.cos2 <- var.cor^2
+    unit.tol <- sqrt(.Machine$double.eps)
+    unit.inertia <- all(abs(var.inertia - 1) <= unit.tol * pmax(1, var.inertia))
+    scale.unit <- prep.state$scaled && unit.inertia
+  } else {
+    warning("Variable-component correlations cannot be recovered from this ",
+            "step_pca() fit (its inputs are not provably centered, or a variable ",
+            "has zero inertia), so the correlation circle is omitted. Add ",
+            "step_center()/step_normalize(), or set ",
+            "step_pca(options = list(center = TRUE)), to recover them.",
+            call. = FALSE)
+  }
 
-  list(scores = scores, var.coord = var.coord, var.cos2 = var.cos2,
-       eig = eig, scale.unit = scaled)
+  list(scores = scores, var.coord = var.coord, var.cor = var.cor,
+       var.cos2 = var.cos2, eig = eig, scale.unit = scale.unit)
+}
+
+# Prove whether every fitted step_pca() input is centered and unit-scaled at the
+# PCA boundary. Unknown intervening transformations fail closed; a later known
+# center/scale/normalize step can re-establish the relevant property.
+.fe_recipe_pca_preprocessing <- function(rec, pca_pos, pca_step){
+  columns <- unname(pca_step$columns)
+  centered <- stats::setNames(rep(FALSE, length(columns)), columns)
+  scaled <- stats::setNames(rep(FALSE, length(columns)), columns)
+
+  preceding <- rec$steps[seq_len(pca_pos - 1L)]
+  for(step in preceding){
+    if(inherits(step, "step_normalize")){
+      hit <- intersect(columns, intersect(names(step$means), names(step$sds)))
+      centered[hit] <- TRUE
+      scaled[hit] <- TRUE
+    }
+    else if(inherits(step, "step_center")){
+      hit <- intersect(columns, names(step$means))
+      centered[hit] <- TRUE
+    }
+    else if(inherits(step, "step_scale")){
+      hit <- intersect(columns, names(step$sds))
+      is.unit <- is.numeric(step$factor) && length(step$factor) == 1L &&
+        is.finite(step$factor) && abs(step$factor - 1) <= sqrt(.Machine$double.eps)
+      scaled[hit] <- is.unit
+    }
+    else if(inherits(step, c("step_rm", "step_select", "step_zv", "step_nzv",
+                             "step_corr", "step_lincomb"))){
+      # These fitted steps only remove columns. Values of the surviving PCA
+      # inputs are unchanged, so an earlier centering/scaling proof remains valid.
+    }
+    else {
+      centered[] <- FALSE
+      scaled[] <- FALSE
+    }
+  }
+
+  # Only a literal center = TRUE proves centering at the training means. prcomp()
+  # also accepts arbitrary numeric centers, which must not be treated as means.
+  if(isTRUE(pca_step$options$center)) centered[] <- TRUE
+
+  internal.scale <- pca_step$res$scale
+  if(is.numeric(internal.scale) && length(internal.scale) == length(columns) &&
+     all(is.finite(internal.scale)) && all(internal.scale > 0)) scaled[] <- TRUE
+
+  list(centered = length(columns) > 0L && all(centered),
+       scaled = length(columns) > 0L && all(scaled))
 }
 
 # Coerce coordinates to a numeric matrix with Dim.1..k colnames and row names.

--- a/man/as_factoextra.Rd
+++ b/man/as_factoextra.Rd
@@ -99,12 +99,18 @@ workflow, \code{workflows::extract_mold()}), the loadings from
 \code{tidy(step, type = "coef")}, and the \emph{full} set of eigenvalues from
 \code{tidy(step, type = "variance")} (so the scree plot and axis percentages are
 honest even when \code{num_comp} keeps only a few components). Variable
-coordinates are the true variable-component correlations (loading times the
-square root of the eigenvalue), and \code{scale.unit} is set to \code{TRUE} when
-a \code{step_normalize()}/\code{step_scale()} precedes the PCA, so the
-correlation circle is drawn only when it is meaningful. Variable coordinates,
-cos2 and contributions, and the eigenvalue percentages, match a full
-\code{FactoMineR::PCA()} of the same (scaled) data regardless of how many
+coordinates are loading times the square root of the eigenvalue. Exact
+variable-component correlations and cos2 are recovered from the full PCA
+inertia when every PCA input is provably centered. When the inputs are not
+provably centered (e.g. a bare \code{step_pca()} with no centering), the
+correlations cannot be recovered: the scores, eigenvalues and variable
+coordinates are still returned (so \code{fviz_pca_ind()}, \code{fviz_eig()} and
+the variable arrows work), but the correlation circle is omitted and a warning
+is issued. \code{scale.unit} is set to \code{TRUE} only when every
+PCA input is both centered and unit-scaled at the PCA boundary; partial scaling
+therefore does not draw a correlation circle. For fully normalized data,
+variable coordinates, correlations, cos2 and contributions, and the eigenvalue
+percentages match a full \code{FactoMineR::PCA()} regardless of how many
 components \code{step_pca()} keeps; the \emph{individual} cos2 is computed over
 the retained components (it equals the full-space cos2 only when all components
 are kept). The two-dimensional plots (\code{fviz_pca_ind()},
@@ -126,8 +132,9 @@ fviz_eig(obj)
 pca <- prcomp(iris[, -5], scale. = TRUE)
 obj2 <- as_factoextra_pca(
   ind.coord = pca$x,
-  var.coord = pca$rotation,
-  eig       = pca$sdev^2
+  var.coord = sweep(pca$rotation, 2, pca$sdev, "*"),
+  eig       = pca$sdev^2,
+  scale.unit = TRUE
 )
 fviz_pca_biplot(obj2, label = "var", col.ind = "steelblue")
 

--- a/tests/testthat/test-as-factoextra-tidymodels.R
+++ b/tests/testthat/test-as-factoextra-tidymodels.R
@@ -60,6 +60,100 @@ test_that("as_factoextra_pca(recipe) cross-validates against base-R ground truth
   expect_equal(abs(unname(obj$ind$coord)), abs(unname(pc$x[, 1:2])), tolerance = 1e-6)
 })
 
+test_that("recipe PCA separates coordinates, correlations and scaling state", {
+  centered <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_center(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2)
+  obj <- as_factoextra_pca(recipes::prep(centered))
+  x_centered <- scale(iris[, 1:4], center = TRUE, scale = FALSE)
+  truth <- stats::cor(x_centered, obj$ind$coord)
+
+  expect_false(obj$scale.unit)
+  expect_equal(unname(obj$var$cor), unname(truth), tolerance = 1e-9)
+  expect_equal(unname(obj$var$cos2), unname(truth^2), tolerance = 1e-9)
+  expect_false(isTRUE(all.equal(unname(obj$var$coord), unname(obj$var$cor))))
+
+  partial <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_center(recipes::all_numeric_predictors()) |>
+    recipes::step_scale(Sepal.Length) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2)
+  partial_obj <- as_factoextra_pca(recipes::prep(partial))
+  x_partial <- scale(iris[, 1:4], center = TRUE, scale = FALSE)
+  x_partial[, "Sepal.Length"] <- x_partial[, "Sepal.Length"] /
+    stats::sd(x_partial[, "Sepal.Length"])
+  partial_truth <- stats::cor(x_partial, partial_obj$ind$coord)
+
+  expect_false(partial_obj$scale.unit)
+  expect_equal(unname(partial_obj$var$cor), unname(partial_truth), tolerance = 1e-9)
+  expect_equal(unname(partial_obj$var$cos2), unname(partial_truth^2), tolerance = 1e-9)
+})
+
+test_that("recipe PCA detects internal scaling and degrades uncentered semantics", {
+  internal <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_pca(
+      recipes::all_numeric_predictors(), num_comp = 2,
+      options = list(center = TRUE, scale. = TRUE)
+  )
+  internal_obj <- as_factoextra_pca(recipes::prep(internal))
+  internal_truth <- stats::prcomp(
+    iris[, 1:4], center = TRUE, scale. = TRUE, rank. = 2
+  )
+  expect_true(internal_obj$scale.unit)
+  expect_equal(unname(internal_obj$ind$coord),
+               unname(internal_truth$x[, 1:2]), tolerance = 1e-9)
+  expect_equal(unname(internal_obj$var$cor),
+               unname(stats::cor(iris[, 1:4], internal_truth$x[, 1:2])),
+               tolerance = 1e-9)
+  expect_equal(internal_obj$var$coord, internal_obj$var$cor,
+               tolerance = 1e-9)
+
+  # Uncentered recipe PCA cannot yield variable-component correlations, so the
+  # correlation circle is dropped (scale.unit = FALSE) with a warning, but the
+  # scores / eigenvalues / variable coordinates are still returned so the scatter
+  # and scree plots keep working.
+  uncentered <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2)
+  expect_warning(u_obj <- as_factoextra_pca(recipes::prep(uncentered)),
+                 "correlation circle is omitted")
+  expect_false(u_obj$scale.unit)
+  expect_equal(nrow(get_eig(u_obj)), 4L)
+  expect_s3_class(fviz_pca_ind(u_obj, geom = "point"), "ggplot")
+  expect_s3_class(fviz_eig(u_obj), "ggplot")
+
+  scale_only <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_scale(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2)
+  expect_warning(so_obj <- as_factoextra_pca(recipes::prep(scale_only)),
+                 "correlation circle is omitted")
+  expect_false(so_obj$scale.unit)
+
+  arbitrary_center <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_pca(
+      recipes::all_numeric_predictors(), num_comp = 2,
+      options = list(center = rep(0, 4))
+    )
+  expect_warning(as_factoextra_pca(recipes::prep(arbitrary_center)),
+                 "correlation circle is omitted")
+})
+
+test_that("column-only recipe steps preserve centering and scaling evidence", {
+  rec <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_corr(recipes::all_numeric_predictors(), threshold = 0.99) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2)
+  prepped <- recipes::prep(rec)
+  obj <- as_factoextra_pca(prepped)
+  baked <- recipes::bake(prepped, new_data = NULL)
+  score_names <- recipes::names0(2, prepped$steps[[3]]$prefix)
+
+  expect_true(obj$scale.unit)
+  expect_equal(
+    abs(unname(obj$ind$coord)),
+    abs(unname(as.matrix(baked[, score_names, drop = FALSE]))),
+    tolerance = 1e-10
+  )
+})
+
 test_that("as_factoextra_pca(recipe) matches FactoMineR (authoritative engine)", {
   skip_if_not_installed("FactoMineR")
   # A step_normalize + step_pca recipe is a scaled PCA, directly comparable to
@@ -153,6 +247,9 @@ test_that("as_factoextra_pca(workflow) matches the recipe path (fitted workflow)
   expect_s3_class(obj_wf, "factoextra_pca")
   expect_equal(obj_wf$eig.values, obj_rec$eig.values, tolerance = 1e-6)
   expect_equal(abs(obj_wf$ind$coord), abs(obj_rec$ind$coord), tolerance = 1e-6)
+  # the workflow path recovers the same variable correlations and scaling state
+  expect_equal(abs(obj_wf$var$cor), abs(obj_rec$var$cor), tolerance = 1e-6)
+  expect_identical(obj_wf$scale.unit, obj_rec$scale.unit)
 
   # unfitted workflow (recipe added but not fit) errors with a fit()/prep() hint
   wf_unfit <- workflows::workflow() |> workflows::add_recipe(rec)

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -1077,6 +1077,11 @@ test_that("as_factoextra_pca() validates inputs and errors clearly", {
   expect_error(as_factoextra_pca(mds_inf), "finite values only")
   expect_error(as_factoextra_pca(mds, var.coord = mds, var.cos2 = matrix(Inf, nrow(mds), 2)),
                "finite values only")
+  # a within-tolerance negative eigenvalue is clamped to 0, not rejected
+  tiny_negative <- -sqrt(.Machine$double.eps) / 2
+  clamped <- as_factoextra_pca(matrix(c(-1, 1, -2, 2), ncol = 2),
+                               eig = c(1, tiny_negative, 0))
+  expect_identical(clamped$eig.values, c(1, 0, 0))
 })
 
 test_that("as_factoextra_pca() does not change existing prcomp/PCA paths (no-regression)", {


### PR DESCRIPTION
Batch D4 of the staged integration of #274 (@erdeyl). Corrects the tidymodels recipe/workflow bridge in `as_factoextra_pca()`. Numeric change, cross-validated; affects only the recipe/workflow path.

### What changes
- Variable-component **correlations and cos2 are recovered from the full PCA inertia**, so they match `FactoMineR::PCA()` of the same data even when `step_pca()` keeps only a few components (previously cos2 was normalized within the retained subspace and matched only when all components were kept).
- `scale.unit` is TRUE only when every PCA input is both centered and unit-scaled at the PCA boundary (a `.fe_recipe_pca_preprocessing()` proof that tracks centering/scaling across recipe steps).
- When the inputs are **not provably centered** (e.g. a bare `step_pca()`), correlations can't be recovered: the scores, eigenvalues and variable coordinates are **still returned** (so `fviz_pca_ind()` / `fviz_eig()` and the variable arrows keep working), but the **correlation circle is omitted with a warning**. This degrades gracefully rather than erroring.

The default constructor and non-recipe paths are unchanged.

### Cross-validation (shipped as tests)
- Recovered `var$cor` / `var$cos2` match `FactoMineR::PCA()` and `stats::cor(preprocessed, scores)` to ~1e-15, and are independent of `num_comp` (identical at `num_comp = 2` vs `4`).
- `scale.unit` states tested across normalize / center-only / partial-scaling / internal `step_pca(options=)`; column-only steps (`step_corr` etc.) preserve the centering/scaling proof.
- The graceful uncentered path is tested (warns, returns a usable object, no circle); the workflow path is checked against the recipe path.

### Notes
- Full suite green in a clean session: **FAIL 0 | WARN 0 | PASS 795** (2 unrelated/graceful skips). `.Rd` regenerated with roxygen2 7.3.3 (only `as_factoextra.Rd`).

Refs #274. Not for merge without maintainer approval.
