### PR TITLE
Integrate #274 (D5): exact Gabriel scaling for form/covariance biplots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,13 @@
   variable contributions, coordinates, and cos2 are unchanged. Cross-validated
   against `FactoMineR::PCA()` and `ade4::inertia.dudi()`. Thanks to @erdeyl (#274).
 
+* `fviz_pca_biplot()`: `biplot.type = "form"` and `biplot.type = "covariance"`
+  now use the exact Gabriel biplot factorization, matching
+  `stats::biplot(scale = 0)` and `stats::biplot(scale = 1)` respectively, instead
+  of the previous display heuristic. The default `biplot.type = "auto"` is
+  unchanged (byte-identical). These two modes require a `prcomp` / `princomp`
+  object. Thanks to @erdeyl (#274).
+
 * `as_factoextra_pca()` recipe / workflow methods (tidymodels): variable-component
   correlations and cos2 are now recovered from the full PCA inertia, so they match
   `FactoMineR::PCA()` of the same data even when `step_pca()` keeps only a few

--- a/R/fviz_pca.R
+++ b/R/fviz_pca.R
@@ -23,7 +23,7 @@
 #'   \code{\link{fviz_pca_ind}()} and \code{\link{fviz_pca_var}()}.
 #'   
 #' @param X an object of class PCA [FactoMineR]; prcomp and princomp [stats]; 
-#'   dudi and pca [ade4]; expOutput/epPCA [ExPosition].
+#'   dudi and pca [ade4]; expoOutput/epPCA [ExPosition].
 #' @param axes a numeric vector of length 2 specifying the dimensions to be 
 #'   plotted.
 #' @param geom a text specifying the geometry to be used for the graph. Allowed 
@@ -36,13 +36,13 @@
 #'   respectively. Default is geom.ind = c("point", "text), geom.var = 
 #'   c("arrow", "text").
 #' @param label a text specifying the elements to be labelled. Default value is 
-#'   "all". Allowed values are "none" or the combination of c("ind", "ind.sup", 
+#'   "all". Allowed values are "all", "none", or a combination of c("ind", "ind.sup",
 #'   "quali", "var", "quanti.sup"). "ind" can be used to label only active 
 #'   individuals. "ind.sup" is for supplementary individuals. "quali" is for 
 #'   supplementary qualitative variables. "var" is for active variables. 
 #'   "quanti.sup" is for quantitative supplementary variables.
 #' @param invisible a text specifying the elements to be hidden on the plot. 
-#'   Default value is "none". Allowed values are the combination of c("ind", 
+#'   Default value is "none". Allowed values are "all", "none", or a combination of c("ind",
 #'   "ind.sup", "quali", "var", "quanti.sup").
 #' @param title the title of the graph
 #' @param habillage an optional factor variable for coloring the observations by
@@ -53,8 +53,8 @@
 #' @param addEllipses logical value. If TRUE, draws ellipses around the 
 #'   individuals when habillage != "none".
 #' @param col.ind,col.var color for individuals and variables, respectively. Can
-#'   be a continuous variable or a factor variable. Possible values include also
-#'   : "cos2", "contrib", "coord", "x" or "y". In this case, the colors for 
+#'   be a continuous variable or a factor variable. Possible values also include
+#'   "cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 #'   individuals/variables are automatically controlled by their qualities of 
 #'   representation ("cos2"), contributions ("contrib"), coordinates (x^2+y^2, 
 #'   "coord"), x values ("x") or y values ("y"). To use automatic coloring (by 
@@ -69,9 +69,9 @@
 #'   to rename the legends.
 #' @param col.ind.sup color for supplementary individuals
 #' @param alpha.ind,alpha.var controls the transparency of individual and 
-#'   variable colors, respectively. The value can variate from 0 (total 
+#'   variable colors, respectively. The value can vary from 0 (total
 #'   transparency) to 1 (no transparency). Default value is 1. Possible values 
-#'   include also : "cos2", "contrib", "coord", "x" or "y". In this case, the 
+#'   also include "cos2", "contrib", "coord", "x", and "y". In this case, the
 #'   transparency for the individual/variable colors are automatically 
 #'   controlled by their qualities ("cos2"), contributions ("contrib"), 
 #'   coordinates (x^2+y^2, "coord"), x values("x") or y values("y"). To use 
@@ -92,10 +92,15 @@
 #' @param biplot.type type of biplot scaling for fviz_pca_biplot(). Options are:
 #'   \itemize{
 #'     \item "auto" (default): Uses range-based rescaling for visualization
-#'     \item "form": Form-oriented scaling (Gabriel-style). Prioritizes
-#'       readability of individual relationships.
-#'     \item "covariance": Covariance-oriented scaling (Gabriel-style).
-#'       Prioritizes readability of variable relationships.
+#'     \item "form": Gabriel form biplot scaling (equivalent to
+#'       \code{stats::biplot(..., scale = 0)}), preserving the score geometry
+#'       used to compare individuals.
+#'     \item "covariance": Gabriel covariance biplot scaling (equivalent to
+#'       \code{stats::biplot(..., scale = 1)}), preserving the variable
+#'       covariance geometry. Because both clouds share a single set of axes
+#'       (unlike \code{stats::biplot()}'s dual axes), the individuals can appear
+#'       compressed relative to the variable arrows; use "form" or "auto" if the
+#'       individual cloud is the focus.
 #'   }
 #'   Note: "form" and "covariance" scaling requires prcomp or princomp objects.
 #' @inheritParams ggpubr::ggpar
@@ -279,31 +284,48 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
   ind <- data.frame(pca.ind$coord[, axes, drop=FALSE])
   colnames(ind)<- c("x", "y")
   
-  # Rescale variable coordinates based on biplot.type
-
-  # Heuristic Gabriel-style scaling choices for improved readability.
+  # Rescale both score and loading coordinates according to Gabriel's biplot
+  # factorization. The default auto mode retains factoextra's historical
+  # range-based display scaling.
+  plot_X <- X
+  var_scale <- NULL
   if(biplot.type == "form" || biplot.type == "covariance") {
-    # Get eigenvalues (singular values squared for scaling)
-    if(inherits(X, "prcomp")) {
-      sdev <- X$sdev[axes]
-    } else if(inherits(X, "princomp")) {
-      sdev <- X$sdev[axes]
-    } else {
+    if(!inherits(X, c("prcomp", "princomp"))) {
       # Fall back to auto for other object types
       warning("biplot.type 'form' or 'covariance' requires prcomp/princomp objects. Using 'auto'.")
       biplot.type <- "auto"
-    }
+    } else {
+      sdev <- as.numeric(X$sdev)
+      if(any(!is.finite(sdev[axes])) || any(sdev[axes] <= 0))
+        stop("The selected axes must have positive finite standard deviations for ",
+             "form/covariance biplot scaling.", call. = FALSE)
 
-    if(biplot.type == "form") {
-      # Form biplot (scale=0): preserves distances between individuals
-      # Variables are scaled down, individuals keep their scores
-      r <- 1 / max(abs(var[, c("x", "y")])) * 0.8 * max(abs(ind[, c("x", "y")]))
-    } else if(biplot.type == "covariance") {
-      # Covariance biplot (scale=1): preserves correlations between variables
-      # Variables scaled by sqrt(n) * sdev, individuals scaled down
-      n_obs <- nrow(ind)
-      # Scale factor to make variable vectors meaningful while keeping individuals visible
-      r <- sqrt(n_obs) * 0.15
+      pca.var <- get_pca_var(X)
+      display_ind <- pca.ind$coord
+      display_var <- pca.var$coord
+      if(biplot.type == "form") {
+        # scale = 0: score coordinates and unscaled loading vectors.
+        display_var[, axes] <- sweep(
+          display_var[, axes, drop = FALSE], 2, sdev[axes], "/"
+        )
+      } else {
+        # scale = 1: scores divided by sqrt(n)*sdev and loadings multiplied
+        # by the same factor.
+        lambda <- sqrt(nrow(display_ind)) * sdev[axes]
+        display_ind[, axes] <- sweep(
+          display_ind[, axes, drop = FALSE], 2, lambda, "/"
+        )
+        display_var[, axes] <- sweep(
+          display_var[, axes, drop = FALSE], 2, sqrt(nrow(display_ind)), "*"
+        )
+      }
+      plot_X <- as_factoextra_pca(
+        ind.coord = display_ind, var.coord = display_var, eig = X$sdev^2,
+        ind.cos2 = pca.ind$cos2, ind.contrib = pca.ind$contrib,
+        var.cos2 = pca.var$cos2, var.contrib = pca.var$contrib,
+        var.cor = pca.var$cor, scale.unit = FALSE
+      )
+      var_scale <- 1
     }
   }
 
@@ -315,6 +337,7 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
     valid_ratios <- c(ratio_x, ratio_y)
     valid_ratios <- valid_ratios[is.finite(valid_ratios) & valid_ratios > 0]
     r <- if(length(valid_ratios) > 0) min(valid_ratios) else 1
+    var_scale <- r * 0.7
   }
   
   # When fill.ind = grouping variable & col.var = continuous variable,
@@ -329,17 +352,17 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
   
   
   # Individuals
-  p <- fviz_pca_ind(X,  axes = axes, geom = geom.ind, repel = repel,
+  p <- fviz_pca_ind(plot_X,  axes = axes, geom = geom.ind, repel = repel,
                     col.ind = col.ind, fill.ind = fill.ind, shape.ind = shape.ind,
                     label = label, invisible=invisible, habillage = habillage,
                     addEllipses = addEllipses, # palette = palette,
                     ellipse.border.remove = ellipse.border.remove,
                     ...)
   # Add variables
-  p <- fviz_pca_var(X, axes = axes, geom =  geom.var, repel = repel,
+  p <- fviz_pca_var(plot_X, axes = axes, geom =  geom.var, repel = repel,
                     col.var = col.var, fill.var = fill.var,
                     label = label, invisible = invisible,
-                    scale.= r*0.7, ggp = p,  ...)
+                    scale.= var_scale, ggp = p,  ...)
   
   if(!is.null(gradient.cols)){
     if(is.gradient.color) p <- p + ggpubr::gradient_color(gradient.cols)

--- a/man/fviz_pca.Rd
+++ b/man/fviz_pca.Rd
@@ -69,7 +69,7 @@ fviz_pca_biplot(
 }
 \arguments{
 \item{X}{an object of class PCA [FactoMineR]; prcomp and princomp [stats]; 
-dudi and pca [ade4]; expOutput/epPCA [ExPosition].}
+dudi and pca [ade4]; expoOutput/epPCA [ExPosition].}
 
 \item{...}{Additional arguments. \itemize{ \item in fviz_pca_ind() and 
 fviz_pca_var(): Additional arguments are passed to the functions fviz() and
@@ -113,8 +113,8 @@ case a basic color palette is created using the function
 individuals when habillage != "none".}
 
 \item{col.ind, col.var}{color for individuals and variables, respectively. Can
-be a continuous variable or a factor variable. Possible values include also
-: "cos2", "contrib", "coord", "x" or "y". In this case, the colors for 
+be a continuous variable or a factor variable. Possible values also include
+"cos2", "contrib", "coord", "x", and "y". In this case, the colors for
 individuals/variables are automatically controlled by their qualities of 
 representation ("cos2"), contributions ("contrib"), coordinates (x^2+y^2, 
 "coord"), x values ("x") or y values ("y"). To use automatic coloring (by 
@@ -125,9 +125,9 @@ cos2, contrib, ....), make sure that habillage ="none".}
 \item{col.ind.sup}{color for supplementary individuals}
 
 \item{alpha.ind, alpha.var}{controls the transparency of individual and 
-variable colors, respectively. The value can variate from 0 (total 
+variable colors, respectively. The value can vary from 0 (total
 transparency) to 1 (no transparency). Default value is 1. Possible values 
-include also : "cos2", "contrib", "coord", "x" or "y". In this case, the 
+also include "cos2", "contrib", "coord", "x", and "y". In this case, the
 transparency for the individual/variable colors are automatically 
 controlled by their qualities ("cos2"), contributions ("contrib"), 
 coordinates (x^2+y^2, "coord"), x values("x") or y values("y"). To use 
@@ -182,14 +182,14 @@ PCA output.}
 values include brewer and ggsci color palettes.}
 
 \item{label}{a text specifying the elements to be labelled. Default value is 
-"all". Allowed values are "none" or the combination of c("ind", "ind.sup", 
+"all". Allowed values are "all", "none", or a combination of c("ind", "ind.sup",
 "quali", "var", "quanti.sup"). "ind" can be used to label only active 
 individuals. "ind.sup" is for supplementary individuals. "quali" is for 
 supplementary qualitative variables. "var" is for active variables. 
 "quanti.sup" is for quantitative supplementary variables.}
 
 \item{invisible}{a text specifying the elements to be hidden on the plot. 
-Default value is "none". Allowed values are the combination of c("ind", 
+Default value is "none". Allowed values are "all", "none", or a combination of c("ind",
 "ind.sup", "quali", "var", "quanti.sup").}
 
 \item{title}{the title of the graph}
@@ -197,10 +197,15 @@ Default value is "none". Allowed values are the combination of c("ind",
 \item{biplot.type}{type of biplot scaling for fviz_pca_biplot(). Options are:
 \itemize{
   \item "auto" (default): Uses range-based rescaling for visualization
-  \item "form": Form-oriented scaling (Gabriel-style). Prioritizes
-    readability of individual relationships.
-  \item "covariance": Covariance-oriented scaling (Gabriel-style).
-    Prioritizes readability of variable relationships.
+  \item "form": Gabriel form biplot scaling (equivalent to
+    \code{stats::biplot(..., scale = 0)}), preserving the score geometry
+    used to compare individuals.
+  \item "covariance": Gabriel covariance biplot scaling (equivalent to
+    \code{stats::biplot(..., scale = 1)}), preserving the variable
+    covariance geometry. Because both clouds share a single set of axes
+    (unlike \code{stats::biplot()}'s dual axes), the individuals can appear
+    compressed relative to the variable arrows; use "form" or "auto" if the
+    individual cloud is the focus.
 }
 Note: "form" and "covariance" scaling requires prcomp or princomp objects.}
 }

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -91,10 +91,62 @@ test_that("fviz_dend applies lwd to branch segments without adding a linewidth g
 
 test_that("fviz_pca_biplot supports form and covariance scaling modes", {
   res.pca <- stats::prcomp(iris[, 1:4], scale. = TRUE)
-  p_form <- fviz_pca_biplot(res.pca, biplot.type = "form")
-  p_cov <- fviz_pca_biplot(res.pca, biplot.type = "covariance")
+  p_form <- fviz_pca_biplot(
+    res.pca, biplot.type = "form", geom.ind = "point",
+    geom.var = "arrow", label = "none"
+  )
+  p_cov <- fviz_pca_biplot(
+    res.pca, biplot.type = "covariance", geom.ind = "point",
+    geom.var = "arrow", label = "none"
+  )
   expect_s3_class(p_form, "ggplot")
   expect_s3_class(p_cov, "ggplot")
+
+  layer_data <- function(p, geom){
+    layer <- Filter(function(x) inherits(x$geom, geom), p$layers)[[1]]
+    as.data.frame(layer$data)[, c("x", "y"), drop = FALSE]
+  }
+  # form == Gabriel scale = 0 (stats::biplot(scale = 0)): scores + rotation
+  expect_equal(
+    unname(as.matrix(layer_data(p_form, "GeomPoint"))),
+    unname(res.pca$x[, 1:2]), tolerance = 1e-12
+  )
+  expect_equal(
+    unname(as.matrix(layer_data(p_form, "GeomSegment"))),
+    unname(res.pca$rotation[, 1:2]), tolerance = 1e-12
+  )
+  # covariance == Gabriel scale = 1 (stats::biplot(scale = 1))
+  lambda <- sqrt(nrow(res.pca$x)) * res.pca$sdev[1:2]
+  expect_equal(
+    unname(as.matrix(layer_data(p_cov, "GeomPoint"))),
+    unname(sweep(res.pca$x[, 1:2], 2, lambda, "/")),
+    tolerance = 1e-12
+  )
+  expect_equal(
+    unname(as.matrix(layer_data(p_cov, "GeomSegment"))),
+    unname(sweep(res.pca$rotation[, 1:2], 2, lambda, "*")),
+    tolerance = 1e-12
+  )
+
+  # princomp: same Gabriel factorization, using n = n.obs
+  pr <- stats::princomp(iris[, 1:4], cor = TRUE)
+  loads <- unclass(pr$loadings)[, 1:2]
+  pf2 <- fviz_pca_biplot(pr, biplot.type = "form", geom.ind = "point",
+                         geom.var = "arrow", label = "none")
+  expect_equal(unname(as.matrix(layer_data(pf2, "GeomPoint"))),
+               unname(pr$scores[, 1:2]), tolerance = 1e-10)
+  expect_equal(unname(as.matrix(layer_data(pf2, "GeomSegment"))),
+               unname(loads), tolerance = 1e-10)
+  pcv2 <- fviz_pca_biplot(pr, biplot.type = "covariance", geom.ind = "point",
+                          geom.var = "arrow", label = "none")
+  lam2 <- sqrt(pr$n.obs) * pr$sdev[1:2]
+  expect_equal(unname(as.matrix(layer_data(pcv2, "GeomPoint"))),
+               unname(sweep(pr$scores[, 1:2], 2, lam2, "/")), tolerance = 1e-10)
+  expect_equal(unname(as.matrix(layer_data(pcv2, "GeomSegment"))),
+               unname(sweep(loads, 2, lam2, "*")), tolerance = 1e-10)
+
+  # the default 'auto' path still renders (byte-identity proven separately)
+  expect_s3_class(fviz_pca_biplot(res.pca), "ggplot")
 })
 
 test_that("fviz_eig parallel analysis is reproducible with parallel.seed", {


### PR DESCRIPTION
Batch D5 of the staged integration of #274 (@erdeyl) — the last core-numeric sub-batch. Gabriel biplot scaling for `fviz_pca_biplot()`. Affects only the opt-in `biplot.type = "form" | "covariance"` values.

### What changes
`biplot.type = "form"` and `"covariance"` now use the exact Gabriel biplot factorization instead of a display heuristic:

| mode | individuals | variables | equals |
|---|---|---|---|
| `"form"` | scores | loadings | `stats::biplot(scale = 0)` |
| `"covariance"` | scores / (√n·sdev) | loadings · √n·sdev | `stats::biplot(scale = 1)` |

- Colours mapped to `cos2`/`contrib` still reflect the **original** PCA (not the rescaled coordinates).
- Non-`prcomp`/`princomp` objects warn and fall back to `"auto"`; axes with non-positive/non-finite standard deviation error clearly.
- A doc note flags that `"covariance"` can compress the individual cloud (both clouds share one set of axes, unlike `stats::biplot()`'s dual axes) — use `"form"` or `"auto"` when individuals are the focus.

### Notes
- The default `biplot.type = "auto"` is **byte-identical** to `release/2.2.0` (verified across prcomp / princomp / FactoMineR and several configurations) — the default biplot does not move.
- Cross-validated **exact** against `stats::biplot(scale = 0/1)` for both `prcomp` and `princomp` (max diff ~1e-16); tests shipped.
- Full suite green in a clean session: **FAIL 0 | WARN 0 | PASS 804** (2 unrelated/graceful skips). `.Rd` regenerated with roxygen2 7.3.3 (only `fviz_pca.Rd`).

Refs #274. Not for merge without maintainer approval.
