### PR TITLE
Integrate #274 (E): DESCRIPTION text/URL refresh and .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^tests/testthat/Rplots\.pdf$
+^vignettes/.*\.html$
 ^pkgdown$
 ^pkgdown/*
 ^.*\.Rproj$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,11 +17,12 @@ Description: Provides easy-to-use functions to extract and visualize the output
     'CA' (Correspondence Analysis), 'MCA' (Multiple Correspondence Analysis),
     'FAMD' (Factor Analysis of Mixed Data), 'MFA' (Multiple Factor Analysis),
     and 'HMFA' (Hierarchical Multiple Factor Analysis) from different R packages.
-    It also includes support for supplementary qualitative variables in
-    'FactoMineR' 'FAMD' and 'MFA' workflows, hardened validation for clustering
-    and dimension-reduction helper workflows, backward-compatible phylogenetic
-    dendrogram layout support for current 'igraph' APIs, and 'ggplot2'-based
-    data visualization.
+    It standardizes coordinates, squared cosines, contributions, and eigenvalues
+    from several analysis backends and produces 'ggplot2'-based factor maps,
+    scree plots, contribution plots, clustering diagnostics, dendrograms, and
+    silhouette plots. It also visualizes two-dimensional 'UMAP' and t-SNE
+    embeddings and adapts precomputed or 'tidymodels' principal-component
+    results for the same plotting interface.
 License: GPL-2
 LazyData: true
 LazyDataCompression: xz
@@ -55,7 +56,7 @@ Suggests:
     workflows
 VignetteBuilder: knitr
 URL: https://github.com/kassambara/factoextra,
-    https://rpkgs.datanovia.com/factoextra/index.html
+    https://rpkgs.datanovia.com/factoextra/
 BugReports: https://github.com/kassambara/factoextra/issues
 Collate:
     'fviz_add.R'


### PR DESCRIPTION
Small metadata housekeeping from #274.

- **DESCRIPTION**: refresh the Description field to reflect the current feature set (UMAP/t-SNE embeddings, the tidymodels bridge, standardized metrics across backends); drop the trailing `index.html` from the datanovia URL.
- **.Rbuildignore**: ignore `tests/testthat/Rplots.pdf` and vignette `.html` build artifacts.

Deliberately **not** taken from #274's DESCRIPTION diff: the `R (>= 4.1.0) -> (>= 4.3.0)` bump (nothing in the integrated code needs > 4.1), the roxygen 8.0.0 switch (kept 7.3.3), and the `recipes`/`testthat`/`workflows` version pins (not required). Metadata only; no code or behavior change.

Refs #274. Not for merge without maintainer approval.