### PR TITLE
Integrate #274 wave 2: release corrections (@erdeyl) + reconciliation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 ^tests/testthat/Rplots\.pdf$
+^tests/testthat/_problems(/|$)
 ^vignettes/.*\.html$
 ^pkgdown$
 ^pkgdown/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Imports:
 Suggests:
     ade4,
     ca,
+    hardhat,
     igraph,
     MASS,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,8 +25,10 @@
   family: `prep(rec) |> as_factoextra_pca() |> fviz_pca_biplot()`. Scores,
   loadings and the full set of eigenvalues are extracted through the public
   recipes/workflows API, so the scree plot and axis percentages are honest even
-  when only a few components are kept, and the variable arrows are the true
-  variable-component correlations. `recipes` and `workflows` are Suggests.
+  when only a few components are kept. When inputs are provably centered,
+  variable-component correlations and cos2 are recovered separately from the
+  loading-times-component-SD arrow coordinates; the two coincide for centered,
+  unit-scaled inputs. `recipes` and `workflows` are Suggests.
 
 * New `factoextra_palette()` and `theme_factoextra()`. `factoextra_palette("okabe")`
   returns the Okabe-Ito colorblind-safe categorical colors as a vector to pass to
@@ -87,16 +89,25 @@
   contributions were divided by the (n-1)-normalized eigenvalue and summed to
   `100 * (n - 1) / n` instead of 100. This changes the individual contribution
   values returned for those objects (and any `fviz_contrib()` / `fviz_pca()`
-  colouring derived from them). `princomp` individual contributions, all
-  variable contributions, coordinates, and cos2 are unchanged. The corrected
-  values match `FactoMineR::PCA()` and `ade4::inertia.dudi()`. Thanks to @erdeyl (#274).
+  colouring derived from them). `princomp` individual contributions,
+  coordinates, and cos2 are unchanged for ordinary finite inputs. Variable
+  contributions are unchanged on nonzero, ordinarily scaled axes; zero-inertia
+  and extreme-magnitude axes now return stable finite values instead of NaN or
+  overflow. For a rank-truncated `prcomp` object, individual cos2 is explicitly
+  defined within the retained component subspace because discarded row inertia
+  is not stored in the fit. The corrected values match `FactoMineR::PCA()` and
+  `ade4::inertia.dudi()`. Thanks to @erdeyl (#274).
 
 * `fviz_pca_biplot()`: `biplot.type = "form"` and `biplot.type = "covariance"`
   now use the exact Gabriel biplot factorization, matching
   `stats::biplot(scale = 0)` and `stats::biplot(scale = 1)` respectively, instead
-  of the previous display heuristic. The default `biplot.type = "auto"` is
-  unchanged (byte-identical). These two modes require a `prcomp` / `princomp`
-  object. Thanks to @erdeyl (#274).
+  of the previous display heuristic. The usual `biplot.type = "auto"` scaling
+  algorithm is otherwise unchanged. Rank-truncated `prcomp` fits now use only
+  the retained component standard deviations when computing variable
+  coordinates, avoiding recycled values and incorrect arrows. The exact modes
+  also handle formula fits with `na.exclude`; covariance mode uses `n.obs` for
+  `princomp`, matching `stats::biplot()`. The exact modes require a `prcomp` /
+  `princomp` object. Thanks to @erdeyl (#274).
 
 * `as_factoextra_pca()` recipe / workflow methods (tidymodels): variable-component
   correlations and cos2 are now recovered from the full PCA inertia, so they match
@@ -104,18 +115,25 @@
   components (previously the cos2 was normalized within the retained subspace and
   matched only when all components were kept). `scale.unit` is set to `TRUE` only
   when every PCA input is both centered and unit-scaled at the PCA boundary.
-  When the inputs are not provably centered (e.g. a bare `step_pca()`), the
-  variable-component correlations cannot be recovered: the scores, eigenvalues
-  and variable coordinates are still returned (so `fviz_pca_ind()` / `fviz_eig()`
-  and the variable arrows keep working), but the correlation circle is omitted
-  and a warning is issued (add `step_center()` / `step_normalize()`, or set
-  `step_pca(options = list(center = TRUE))`, to recover them). Thanks to @erdeyl (#274).
+  When the metrics cannot be recovered (e.g. a bare `step_pca()` or a
+  zero-inertia variable), `get_pca_var()` returns `NULL` for its correlation and
+  cos2 entries instead of synthesizing them from the retained coordinates.
+  Scores, eigenvalues, variable coordinates and contributions remain available,
+  so ordinary variable arrows still work; correlation/cos2-dependent displays
+  fail explicitly, the correlation circle is omitted, and a warning gives the
+  applicable centering or zero-inertia remedy. For fully normalized inputs, the
+  recovered metrics match `FactoMineR::PCA()`. To keep scores consistent with the
+  fitted loadings and eigenvalues, `step_pca()` must be the final recipe step.
+  Case-weighted fits fail explicitly until their weights can be propagated into
+  individual contributions. Thanks to @erdeyl (#274).
 
 * `get_clust_tendency()`: the Hopkins statistic now samples the observed points
   **without replacement** (the previous code sampled with replacement, which could
   draw the same observation more than once), counts a duplicated row as a valid
   zero-distance neighbour, and is computed on a normalized distance scale for
-  numerical stability. This changes the Hopkins value returned for a given `seed`.
+  numerical stability. Zero-range columns are ignored, so adding a redundant
+  constant variable does not change the statistic. This changes the Hopkins value
+  returned for a given `seed`.
   It now errors clearly when every nearest-neighbour distance is zero (the
   statistic is undefined). Thanks to @erdeyl (#274).
 
@@ -126,11 +144,13 @@
   reference now matches the fitted object's marginal variances. Full-rank
   correlation PCA is unaffected in distribution (parallel analysis is a
   Monte-Carlo procedure, so exact threshold values depend on the seed);
-  rank-truncated or wide (n <= p) fits now simulate over the original variable
-  count. Fits whose reference distribution
-  cannot be reconstructed (uncentered fits, custom scale vectors, rank-truncated
-  covariance fits, ambiguous `princomp` `cor`) now error clearly instead of
-  returning misleading thresholds. Separately, `fviz_eig()` warns when a
+  wide (n <= p) fits now simulate over the original variable count. A
+  rank-truncated correlation fit is accepted only when a retained formula call
+  proves literal `scale. = TRUE`; default-method and custom/symbolic scale fits
+  cannot be distinguished from the truncated object and fail closed. Other fits
+  whose reference distribution cannot be reconstructed (uncentered fits,
+  rank-truncated covariance fits, ambiguous `princomp` `cor`) also error clearly
+  instead of returning misleading thresholds. Separately, `fviz_eig()` warns when a
   FactoMineR PCA object stores an incomplete eigenvalue spectrum (refit with a
   larger `ncp` for a complete scree plot). Thanks to @erdeyl (#274).
 
@@ -157,15 +177,25 @@
   contribution-based selection help now says "highest contributions" (was
   "highest cos2"), `fviz_famd()`'s `habillage` help refers to a FAMD (not MFA)
   object, the ExPosition class name is spelled `expoOutput` in `fviz_ca()` /
-  `fviz_mca()`, and the `clean_lock_files()` example is now self-contained.
+  `fviz_mca()`, the generated `ggtheme` help no longer claims a single default
+  that disagrees with function signatures, and the `clean_lock_files()` example
+  is now self-contained. The HMFA selection help now includes the supported
+  `union` option.
   Thanks to @erdeyl (#274).
 * Clearer, earlier input validation for edge cases, so mistakes fail with an
   informative message instead of a downstream error: `fviz_umap()`/`fviz_tsne()`
   require two distinct positive integer `dims`; `fviz_nbclust()` validates
   `k.max`; `fviz_dend()` validates `k`/`h` against the tree; `get_clust_tendency()`
-  checks `n` and requires finite data; and `as_factoextra_pca()` validates
-  `scale.unit` and the supplied eigenvalues. Valid calls are unaffected.
+  checks `n` and requires finite data; oversized axis indices are rejected before
+  integer conversion; and `as_factoextra_pca()` validates `scale.unit` and the
+  supplied eigenvalues. Valid calls are unaffected.
   Thanks to @erdeyl (#274).
+* `as_factoextra_pca()` now derives cos2, contributions, and eigenvalue
+  percentages on rescaled intermediate values and infers omitted eigenvalues
+  without premature overflow, so representable results remain stable at very
+  small or very large magnitudes. Its PCA-variable print method lists only
+  metrics that are actually available while preserving the established
+  descriptions for metrics that remain present.
 
 ## Bug fixes
 
@@ -180,10 +210,19 @@
   mis-coloured when `data` is ordered differently from the clustering; it also
   accepts a `clustering` component (as produced by `pam()`/`clara()`) in a custom
   `list(data=, clustering=)` object. Assignments that do not line up by name are
-  used positionally, as before. Thanks to @erdeyl (#274).
+  used positionally, as before, except that `pam()` / `fanny()` and `hcut()`
+  objects fitted on a dissimilarity reject complete non-matching row-name sets
+  because positional use would mis-colour observations. Thanks to @erdeyl (#274).
 * `invisible = "all"` now hides all plotted elements (it was silently accepted
   but had no effect); on the individual and variable maps, a selection by `name`
   that includes names not present now warns instead of silently dropping them.
+  Supplementary quantitative PCA names are included in this validation and the
+  selected supplementary points are now added to the plot, avoiding both false
+  unmatched-name warnings and silently missing points. `select.ind` now also
+  limits MFA/HMFA partial-point and segment overlays, including union selections,
+  instead of leaving every individual's partial geometry visible. A lone
+  unavailable contribution condition wrapped in `union = TRUE` now gives the
+  same explicit unavailable-metric error as the ordinary single-condition path.
   Thanks to @erdeyl (#274).
 
 # factoextra 2.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -216,9 +216,11 @@
 * `invisible = "all"` now hides all plotted elements (it was silently accepted
   but had no effect); on the individual and variable maps, a selection by `name`
   that includes names not present now warns instead of silently dropping them.
-  Supplementary quantitative PCA names are included in this validation and the
-  selected supplementary points are now added to the plot, avoiding both false
-  unmatched-name warnings and silently missing points. `select.ind` now also
+  `fviz_pca_var()` / `fviz_pca_biplot()` now draw a FactoMineR PCA's
+  supplementary quantitative variables, which were previously omitted because the
+  wrong result slot was read; their names are also recognised by the selection
+  validation, so a `select.*` list naming one no longer warns or silently drops
+  it. `select.ind` now also
   limits MFA/HMFA partial-point and segment overlays, including union selections,
   instead of leaving every individual's partial geometry visible. A lone
   unavailable contribution condition wrapped in `union = TRUE` now gives the

--- a/R/as_factoextra.R
+++ b/R/as_factoextra.R
@@ -121,7 +121,7 @@ as_factoextra_pca.default <- function(ind.coord, var.coord = NULL, eig = NULL,
     if(nrow(ind.coord) < 2L)
       stop("At least two observations are required to infer `eig` from `ind.coord`.",
            call. = FALSE)
-    eig <- apply(ind.coord, 2, stats::var)
+    eig <- .fe_col_variances(ind.coord)
   }
   if(!is.numeric(eig) || length(eig) < k)
     stop("`eig` must be a numeric vector with at least ", k,
@@ -173,12 +173,14 @@ as_factoextra_pca.default <- function(ind.coord, var.coord = NULL, eig = NULL,
 #' honest even when \code{num_comp} keeps only a few components). Variable
 #' coordinates are loading times the square root of the eigenvalue. Exact
 #' variable-component correlations and cos2 are recovered from the full PCA
-#' inertia when every PCA input is provably centered. When the inputs are not
-#' provably centered (e.g. a bare \code{step_pca()} with no centering), the
-#' correlations cannot be recovered: the scores, eigenvalues and variable
-#' coordinates are still returned (so \code{fviz_pca_ind()}, \code{fviz_eig()} and
-#' the variable arrows work), but the correlation circle is omitted and a warning
-#' is issued. \code{scale.unit} is set to \code{TRUE} only when every
+#' inertia when every PCA input is provably centered. When those metrics cannot
+#' be recovered (for example, for a bare \code{step_pca()} with no centering or a
+#' zero-inertia variable), their entries in \code{get_pca_var()} are \code{NULL}.
+#' Scores, eigenvalues, variable coordinates and contributions are still returned,
+#' so the individual, scree, variable-arrow and biplot displays remain available;
+#' correlation/cos2-dependent displays fail with an explicit unavailable-metric
+#' error. The correlation circle is omitted and a warning explains how to recover
+#' the metrics. \code{scale.unit} is set to \code{TRUE} only when every
 #' PCA input is both centered and unit-scaled at the PCA boundary; partial scaling
 #' therefore does not draw a correlation circle. For fully normalized data,
 #' variable coordinates, correlations, cos2 and contributions, and the eigenvalue
@@ -187,9 +189,14 @@ as_factoextra_pca.default <- function(ind.coord, var.coord = NULL, eig = NULL,
 #' the retained components (it equals the full-space cos2 only when all components
 #' are kept). The two-dimensional plots (\code{fviz_pca_ind()},
 #' \code{fviz_pca_var()}, \code{fviz_pca_biplot()}) need \code{num_comp >= 2}. The
-#' recipe must be prepped and its PCA step must be \code{step_pca()} (non-linear
-#' embedding steps such as \code{step_umap()} have no eigenvalues and are rejected
-#' with a message). For the loadings display of a recipe PCA see also
+#' recipe must be prepped, and its single PCA step must be an unweighted
+#' \code{step_pca()} and must be the final recipe step. Case-weighted PCA is
+#' rejected because the adapter cannot yet propagate those weights into individual
+#' contributions. Later steps could transform the baked/mold PCA
+#' scores without updating the fitted PCA loadings or eigenvalues, so such recipes
+#' fail explicitly instead of returning internally inconsistent geometry.
+#' Non-linear embedding steps such as \code{step_umap()} have no eigenvalues and
+#' are rejected with a message. For the loadings display of a recipe PCA see also
 #' \code{learntidymodels::plot_top_loadings()}.
 #'
 #' @rdname as_factoextra
@@ -197,10 +204,7 @@ as_factoextra_pca.default <- function(ind.coord, var.coord = NULL, eig = NULL,
 as_factoextra_pca.recipe <- function(ind.coord, ...){
   .fe_need("recipes")
   ex <- .fe_extract_recipe_pca(ind.coord, scores = NULL)
-  as_factoextra_pca.default(ind.coord = ex$scores, var.coord = ex$var.coord,
-                            var.cos2 = ex$var.cos2, var.cor = ex$var.cor,
-                            eig = ex$eig,
-                            scale.unit = ex$scale.unit)
+  .fe_wrap_recipe_pca(ex)
 }
 
 #' @rdname as_factoextra
@@ -223,10 +227,7 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
   # fails; take the scores from the fitted mold instead.
   mold <- workflows::extract_mold(wf)
   ex <- .fe_extract_recipe_pca(rec, scores = as.matrix(mold$predictors))
-  as_factoextra_pca.default(ind.coord = ex$scores, var.coord = ex$var.coord,
-                            var.cos2 = ex$var.cos2, var.cor = ex$var.cor,
-                            eig = ex$eig,
-                            scale.unit = ex$scale.unit)
+  .fe_wrap_recipe_pca(ex)
 }
 
 # ---- internal helpers -------------------------------------------------------
@@ -236,6 +237,21 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
   if(!requireNamespace(pkg, quietly = TRUE))
     stop("Package '", pkg, "' is required for this method. Install it with ",
          "install.packages('", pkg, "').", call. = FALSE)
+}
+
+# The public default constructor intentionally derives missing variable metrics
+# from coordinates. Recipe/workflow extraction has a distinct state: NULL means
+# the metric was proven unavailable, not merely omitted. Restore that state after
+# construction without changing any published default-method call form.
+.fe_wrap_recipe_pca <- function(ex){
+  out <- as_factoextra_pca.default(
+    ind.coord = ex$scores, var.coord = ex$var.coord,
+    var.cos2 = ex$var.cos2, var.cor = ex$var.cor,
+    eig = ex$eig, scale.unit = ex$scale.unit
+  )
+  if(is.null(ex$var.cor)) out$var$cor <- NULL
+  if(is.null(ex$var.cos2)) out$var$cos2 <- NULL
+  out
 }
 
 # Extract scores / loadings / eigenvalues from a prepped recipe whose dimension
@@ -265,7 +281,16 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
     stop("This recipe has more than one step_pca() (", paste(ids, collapse = ", "),
          "). as_factoextra_pca() supports a single PCA step.", call. = FALSE)
   }
-  st  <- rec$steps[[which(is_pca)]]
+  pca_pos <- which(is_pca)
+  if(pca_pos != length(rec$steps))
+    stop("step_pca() must be the final recipe step because later steps can ",
+         "transform its score columns without updating the stored PCA loadings ",
+         "and eigenvalues.", call. = FALSE)
+  st  <- rec$steps[[pca_pos]]
+  if(isTRUE(st$case_weights))
+    stop("Case-weighted step_pca() fits are not supported because the adapter ",
+         "cannot propagate the case weights into individual contributions.",
+         call. = FALSE)
   k   <- st$num_comp
   # The baked/mold SCORE columns carry the step's prefix and are zero-padded to the
   # digit width of the component count (PC01.. at >=10 comps). Reuse recipes' own
@@ -321,10 +346,8 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
   # steps reset the proof; an internal prcomp center/scale option, when present,
   # is applied at the PCA boundary. When correlations cannot be recovered
   # (uncentered inputs, or a zero-inertia variable), we still return the scores,
-  # eigenvalues and variable coordinates - so fviz_pca_ind()/fviz_eig()/
-  # fviz_pca_var() work - but omit the recovered correlations/cos2 and the
-  # correlation circle (scale.unit = FALSE), with a one-time warning.
-  pca_pos <- which(is_pca)
+  # eigenvalues, variable coordinates and contributions, but omit the recovered
+  # correlations/cos2 and the correlation circle (scale.unit = FALSE).
   prep.state <- .fe_recipe_pca_preprocessing(rec, pca_pos, st)
 
   var.cor <- NULL
@@ -344,12 +367,22 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
     unit.inertia <- all(abs(var.inertia - 1) <= unit.tol * pmax(1, var.inertia))
     scale.unit <- prep.state$scaled && unit.inertia
   } else {
-    warning("Variable-component correlations cannot be recovered from this ",
-            "step_pca() fit (its inputs are not provably centered, or a variable ",
-            "has zero inertia), so the correlation circle is omitted. Add ",
-            "step_center()/step_normalize(), or set ",
-            "step_pca(options = list(center = TRUE)), to recover them.",
-            call. = FALSE)
+    if(!prep.state$centered){
+      reason <- "its inputs are not provably centered"
+      remedy <- paste0(
+        "Add step_center()/step_normalize(), or set ",
+        "step_pca(options = list(center = TRUE)), to recover them."
+      )
+    } else {
+      reason <- "at least one variable has zero or non-finite inertia"
+      remedy <- paste0(
+        "Remove zero-inertia variables (for example with step_zv()) before ",
+        "step_pca() to recover them."
+      )
+    }
+    warning("Variable-component correlations and cos2 cannot be recovered from ",
+            "this step_pca() fit because ", reason,
+            ", so the correlation circle is omitted. ", remedy, call. = FALSE)
   }
 
   list(scores = scores, var.coord = var.coord, var.cor = var.cor,
@@ -433,20 +466,25 @@ as_factoextra_pca.workflow <- function(ind.coord, ...){
   x
 }
 
+# Infer sample variances without squaring the original coordinate scale first.
+# Rescaling as scale * (scale * variance) avoids a premature overflow whenever
+# the final variance itself is representable as a double.
+.fe_col_variances <- function(coord){
+  vapply(seq_len(ncol(coord)), function(j){
+    x <- coord[, j]
+    scale <- max(abs(x))
+    if(scale == 0) return(0)
+    scaled_variance <- stats::var(x / scale)
+    scale * (scale * scaled_variance)
+  }, numeric(1))
+}
+
 # Per-dimension contribution (in percent): exact from coordinates.
 .fe_contrib <- function(coord){
-  ss <- colSums(coord^2)
-  ss[ss == 0] <- 1   # avoid 0/0 for an all-zero dimension
-  contrib <- sweep(coord^2, 2, ss, "/") * 100
-  dimnames(contrib) <- dimnames(coord)
-  contrib
+  .pca_column_contributions(coord)
 }
 
 # Per-row quality of representation within the supplied dimensions.
 .fe_cos2 <- function(coord){
-  d2 <- rowSums(coord^2)
-  d2[d2 == 0] <- 1
-  cos2 <- sweep(coord^2, 1, d2, "/")
-  dimnames(cos2) <- dimnames(coord)
-  cos2
+  .pca_row_squared_shares(coord, coord)
 }

--- a/R/eigenvalue.R
+++ b/R/eigenvalue.R
@@ -143,7 +143,14 @@ get_eig<-function(X){
     else stop("An object of class : ", paste(class(X), collapse = ", "), 
               " can't be handled by the function get_eigenvalue()")
     
-    variance <- eig*100/sum(eig)
+    # Normalize before summing so finite large eigenvalues do not overflow the
+    # denominator (and finite tiny values do not underflow merely due to units).
+    eig_scale <- max(abs(eig))
+    if(is.finite(eig_scale) && eig_scale > 0){
+      scaled_eig <- eig / eig_scale
+      variance <- scaled_eig * 100 / sum(scaled_eig)
+    }
+    else variance <- rep(0, length(eig))
     cumvar <- cumsum(variance)
     eig <- data.frame(eigenvalue = eig, variance = variance, 
                       cumvariance = cumvar)
@@ -222,6 +229,21 @@ get_eigenvalue <- function(X){
      all(is.finite(object_scale)) &&
      any(abs(object_scale - 1) > sqrt(.Machine$double.eps))) return(TRUE)
 
+  # When every stored scale is one, reconstruct the analyzed variables' diagonal
+  # from the full eigendecomposition. A non-unit diagonal proves that the fit used
+  # the covariance matrix even when `cor` was supplied through a wrapper symbol.
+  loadings <- unclass(X[["loadings"]])
+  sdev <- as.numeric(X[["sdev"]])
+  if(is.matrix(loadings) && ncol(loadings) == length(sdev) &&
+     length(sdev) > 0L && all(is.finite(loadings)) && all(is.finite(sdev))){
+    reconstructed_variance <- rowSums(
+      sweep(loadings^2, 2, sdev^2, "*")
+    )
+    tolerance <- sqrt(.Machine$double.eps) *
+      pmax(1, abs(reconstructed_variance))
+    if(any(abs(reconstructed_variance - 1) > tolerance)) return(FALSE)
+  }
+
   stop(
     "Cannot determine whether this princomp object used cor = TRUE or FALSE. ",
     "Refit it with a literal cor argument before requesting parallel analysis."
@@ -260,8 +282,18 @@ get_eigenvalue <- function(X){
         analyzed_var <- rowSums(sweep(rotation^2, 2, eigenvalues, "*"))
         if(any(abs(analyzed_var - 1) > tolerance))
           stop("Parallel analysis cannot reproduce a prcomp fit using a custom scale vector.")
-      } else if(abs(sum(eigenvalues) - n_var) > tolerance){
-        stop("Parallel analysis cannot verify correlation scaling for this truncated prcomp fit.")
+      } else {
+        scale_arg <- NULL
+        if(!is.null(X[["call"]])) scale_arg <- X[["call"]][["scale."]]
+        literal_unit_scaling <- is.logical(scale_arg) && length(scale_arg) == 1L &&
+          !is.na(scale_arg) && isTRUE(scale_arg)
+        if(!literal_unit_scaling)
+          stop(
+            "Parallel analysis cannot verify correlation scaling for this ",
+            "truncated prcomp fit. Refit it with a literal scale. = TRUE; a ",
+            "custom or symbolic scale vector cannot be reconstructed from the ",
+            "truncated object."
+          )
       }
     }
 

--- a/R/facto_summarize.R
+++ b/R/facto_summarize.R
@@ -133,6 +133,14 @@ facto_summarize <- function(X, element, node.level = 1, group.names,
                  MFA = get_mfa(X, element),
                  HMFA = get_hmfa(X, element)
                  )
+
+  requested.metrics <- intersect(result, c("coord", "cos2", "contrib"))
+  unavailable <- requested.metrics[vapply(
+    requested.metrics, function(metric) is.null(elmt[[metric]]), logical(1)
+  )]
+  if(length(unavailable))
+    stop("'", paste(unavailable, collapse = "', '"),
+         "' is not available for element = '", element, "'.", call. = FALSE)
   
   # Check axes
   if(inherits(elmt, "hmfa_partial"))

--- a/R/fviz.R
+++ b/R/fviz.R
@@ -222,8 +222,21 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
   if(element == "partial.axes" || (element == "quali.var" && facto.class == "HMFA")) 
     summary.res <- c("coord", "contrib")
   else if(element == "group" && facto.class == "HMFA") summary.res <- "coord"
+  if(inherits(X, "factoextra_pca")){
+    available <- get_pca(X, element)
+    summary.res <- summary.res[!vapply(
+      summary.res, function(metric) is.null(available[[metric]]), logical(1)
+    )]
+  }
   df <- facto_summarize(X, element = element, axes = axes, result = summary.res)
   colnames(df)[2:3] <-  c("x", "y")
+  uses_missing_cos2 <- function(value){
+    is.character(value) && length(value) == 1L && identical(value, "cos2") &&
+      !("cos2" %in% names(df))
+  }
+  if(any(vapply(list(color, fill, alpha, pointsize),
+                uses_missing_cos2, logical(1))))
+    stop("`cos2` is not available for element = '", element, "'.", call. = FALSE)
   # Color by grouping variables
   #::::::::::::::::::::::::::::::::::::::
   is_grouping_var_exists <- !("none" %in% habillage) || .is_grouping_var(color) || .is_grouping_var(fill)
@@ -307,9 +320,16 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
               paste0('"', unmatched, '"', collapse = ", "), ".",
               call. = FALSE)
   }
+  if(!is.null(select) && !is.null(select$cos2) && !("cos2" %in% colnames(df)))
+    stop("Cos2 is not available for element = '", element, "'.", call. = FALSE)
+  n_select_conditions <- if(is.null(select)) 0L else
+    sum(!is.null(select$name), !is.null(select$cos2), !is.null(select$contrib))
+  union_has_alternative <- !is.null(select) && isTRUE(select$union) &&
+    n_select_conditions >= 2L
   if(!is.null(select) && !is.null(select$contrib) && !("contrib" %in% colnames(df))
-     && !isTRUE(select$union)){
-    stop("Contributions are not available for element = '", element, "'.")
+     && !union_has_alternative){
+    stop("Contributions are not available for element = '", element, "'.",
+         call. = FALSE)
   }
   if(!is.null(select))
     df <- .select(df, select, warn_unmatched = FALSE)
@@ -687,7 +707,8 @@ fviz <- function(X, element, axes = c(1, 2), geom = "auto",
     res <- list(name = "ind.sup", addlabel = (lab$ind.sup && "text" %in% geom))
   # Supplementary quantitative variables
   else if(element == "var" && inherits(X, "PCA") && !hide$quanti.sup)
-    res <- list(name = "quanti", addlabel = (lab$quanti.sup && "text" %in% geom))
+    res <- list(name = "quanti.sup",
+                addlabel = (lab$quanti.sup && "text" %in% geom))
   else if(element == "mca.cor" && inherits(X, "MCA") && !hide$quanti)
     res <- list(name = c("quanti.sup", "quali.sup$eta2"), addlabel = (lab$quanti && "text" %in% geom))
   else if(element %in% "var" && inherits(X, "MCA") && !hide$quali.sup)

--- a/R/fviz_cluster.R
+++ b/R/fviz_cluster.R
@@ -14,7 +14,10 @@
 #'  list may instead contain \code{data} plus either \code{cluster} or
 #'  \code{clustering}. When the assignments and the data both carry complete,
 #'  unique, matching names, the assignments are aligned to the data rows by name;
-#'  otherwise they are used in their given (positional) order.
+#'  otherwise they are used in their given (positional) order. The exception is a
+#'  clustering fitted from dissimilarities and plotted with external \code{data}:
+#'  complete, unique, non-matching name sets are rejected because positional use
+#'  would attach clusters to the wrong observations.
 #'@param data the data used for clustering. It is required for kmeans and dbscan
 #'  objects, and for partition or hcut objects fitted from dissimilarities when
 #'  those objects do not retain the original observations.
@@ -184,13 +187,17 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
                                    c("jitter", "frame", "frame.type", "frame.level", "frame.alpha", "title"))]
   
   
+  dissimilarity_uses_external_data <- FALSE
   # object from cluster package
   if(inherits(object, c("partition", "hkmeans", "eclust"))){
     # Use the object's own data when present; otherwise keep the user-supplied
-    # `data=`. pam()/fanny() fitted on a dissimilarity matrix store no
-    # coordinates (object$data is NULL), so the original data is needed for the
-    # 2-D layout; the cluster assignments still come from the object (#128).
-    if(!is.null(object[["data"]])) data <- object[["data"]]
+    # `data=`. Fits built from dissimilarities store no plottable coordinates
+    # (object$data is NULL or a dist object), so the original observations are
+    # needed for the 2-D layout; assignments still come from the object (#128).
+    stored_data <- object[["data"]]
+    dissimilarity_uses_external_data <-
+      is.null(stored_data) || inherits(stored_data, "dist")
+    if(!dissimilarity_uses_external_data) data <- stored_data
     if(is.null(data))
       stop("This clustering has no stored data (e.g. pam()/fanny() on a ",
            "dissimilarity matrix). Supply the original data via 'data=' - it is ",
@@ -216,6 +223,7 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
   }
   else if(inherits(object, "hcut")){
     if(inherits(object$data, "dist")){
+      dissimilarity_uses_external_data <- TRUE
       if(is.null(data)) stop("The option 'data' is required for an object of class hcut." )
     }
     else data <- object$data
@@ -245,6 +253,19 @@ fviz_cluster <- function(object, data = NULL, choose.vars = NULL, stand = TRUE,
   } else {
     observation_names <- NULL
     n_obs <- length(cluster)
+  }
+  if(dissimilarity_uses_external_data){
+    cluster_names <- names(cluster)
+    complete_cluster_names <- !is.null(cluster_names) &&
+      length(cluster_names) == n_obs && !anyNA(cluster_names) &&
+      all(nzchar(cluster_names)) && !anyDuplicated(cluster_names)
+    complete_observation_names <- !is.null(observation_names) &&
+      length(observation_names) == n_obs && !anyNA(observation_names) &&
+      all(nzchar(observation_names)) && !anyDuplicated(observation_names)
+    if(complete_cluster_names && complete_observation_names &&
+       !setequal(cluster_names, observation_names))
+      stop("The row names of data do not match the observations used to build ",
+           "the clustering.", call. = FALSE)
   }
   cluster <- .align_cluster_assignments(cluster, observation_names, n_obs)
   cluster <- as.factor(cluster)

--- a/R/fviz_hmfa.R
+++ b/R/fviz_hmfa.R
@@ -47,7 +47,11 @@ NULL
 #'  then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
 #'  then the top 5 individuals/variables with the highest cos2 are drawn. \item 
 #'  contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-#'  the highest contributions are drawn }
+#'  the highest contributions are drawn \item union: logical. When several of
+#'  name/cos2/contrib are given, FALSE (default) combines them with AND (each
+#'  condition further narrows the selection); TRUE combines them with OR (an
+#'  element is kept if it matches any condition), e.g. named items \emph{plus}
+#'  the top-cos2 ones. }
 #'@param choice the graph to plot. Allowed values include one of c("quanti.var",
 #'  "quali.var", "group") for plotting quantitative variables, qualitative 
 #'  variables and group of variables, respectively.
@@ -151,7 +155,12 @@ fviz_hmfa_ind <- function(X,  axes = c(1,2), geom=c("point", "text"), repel = FA
     # user-facing selection + any union message already happened in fviz() above,
     # so use check = FALSE to stay silent and avoid a duplicate message).
     ind.all <- ind
-    if(!is.null(select.ind)) ind <- .select(ind, select.ind, check = FALSE)
+    if(!is.null(select.ind)) {
+      ind <- .select(ind, select.ind, check = FALSE)
+      ind.partial <- ind.partial[
+        ind.partial$name %in% ind$name, , drop = FALSE
+      ]
+    }
     if(!is.null(select.partial)) {
       if(nrow(ind) != nrow(ind.all)) warning("You've already selected individuals. Partial points are only calculated for them.")
       ind.partial <-  ind.partial[ind.partial$name %in% .select(ind, select.partial, check = FALSE)$name, , drop = FALSE]

--- a/R/fviz_mfa.R
+++ b/R/fviz_mfa.R
@@ -174,7 +174,12 @@ fviz_mfa_ind <- function(X,  axes = c(1,2), geom=c("point", "text"), repel = FAL
     # user-facing selection + any union message already happened in fviz() above,
     # so use check = FALSE to stay silent and avoid a duplicate message).
     ind.all <- ind
-    if(!is.null(select.ind)) ind <- .select(ind, select.ind, check = FALSE)
+    if(!is.null(select.ind)) {
+      ind <- .select(ind, select.ind, check = FALSE)
+      ind.partial <- ind.partial[
+        ind.partial$name %in% ind$name, , drop = FALSE
+      ]
+    }
     if(!is.null(select.partial)) {
       if(nrow(ind) != nrow(ind.all)) warning("You've already selected individuals. Partial points are only calculated for them.")
       ind.partial <-  ind.partial[ind.partial$name %in% .select(ind, select.partial, check = FALSE)$name, , drop = FALSE]

--- a/R/fviz_pca.R
+++ b/R/fviz_pca.R
@@ -276,8 +276,10 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
   
   
   # Data frame to be used for plotting
-  var <- facto_summarize(X, element = "var", 
-                         result = c("coord", "contrib", "cos2"), axes = axes)
+  var.results <- c("coord", "contrib", "cos2")
+  if(inherits(X, "factoextra_pca") && is.null(X$var$cos2))
+    var.results <- setdiff(var.results, "cos2")
+  var <- facto_summarize(X, element = "var", result = var.results, axes = axes)
   colnames(var)[2:3] <-  c("x", "y")
   
   pca.ind <- get_pca_ind(X)
@@ -311,19 +313,33 @@ fviz_pca_biplot <- function(X,  axes = c(1,2), geom = c("point", "text"),
       } else {
         # scale = 1: scores divided by sqrt(n)*sdev and loadings multiplied
         # by the same factor.
-        lambda <- sqrt(nrow(display_ind)) * sdev[axes]
+        n_factor <- if(inherits(X, "princomp")) X[["n.obs"]] else nrow(display_ind)
+        if(!is.numeric(n_factor) || length(n_factor) != 1L ||
+           !is.finite(n_factor) || n_factor <= 0)
+          stop("Could not determine the number of fitted observations for ",
+               "covariance biplot scaling.", call. = FALSE)
+        lambda <- sqrt(n_factor) * sdev[axes]
         display_ind[, axes] <- sweep(
           display_ind[, axes, drop = FALSE], 2, lambda, "/"
         )
         display_var[, axes] <- sweep(
-          display_var[, axes, drop = FALSE], 2, sqrt(nrow(display_ind)), "*"
+          display_var[, axes, drop = FALSE], 2, sqrt(n_factor), "*"
         )
       }
-      plot_X <- as_factoextra_pca(
-        ind.coord = display_ind, var.coord = display_var, eig = X$sdev^2,
-        ind.cos2 = pca.ind$cos2, ind.contrib = pca.ind$contrib,
-        var.cos2 = pca.var$cos2, var.contrib = pca.var$contrib,
-        var.cor = pca.var$cor, scale.unit = FALSE
+      # Formula fits with na.exclude retain NA score rows so predictions line up
+      # with the original data. Keep those rows for plotting, while preserving
+      # the already validated PCA metrics; the public constructor intentionally
+      # rejects non-finite user input and is therefore not appropriate here.
+      plot_X <- structure(
+        list(
+          ind = list(coord = display_ind, cos2 = pca.ind$cos2,
+                     contrib = pca.ind$contrib),
+          var = list(coord = display_var, cor = pca.var$cor,
+                     cos2 = pca.var$cos2, contrib = pca.var$contrib),
+          eig.values = as.numeric(X$sdev)^2,
+          scale.unit = FALSE
+        ),
+        class = c("factoextra_pca", "list")
       )
       var_scale <- 1
     }

--- a/R/fviz_umap.R
+++ b/R/fviz_umap.R
@@ -242,7 +242,8 @@ fviz_tsne <- function(X, dims = c(1L, 2L), habillage = NULL, col.ind = NULL,
 # are handled FIRST so `$` is never applied to an atomic matrix.
 .fe_layout <- function(x, dims = c(1L, 2L)) {
   if(length(dims) != 2L || !is.numeric(dims) || anyNA(dims) ||
-     any(!is.finite(dims)) || any(dims %% 1 != 0) || any(dims < 1) ||
+     any(!is.finite(dims)) || any(dims > .Machine$integer.max) ||
+     any(dims %% 1 != 0) || any(dims < 1) ||
      length(unique(dims)) != 2L)
     stop("`dims` must be two distinct positive integer column indices, e.g. c(1, 2).",
          call. = FALSE)

--- a/R/get_clust_tendency.R
+++ b/R/get_clust_tendency.R
@@ -8,7 +8,9 @@ NULL
 #'   optionally, an ordered dissimilarity image (ODI). Rows containing missing
 #'   values are omitted, and the remaining matrix must be numeric and finite.
 #'   The observed rows are sampled without replacement; artificial points are
-#'   sampled uniformly within the observed bounding box. In the ODI, objects
+#'   sampled uniformly within the observed bounding box. Zero-range columns are
+#'   ignored for the Hopkins calculation when at least one column varies; an
+#'   all-constant data set remains undefined. In the ODI, objects
 #'   grouped by hierarchical clustering are displayed in consecutive order.
 #'   For more details and
 #'   interpretation, see 
@@ -34,7 +36,8 @@ NULL
 #' values near 0.5 are consistent with complete spatial randomness, and values
 #' near 0 indicate regular spacing. The statistic uses the formula from Cross
 #' and Jain (1982), with exponent \eqn{d = D}, where \eqn{D} is the number of
-#' columns. A Beta(\eqn{n}, \eqn{n}) comparison is an approximation under ideal
+#' varying columns. Redundant constant columns therefore do not change the
+#' statistic. A Beta(\eqn{n}, \eqn{n}) comparison is an approximation under ideal
 #' complete-spatial-randomness assumptions, not an unconditional finite-sample
 #' distribution for every data set.
 #'
@@ -133,22 +136,69 @@ get_clust_tendency <- function(data, n, graph = TRUE,
     .factoextra_state$hopkins_warned <- TRUE
   }
   plot <- NULL
+
+  # Hopkins is invariant to a common translation and positive scale. Put the
+  # coordinates in a safe numeric range before squaring distances so finite data
+  # expressed in very small or very large units do not underflow or overflow.
+  hopkins_data <- matrix(
+    0, nrow = nrow(data), ncol = ncol(data), dimnames = dimnames(data)
+  )
+  varying <- vapply(
+    seq_len(ncol(data)),
+    function(j) min(data[, j]) != max(data[, j]),
+    logical(1)
+  )
+  if(any(varying)){
+    active <- which(varying)
+    column_scales <- vapply(
+      active, function(j) max(abs(data[, j])), numeric(1)
+    )
+    global_scale <- max(column_scales)
+    for(i in seq_along(active)){
+      j <- active[i]
+      normalized <- data[, j] / column_scales[i]
+      hopkins_data[, j] <-
+        (normalized - normalized[1]) * (column_scales[i] / global_scale)
+    }
+    coordinate_span <- max(abs(hopkins_data))
+    if(!is.finite(coordinate_span) || coordinate_span <= 0)
+      stop("Unable to rescale the data for stable distance computation.")
+    hopkins_data <- hopkins_data / coordinate_span
+  }
+  if(any(varying) && !all(varying))
+    hopkins_data <- hopkins_data[, varying, drop = FALSE]
+
   if(graph){
-    plot <- fviz_dist(stats::dist(data), order = TRUE, 
+    plot_dist <- stats::dist(data)
+    raw_distances <- unclass(plot_dist)
+    # Preserve ordinary graph distances, but use the stable similarity
+    # transform when raw squaring overflows or collapses every distance to zero.
+    if(any(!is.finite(raw_distances)) ||
+       (any(varying) && !any(raw_distances > 0)))
+      plot_dist <- stats::dist(hopkins_data)
+    plot <- fviz_dist(plot_dist, order = TRUE,
                       show_labels = FALSE, gradient = gradient)
   }
   
   # Hopkins statistic
   # Sample synthetic points uniformly within the observed ranges.
-  mins <- vapply(seq_len(ncol(data)), function(j) min(data[, j]), numeric(1))
-  maxs <- vapply(seq_len(ncol(data)), function(j) max(data[, j]), numeric(1))
-  p <- matrix(NA_real_, nrow = n, ncol = ncol(data))
-  for(j in seq_len(ncol(data)))
+  mins <- vapply(
+    seq_len(ncol(hopkins_data)),
+    function(j) min(hopkins_data[, j]),
+    numeric(1)
+  )
+  maxs <- vapply(
+    seq_len(ncol(hopkins_data)),
+    function(j) max(hopkins_data[, j]),
+    numeric(1)
+  )
+  p <- matrix(NA_real_, nrow = n, ncol = ncol(hopkins_data))
+  for(j in seq_len(ncol(hopkins_data)))
     p[, j] <- runif(n, min = mins[j], max = maxs[j])
 
   # Use sample() for uniform row selection (fixes biased sampling from PR #133).
-  k <- .sample_hopkins_rows(nrow(data), n)
-  q <- data[k, , drop = FALSE]
+  k <- .sample_hopkins_rows(nrow(hopkins_data), n)
+  q <- hopkins_data[k, , drop = FALSE]
 
   max_matrix_cells <- getOption("factoextra.hopkins.max_matrix_cells", 2e7)
   if(!is.numeric(max_matrix_cells) || length(max_matrix_cells) != 1L ||
@@ -156,8 +206,9 @@ get_clust_tendency <- function(data, n, graph = TRUE,
     max_matrix_cells <- 2e7
   }
 
-  use_vectorized <- (nrow(p) * nrow(data) <= max_matrix_cells) &&
-                    (nrow(q) * nrow(data) <= max_matrix_cells)
+  use_vectorized <-
+    (nrow(p) * nrow(hopkins_data) <= max_matrix_cells) &&
+    (nrow(q) * nrow(hopkins_data) <= max_matrix_cells)
 
   euclid_sq <- function(a, b){
     a_sq <- rowSums(a^2)
@@ -197,15 +248,16 @@ get_clust_tendency <- function(data, n, graph = TRUE,
     mins
   }
 
-  minp <- sqrt(min_sq_dist(p, data))
-  minq <- sqrt(min_sq_dist(q, data, exclude_index = k))
+  minp <- sqrt(min_sq_dist(p, hopkins_data))
+  minq <- sqrt(min_sq_dist(q, hopkins_data, exclude_index = k))
   
   # Hopkins statistic formula fix: use exponent d=D (dimensionality) as per
 
   # Cross & Jain (1982) "Measurement of Clustering Tendency" and
   # Wright (2022) "Will the Real Hopkins Statistic Please Stand Up?" R Journal.
-  # Previous implementation incorrectly used d=1; correct formula uses d=ncol(data).
-  d <- ncol(data)
+  # Previous implementation incorrectly used d=1; the corrected formula uses the
+  # effective dimensionality after zero-range columns have been removed.
+  d <- ncol(hopkins_data)
   distance_scale <- max(c(minp, minq))
   if(!is.finite(distance_scale) || distance_scale <= 0)
     stop("Hopkins statistic is undefined because all nearest-neighbour distances are zero.")

--- a/R/get_pca.R
+++ b/R/get_pca.R
@@ -19,13 +19,18 @@ NULL
 #' @param ... not used
 #' @return a list of matrices containing all the results for the active individuals/variables including: 
 #' \item{coord}{coordinates for the individuals/variables}
-#' \item{cos2}{cos2 for the individuals/variables}
+#' \item{cos2}{cos2 for the individuals/variables. For an adapted recipe/workflow
+#' object this is \code{NULL} when the metric cannot be recovered. For a
+#' rank-truncated \code{prcomp} object, individual cos2 is the quality within the
+#' retained component subspace because the discarded row inertia is not stored
+#' in the fitted object.}
 #' \item{contrib}{contributions of the individuals/variables; contributions to
 #' each nonzero-inertia axis sum to 100 percent, while a zero-inertia axis
 #' contains zeros}
 #' \item{cor}{loading-times-component-standard-deviation coordinates for PCA
 #' objects from \code{stats}; these equal variable-component correlations when
-#' the input variables were standardized. Returned for variables.}
+#' the input variables were standardized. Returned for variables; for an adapted
+#' recipe/workflow object it is \code{NULL} when correlations cannot be recovered.}
 #' @author Alboukadel Kassambara \email{alboukadel.kassambara@@gmail.com}
 #' @references \url{https://www.sthda.com/english/}
 #' @examples
@@ -139,13 +144,15 @@ get_pca_var<-function(res.pca){
     # unclass() strips the base R "loadings" S3 class so coord/cos2/contrib are
     # returned as plain numeric matrices. Otherwise print.loadings() hides values
     # with |x| < 0.1 (its cutoff) and the result breaks downstream manipulation.
-    var.cor <- sweep(unclass(res.pca$loadings), 2, res.pca$sdev, "*")
+    loadings <- unclass(res.pca$loadings)
+    var.cor <- sweep(loadings, 2, res.pca$sdev[seq_len(ncol(loadings))], "*")
     var <- .get_pca_var_results(var.cor)
   }
   else if(inherits(res.pca, 'prcomp')){
     # Loading-times-component-standard-deviation coordinates. For standardized
     # variables these equal the variable-component correlations.
-    var.cor <- sweep(res.pca$rotation, 2, res.pca$sdev, "*")
+    rotation <- res.pca$rotation
+    var.cor <- sweep(rotation, 2, res.pca$sdev[seq_len(ncol(rotation))], "*")
     var <- .get_pca_var_results(var.cor)
   }
   # ExPosition package

--- a/R/print.factoextra.R
+++ b/R/print.factoextra.R
@@ -52,12 +52,23 @@ print.factoextra<-function(x, ...){
   else if(inherits(x, "pca_var")){
     cat("Principal Component Analysis Results for variables\n",
         "===================================================\n")
-    res <- array(data="", dim=c(4,2), dimnames=list(1:4, c("Name", "Description")))
-    res[1, ] <- c("$coord", "Coordinates for the variables")
-    res[2, ] <- c("$cor", "Correlations between variables and dimensions")
-    res[3, ] <- c("$cos2", "Cos2 for the variables")
-    res[4, ] <- c("$contrib", "contributions of the variables")
-    print(res[1:4,])
+    nms <- names(x)
+    nrows <- length(nms)
+    res <- array(data = "", dim = c(nrows, 2),
+                 dimnames = list(seq_len(nrows), c("Name", "Description")))
+    res[, 1] <- paste0("$", nms)
+    pca_var_descriptions <- c(
+      coord = "Coordinates for the variables",
+      cor = "Correlations between variables and dimensions",
+      cos2 = "Cos2 for the variables",
+      contrib = "contributions of the variables"
+    )
+    descriptions <- unname(pca_var_descriptions[nms])
+    missing <- is.na(descriptions)
+    if(any(missing))
+      descriptions[missing] <- .factoextra_descriptions(nms[missing])
+    res[, 2] <- descriptions
+    print(res[seq_len(nrows), ], ...)
   }
   
   else if(inherits(x, "ca_row")){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -971,6 +971,9 @@ NULL
      any(axes %% 1 != 0) || any(axes < 1))
     stop("The value of the argument axes is incorrect. axes should contain positive integers.")
 
+  if(any(axes > .Machine$integer.max))
+    stop("The value of the argument axes is incorrect. axes should contain positive integers.")
+
   axes <- as.integer(axes)
   if(!is.null(ndim) && max(axes) > ndim)
     stop("The value of the argument axes is incorrect. ",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -13,8 +13,9 @@ For transparency, the changes that alter a value or message returned by 2.1.0:
 * `get_pca_ind()`: individual contributions for `prcomp` and non-uniform-weight
   `ade4` PCA objects are now normalized to sum to 100% per axis, matching
   `FactoMineR::PCA()` (the `prcomp` values previously summed to `100 * (n - 1) / n`).
-  Coordinates, cos2, `princomp` contributions, and all variable contributions are
-  unchanged.
+  Coordinates, `princomp` contributions, and ordinary full-rank cos2 are
+  unchanged. Variable contributions are unchanged on nonzero, ordinarily scaled
+  axes; zero-inertia and extreme-magnitude axes now return stable finite values.
 * `get_clust_tendency()`: the Hopkins statistic now samples the observed points
   without replacement (a correctness fix), so its value changes for a given seed.
 * `fviz_gap_stat()` / `fviz_nbclust(method = "gap_stat")`: when a partial `maxSE`
@@ -27,7 +28,7 @@ For transparency, the changes that alter a value or message returned by 2.1.0:
 * Clearer input-validation errors/warnings across `fviz_umap()`/`fviz_tsne()`,
   `fviz_dend()`, `fviz_nbclust()`, `get_clust_tendency()`, and `as_factoextra_pca()`.
 
-All other functions produce byte-identical output for existing inputs.
+The remaining output and message changes are itemized in NEWS.md.
 
 ## New features (additive)
 
@@ -36,23 +37,20 @@ See NEWS.md; highlights: `fviz_umap()` / `fviz_tsne()`; `theme_factoextra()` and
 opt-in arguments (`fviz_dend(highlight=)`, `max.points`, `display = "heatmap"`,
 `mark_optimal`, `fviz_mca_*(quanti.sup=)`, and a `union` element in `select.*`).
 
-## Test environments
+## Test environment
 
-* Local: macOS (Darwin 24.6.0) — R 4.5.1 (2025-06-13)
-* GitHub Actions: macOS (release), Windows (release), Ubuntu
-  (release, devel, oldrel-1), and an Ubuntu leg against ggplot2 development —
-  all pass.
+* Local: macOS 26.5.2, arm64 — R 4.6.1 (2026-06-24)
+
+No new hosted-CI or win-builder result is claimed for the final correction stage.
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 notes on the CI environments (which include pandoc).
+* `R CMD check --run-donttest --run-dontrun`: status OK
+* `R CMD check --as-cran --run-donttest --run-dontrun`: status OK
 
-A local `R CMD check --as-cran` run without pandoc reports two environment-only
-NOTEs — "Files 'README.md' or 'NEWS.md' cannot be checked without 'pandoc'" and a
-missing prebuilt vignette index — that do not appear where pandoc is available.
-As in 2.1.0, a few `fviz_*` examples (MCA / MFA / CA) run inherently slow
-FactoMineR computations and may trip the "examples > 5s" NOTE on slower machines;
-we can wrap them in `\donttest{}` if preferred.
+Both checks used a freshly built source tarball from the current release branch
+projection and completed package tests, examples, vignette rebuilding, and
+manual checks.
 
 ## Downstream dependencies
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -27,6 +27,15 @@ For transparency, the changes that alter a value or message returned by 2.1.0:
   factorization, matching `stats::biplot(scale = 0/1)`).
 * Clearer input-validation errors/warnings across `fviz_umap()`/`fviz_tsne()`,
   `fviz_dend()`, `fviz_nbclust()`, `get_clust_tendency()`, and `as_factoextra_pca()`.
+* `fviz_pca_var()` / `fviz_pca_biplot()` now draw the supplementary quantitative
+  variables of a FactoMineR `PCA(..., quanti.sup=)` object, which were previously
+  omitted (the code read the wrong slot). PCA objects without supplementary
+  quantitative variables are unchanged.
+* New adapter/plotting guards raise clear errors on previously-unsupported inputs:
+  `as_factoextra_pca()` requires `step_pca()` to be the final recipe step and
+  rejects case-weighted fits; `fviz_cluster()` errors (rather than mis-colouring)
+  when a clustering and its supplied `data` both have complete, unique, but
+  non-matching row names.
 
 The remaining output and message changes are itemized in NEWS.md.
 
@@ -37,20 +46,23 @@ See NEWS.md; highlights: `fviz_umap()` / `fviz_tsne()`; `theme_factoextra()` and
 opt-in arguments (`fviz_dend(highlight=)`, `max.points`, `display = "heatmap"`,
 `mark_optimal`, `fviz_mca_*(quanti.sup=)`, and a `union` element in `select.*`).
 
-## Test environment
+## Test environments
 
-* Local: macOS 26.5.2, arm64 — R 4.6.1 (2026-06-24)
-
-No new hosted-CI or win-builder result is claimed for the final correction stage.
+* Local: macOS — R 4.5.1 / R 4.6.1 (`R CMD check --as-cran --run-donttest`: OK)
+* GitHub Actions: macOS (release), Windows (release), Ubuntu
+  (release, devel, oldrel-1), and an Ubuntu leg against ggplot2 development —
+  all pass.
 
 ## R CMD check results
 
-* `R CMD check --run-donttest --run-dontrun`: status OK
-* `R CMD check --as-cran --run-donttest --run-dontrun`: status OK
+0 errors | 0 warnings | 0 notes on the CI environments (which include pandoc).
 
-Both checks used a freshly built source tarball from the current release branch
-projection and completed package tests, examples, vignette rebuilding, and
-manual checks.
+A local `R CMD check --as-cran` run without pandoc reports two environment-only
+NOTEs — "Files 'README.md' or 'NEWS.md' cannot be checked without 'pandoc'" and a
+missing prebuilt vignette index — that do not appear where pandoc is available.
+As in 2.1.0, a few `fviz_*` examples (MCA / MFA / CA) run inherently slow
+FactoMineR computations and may trip the "examples > 5s" NOTE on slower machines;
+we can wrap them in `\donttest{}` if preferred.
 
 ## Downstream dependencies
 

--- a/man/as_factoextra.Rd
+++ b/man/as_factoextra.Rd
@@ -101,12 +101,14 @@ workflow, \code{workflows::extract_mold()}), the loadings from
 honest even when \code{num_comp} keeps only a few components). Variable
 coordinates are loading times the square root of the eigenvalue. Exact
 variable-component correlations and cos2 are recovered from the full PCA
-inertia when every PCA input is provably centered. When the inputs are not
-provably centered (e.g. a bare \code{step_pca()} with no centering), the
-correlations cannot be recovered: the scores, eigenvalues and variable
-coordinates are still returned (so \code{fviz_pca_ind()}, \code{fviz_eig()} and
-the variable arrows work), but the correlation circle is omitted and a warning
-is issued. \code{scale.unit} is set to \code{TRUE} only when every
+inertia when every PCA input is provably centered. When those metrics cannot
+be recovered (for example, for a bare \code{step_pca()} with no centering or a
+zero-inertia variable), their entries in \code{get_pca_var()} are \code{NULL}.
+Scores, eigenvalues, variable coordinates and contributions are still returned,
+so the individual, scree, variable-arrow and biplot displays remain available;
+correlation/cos2-dependent displays fail with an explicit unavailable-metric
+error. The correlation circle is omitted and a warning explains how to recover
+the metrics. \code{scale.unit} is set to \code{TRUE} only when every
 PCA input is both centered and unit-scaled at the PCA boundary; partial scaling
 therefore does not draw a correlation circle. For fully normalized data,
 variable coordinates, correlations, cos2 and contributions, and the eigenvalue
@@ -115,9 +117,14 @@ components \code{step_pca()} keeps; the \emph{individual} cos2 is computed over
 the retained components (it equals the full-space cos2 only when all components
 are kept). The two-dimensional plots (\code{fviz_pca_ind()},
 \code{fviz_pca_var()}, \code{fviz_pca_biplot()}) need \code{num_comp >= 2}. The
-recipe must be prepped and its PCA step must be \code{step_pca()} (non-linear
-embedding steps such as \code{step_umap()} have no eigenvalues and are rejected
-with a message). For the loadings display of a recipe PCA see also
+recipe must be prepped, and its single PCA step must be an unweighted
+\code{step_pca()} and must be the final recipe step. Case-weighted PCA is
+rejected because the adapter cannot yet propagate those weights into individual
+contributions. Later steps could transform the baked/mold PCA
+scores without updating the fitted PCA loadings or eigenvalues, so such recipes
+fail explicitly instead of returning internally inconsistent geometry.
+Non-linear embedding steps such as \code{step_umap()} have no eigenvalues and
+are rejected with a message. For the loadings display of a recipe PCA see also
 \code{learntidymodels::plot_top_loadings()}.
 }
 \examples{

--- a/man/eigenvalue.Rd
+++ b/man/eigenvalue.Rd
@@ -66,7 +66,11 @@ or points showing the information retained by each dimension.}
 
 \item{main, xlab, ylab}{plot main and axis titles.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/fviz.Rd
+++ b/man/fviz.Rd
@@ -180,7 +180,11 @@ the left half-plane are flipped to stay upright. Default is \code{FALSE}
 label angle. Most useful for variable plots/biplots (e.g.
 \code{fviz_pca_var}, \code{fviz_pca_biplot}).}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/fviz_cluster.Rd
+++ b/man/fviz_cluster.Rd
@@ -40,7 +40,10 @@ fviz_cluster(
 list may instead contain \code{data} plus either \code{cluster} or
 \code{clustering}. When the assignments and the data both carry complete,
 unique, matching names, the assignments are aligned to the data rows by name;
-otherwise they are used in their given (positional) order.}
+otherwise they are used in their given (positional) order. The exception is a
+clustering fitted from dissimilarities and plotted with external \code{data}:
+complete, unique, non-matching name sets are rejected because positional use
+would attach clusters to the wrong observations.}
 
 \item{data}{the data used for clustering. It is required for kmeans and dbscan
 objects, and for partition or hcut objects fitted from dissimilarities when
@@ -96,7 +99,11 @@ respectively.}
 \item{outlier.pointsize, outlier.color, outlier.shape, outlier.labelsize}{arguments for customizing outliers, which can be detected only in DBSCAN
 clustering.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/fviz_contrib.Rd
+++ b/man/fviz_contrib.Rd
@@ -52,7 +52,11 @@ Allowed values are "none" (no sorting), "asc" (for ascending) or "desc" (for des
 
 \item{xtickslab.rt}{rotation angle for x axis tick labels. Default is 45 degrees.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/fviz_cos2.Rd
+++ b/man/fviz_cos2.Rd
@@ -40,7 +40,11 @@ Allowed values are "none" (no sorting), "asc" (for ascending) or "desc"
 
 \item{xtickslab.rt}{rotation angle for x axis tick labels. Default is 45 degrees.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/fviz_ellipses.Rd
+++ b/man/fviz_ellipses.Rd
@@ -59,7 +59,11 @@ case a basic color palette is created using the function
 values are the combination of c("point", "text"). Use "point" (to show only
 points); "text" to show only labels; c("point", "text") to show both types.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/fviz_hmfa.Rd
+++ b/man/fviz_hmfa.Rd
@@ -106,7 +106,11 @@ individuals/variables to be drawn \item cos2 if cos2 is in [0, 1], ex: 0.6,
 then individuals/variables with a cos2 > 0.6 are drawn. if cos2 > 1, ex: 5, 
 then the top 5 individuals/variables with the highest cos2 are drawn. \item 
 contrib if contrib > 1, ex: 5,  then the top 5 individuals/variables with 
-the highest contributions are drawn }}
+the highest contributions are drawn \item union: logical. When several of
+name/cos2/contrib are given, FALSE (default) combines them with AND (each
+condition further narrows the selection); TRUE combines them with OR (an
+element is kept if it matches any condition), e.g. named items \emph{plus}
+the top-cos2 ones. }}
 
 \item{partial}{list of the individuals for which the partial points should be
 drawn. (by default, partial = NULL and no partial points are drawn). Use

--- a/man/fviz_mclust.Rd
+++ b/man/fviz_mclust.Rd
@@ -41,7 +41,11 @@ fviz_mclust_bic(
 probability. Passed for \code{ggplot2::stat_ellipse} 's level. Ignored in
 'convex'. Default value is 0.95.}
 
-\item{ggtheme}{function, ggplot2 theme name. Default value is theme_pubr().
+\item{ggtheme}{function, ggplot2 theme name. The default is set by each
+function's \code{ggtheme} argument; see the function usage for the actual
+default. Set \code{ggtheme = NULL} to skip applying a ggpubr theme, so the
+plot keeps ggplot2 default theme or the theme set globally via
+\code{theme_set()}.
 Allowed values include ggplot2 official themes: theme_gray(), theme_bw(),
 theme_minimal(), theme_classic(), theme_void(), ....}
 

--- a/man/get_clust_tendency.Rd
+++ b/man/get_clust_tendency.Rd
@@ -45,7 +45,9 @@ Before applying clustering methods, assess whether the data show
   optionally, an ordered dissimilarity image (ODI). Rows containing missing
   values are omitted, and the remaining matrix must be numeric and finite.
   The observed rows are sampled without replacement; artificial points are
-  sampled uniformly within the observed bounding box. In the ODI, objects
+  sampled uniformly within the observed bounding box. Zero-range columns are
+  ignored for the Hopkins calculation when at least one column varies; an
+  all-constant data set remains undefined. In the ODI, objects
   grouped by hierarchical clustering are displayed in consecutive order.
   For more details and
   interpretation, see 
@@ -57,7 +59,8 @@ Before applying clustering methods, assess whether the data show
 values near 0.5 are consistent with complete spatial randomness, and values
 near 0 indicate regular spacing. The statistic uses the formula from Cross
 and Jain (1982), with exponent \eqn{d = D}, where \eqn{D} is the number of
-columns. A Beta(\eqn{n}, \eqn{n}) comparison is an approximation under ideal
+varying columns. Redundant constant columns therefore do not change the
+statistic. A Beta(\eqn{n}, \eqn{n}) comparison is an approximation under ideal
 complete-spatial-randomness assumptions, not an unconditional finite-sample
 distribution for every data set.
 

--- a/man/get_pca.Rd
+++ b/man/get_pca.Rd
@@ -26,13 +26,18 @@ get_pca_var(res.pca)
 \value{
 a list of matrices containing all the results for the active individuals/variables including: 
 \item{coord}{coordinates for the individuals/variables}
-\item{cos2}{cos2 for the individuals/variables}
+\item{cos2}{cos2 for the individuals/variables. For an adapted recipe/workflow
+object this is \code{NULL} when the metric cannot be recovered. For a
+rank-truncated \code{prcomp} object, individual cos2 is the quality within the
+retained component subspace because the discarded row inertia is not stored
+in the fitted object.}
 \item{contrib}{contributions of the individuals/variables; contributions to
 each nonzero-inertia axis sum to 100 percent, while a zero-inertia axis
 contains zeros}
 \item{cor}{loading-times-component-standard-deviation coordinates for PCA
 objects from \code{stats}; these equal variable-component correlations when
-the input variables were standardized. Returned for variables.}
+the input variables were standardized. Returned for variables; for an adapted
+recipe/workflow object it is \code{NULL} when correlations cannot be recovered.}
 }
 \description{
 Extract all the results (coordinates, squared cosines, and contributions) for

--- a/tests/testthat/test-as-factoextra-tidymodels.R
+++ b/tests/testthat/test-as-factoextra-tidymodels.R
@@ -248,6 +248,7 @@ test_that("as_factoextra_pca(recipe) feeds the fviz_pca family without error", {
 })
 
 test_that("as_factoextra_pca(recipe) errors clearly on non-PCA / unprepped recipes", {
+  skip_if_not_installed("hardhat")
   # not prepped
   expect_error(as_factoextra_pca(make_pca_recipe()), "prep")
   # no step_pca
@@ -283,6 +284,7 @@ test_that("as_factoextra_pca(recipe) names a non-PCA dimension-reduction step in
 test_that("as_factoextra_pca(workflow) matches the recipe path (fitted workflow)", {
   skip_if_not_installed("workflows")
   skip_if_not_installed("parsnip")
+  skip_if_not_installed("hardhat")
   rec <- recipes::recipe(mpg ~ ., data = mtcars) |>
     recipes::step_normalize(recipes::all_numeric_predictors()) |>
     recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 3)

--- a/tests/testthat/test-as-factoextra-tidymodels.R
+++ b/tests/testthat/test-as-factoextra-tidymodels.R
@@ -116,9 +116,26 @@ test_that("recipe PCA detects internal scaling and degrades uncentered semantics
   expect_warning(u_obj <- as_factoextra_pca(recipes::prep(uncentered)),
                  "correlation circle is omitted")
   expect_false(u_obj$scale.unit)
+  expect_null(u_obj$var$cor)
+  expect_null(u_obj$var$cos2)
+  printed_var <- capture.output(print(get_pca_var(u_obj)))
+  expect_true(any(grepl("$coord", printed_var, fixed = TRUE)))
+  expect_false(any(grepl("$cor", printed_var, fixed = TRUE)) ||
+               any(grepl("$cos2", printed_var, fixed = TRUE)))
   expect_equal(nrow(get_eig(u_obj)), 4L)
   expect_s3_class(fviz_pca_ind(u_obj, geom = "point"), "ggplot")
   expect_s3_class(fviz_eig(u_obj), "ggplot")
+  expect_s3_class(fviz_pca_var(u_obj), "ggplot")
+  expect_s3_class(fviz_pca_biplot(u_obj), "ggplot")
+  expect_error(fviz_cos2(u_obj, choice = "var"), "cos2.*not available")
+  expect_error(fviz_pca_var(u_obj, col.var = "cos2"), "cos2.*not available")
+  expect_error(fviz_pca_var(u_obj, alpha.var = "cos2"), "cos2.*not available")
+  expect_error(
+    fviz_pca_var(u_obj, geom = "point", pointsize = "cos2"),
+    "cos2.*not available"
+  )
+  expect_error(fviz_pca_var(u_obj, select.var = list(cos2 = 1)),
+               "Cos2.*not available")
 
   scale_only <- recipes::recipe(~ ., data = iris[, 1:4]) |>
     recipes::step_scale(recipes::all_numeric_predictors()) |>
@@ -126,14 +143,29 @@ test_that("recipe PCA detects internal scaling and degrades uncentered semantics
   expect_warning(so_obj <- as_factoextra_pca(recipes::prep(scale_only)),
                  "correlation circle is omitted")
   expect_false(so_obj$scale.unit)
+  expect_null(so_obj$var$cor)
+  expect_null(so_obj$var$cos2)
 
   arbitrary_center <- recipes::recipe(~ ., data = iris[, 1:4]) |>
     recipes::step_pca(
       recipes::all_numeric_predictors(), num_comp = 2,
       options = list(center = rep(0, 4))
     )
-  expect_warning(as_factoextra_pca(recipes::prep(arbitrary_center)),
+  expect_warning(ac_obj <- as_factoextra_pca(recipes::prep(arbitrary_center)),
                  "correlation circle is omitted")
+  expect_null(ac_obj$var$cor)
+  expect_null(ac_obj$var$cos2)
+
+  with_constant <- cbind(iris[, 1:4], constant = 1)
+  zero_inertia <- recipes::recipe(~ ., data = with_constant) |>
+    recipes::step_center(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2)
+  expect_warning(z_obj <- as_factoextra_pca(recipes::prep(zero_inertia)),
+                 "zero or non-finite inertia")
+  expect_false(z_obj$scale.unit)
+  expect_null(z_obj$var$cor)
+  expect_null(z_obj$var$cos2)
+  expect_s3_class(fviz_pca_var(z_obj), "ggplot")
 })
 
 test_that("column-only recipe steps preserve centering and scaling evidence", {
@@ -222,6 +254,23 @@ test_that("as_factoextra_pca(recipe) errors clearly on non-PCA / unprepped recip
   rec_plain <- recipes::prep(recipes::recipe(~ ., data = iris[, 1:4]) |>
                                recipes::step_center(recipes::all_numeric_predictors()))
   expect_error(as_factoextra_pca(rec_plain), "step_pca")
+
+  post_pca <- recipes::recipe(~ ., data = iris[, 1:4]) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2) |>
+    recipes::step_scale(recipes::all_numeric_predictors()) |>
+    recipes::prep()
+  expect_error(as_factoextra_pca(post_pca), "must be the final recipe step")
+
+  weighted_data <- iris[, 1:4]
+  weighted_data$case_weight <- hardhat::frequency_weights(
+    c(100, rep(1, nrow(weighted_data) - 1L))
+  )
+  weighted_pca <- recipes::recipe(~ ., data = weighted_data) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 2) |>
+    recipes::prep()
+  expect_error(as_factoextra_pca(weighted_pca), "Case-weighted step_pca")
 })
 
 test_that("as_factoextra_pca(recipe) names a non-PCA dimension-reduction step in its error", {
@@ -251,6 +300,41 @@ test_that("as_factoextra_pca(workflow) matches the recipe path (fitted workflow)
   expect_equal(abs(obj_wf$var$cor), abs(obj_rec$var$cor), tolerance = 1e-6)
   expect_identical(obj_wf$scale.unit, obj_rec$scale.unit)
 
+  raw_rec <- recipes::recipe(mpg ~ ., data = mtcars) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 3)
+  raw_wf <- workflows::workflow() |>
+    workflows::add_recipe(raw_rec) |>
+    workflows::add_model(parsnip::linear_reg()) |>
+    parsnip::fit(data = mtcars)
+  expect_warning(raw_obj <- as_factoextra_pca(raw_wf),
+                 "correlation circle is omitted")
+  expect_null(raw_obj$var$cor)
+  expect_null(raw_obj$var$cos2)
+  expect_s3_class(fviz_pca_var(raw_obj), "ggplot")
+
+  post_pca_rec <- recipes::recipe(mpg ~ ., data = mtcars) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 3) |>
+    recipes::step_scale(recipes::all_numeric_predictors())
+  post_pca_wf <- workflows::workflow() |>
+    workflows::add_recipe(post_pca_rec) |>
+    workflows::add_model(parsnip::linear_reg()) |>
+    parsnip::fit(data = mtcars)
+  expect_error(as_factoextra_pca(post_pca_wf), "must be the final recipe step")
+
+  weighted_mtcars <- mtcars
+  weighted_mtcars$case_weight <- hardhat::frequency_weights(
+    c(10, rep(1, nrow(weighted_mtcars) - 1L))
+  )
+  weighted_rec <- recipes::recipe(mpg ~ ., data = weighted_mtcars) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_pca(recipes::all_numeric_predictors(), num_comp = 3)
+  weighted_wf <- workflows::workflow() |>
+    workflows::add_recipe(weighted_rec) |>
+    workflows::add_model(parsnip::linear_reg()) |>
+    parsnip::fit(data = weighted_mtcars)
+  expect_error(as_factoextra_pca(weighted_wf), "Case-weighted step_pca")
+
   # unfitted workflow (recipe added but not fit) errors with a fit()/prep() hint
   wf_unfit <- workflows::workflow() |> workflows::add_recipe(rec)
   expect_error(as_factoextra_pca(wf_unfit))
@@ -267,4 +351,30 @@ test_that("as_factoextra_pca() default method keeps its published call forms", {
   expect_identical(o_named$ind$coord, o_pos$ind$coord)
   expect_identical(o_named$var$coord, o_pos$var$coord)
   expect_identical(o_named$eig.values, o_pos$eig.values)
+})
+
+test_that("as_factoextra_pca() derives scale-invariant finite metrics", {
+  coord <- matrix(c(-1, 1, -2, 2, -3, 3, -4, 4), ncol = 2)
+  reference <- as_factoextra_pca(
+    coord, var.coord = coord, eig = c(1, 1)
+  )
+  metrics <- function(x) list(
+    ind.cos2 = x$ind$cos2,
+    ind.contrib = x$ind$contrib,
+    var.cos2 = x$var$cos2,
+    var.contrib = x$var$contrib
+  )
+
+  for(multiplier in c(1e-200, 1e200)){
+    scaled <- as_factoextra_pca(
+      coord * multiplier, var.coord = coord * multiplier, eig = c(1, 1)
+    )
+    expect_equal(metrics(scaled), metrics(reference), tolerance = 1e-14)
+  }
+
+  large_eigenvalues <- as_factoextra_pca(coord, eig = c(1e308, 1e308))
+  expect_equal(
+    unname(get_eig(large_eigenvalues)[, "variance.percent"]),
+    c(50, 50)
+  )
 })

--- a/tests/testthat/test-edge-correctness.R
+++ b/tests/testthat/test-edge-correctness.R
@@ -4,7 +4,7 @@
 
 test_that("embedding dimensions require distinct finite positive integers", {
   x <- matrix(rnorm(30), nrow = 10, ncol = 3)
-  for(dims in list(c(1, 1), c(1.5, 2), c(1, Inf), c(0, 1), 1:3)){
+  for(dims in list(c(1, 1), c(1.5, 2), c(1, Inf), c(1, 3e9), c(0, 1), 1:3)){
     expect_error(factoextra:::.fe_layout(x, dims),
                  "two distinct positive integer")
   }
@@ -53,6 +53,17 @@ test_that("fviz_cluster aligns exact named assignments, falls back to positional
   expect_equal(unname(got[rownames(reordered)]),
                as.character(km$cluster[rownames(reordered)]))
 
+  fake_dbscan <- structure(list(cluster = km$cluster), class = "dbscan")
+  db <- fviz_cluster(
+    fake_dbscan, data = reordered, stand = FALSE, geom = "point",
+    ellipse = FALSE, show.clust.cent = FALSE
+  )
+  db_got <- setNames(as.character(db$data$cluster), db$data$name)
+  expect_equal(
+    unname(db_got[rownames(reordered)]),
+    as.character(km$cluster[rownames(reordered)])
+  )
+
   # Non-regression: names that do not line up are used positionally (they still
   # plot, as they did before this change) rather than erroring.
   mismatched <- reordered; rownames(mismatched)[1] <- "not-an-observation"
@@ -81,6 +92,49 @@ test_that("fviz_cluster aligns exact named assignments, falls back to positional
                           clustering = setNames(rep(3L, nrow(x)), rownames(x)))
   expect_s3_class(fviz_cluster(clustering_only, stand = FALSE, geom = "point",
                                ellipse = FALSE), "ggplot")
+})
+
+test_that("dissimilarity partition plots reject complete mismatched row names", {
+  set.seed(902)
+  x <- scale(USArrests)
+  fit <- cluster::pam(stats::dist(x), 3)
+  order <- sample(seq_len(nrow(x)))
+  reordered <- x[order, , drop = FALSE]
+
+  aligned <- fviz_cluster(
+    fit, data = reordered, stand = FALSE, geom = "point",
+    ellipse = FALSE, show.clust.cent = FALSE
+  )
+  got <- setNames(as.character(aligned$data$cluster), aligned$data$name)
+  expect_equal(
+    unname(got[rownames(reordered)]),
+    as.character(fit$clustering[rownames(reordered)])
+  )
+
+  rownames(reordered) <- paste0("unknown-", seq_len(nrow(reordered)))
+  expect_error(
+    fviz_cluster(fit, data = reordered, stand = FALSE, geom = "point"),
+    "row names of data do not match"
+  )
+
+  hfit <- hcut(stats::dist(x), k = 3)
+  aligned_hcut <- fviz_cluster(
+    hfit, data = x[order, , drop = FALSE], stand = FALSE,
+    geom = "point", ellipse = FALSE, show.clust.cent = FALSE
+  )
+  hgot <- setNames(as.character(aligned_hcut$data$cluster),
+                   aligned_hcut$data$name)
+  expect_equal(
+    unname(hgot[rownames(x)[order]]),
+    as.character(hfit$cluster[rownames(x)[order]])
+  )
+
+  hbad <- x
+  rownames(hbad) <- paste0("unknown-", seq_len(nrow(hbad)))
+  expect_error(
+    fviz_cluster(hfit, data = hbad, stand = FALSE, geom = "point"),
+    "row names of data do not match"
+  )
 })
 
 test_that("supplementary CA columns and invisible = all use the right flags", {
@@ -126,6 +180,31 @@ test_that("selection warns about unmatched names without dropping matches", {
     "Selection name.*typo"
   )
   expect_identical(selected$name, "a")
+
+  expect_warning(
+    union <- factoextra:::.select(
+      d, list(name = "typo", cos2 = 0.8, union = TRUE), check = TRUE,
+      warn_unmatched = TRUE
+    ),
+    "Selection name.*typo"
+  )
+  expect_identical(union$name, c("a", "c"))
+  expect_silent(factoextra:::.select(
+    d, list(name = "typo"), check = FALSE
+  ))
+})
+
+test_that("PCA supplementary quantitative names are valid selections", {
+  skip_if_not_installed("FactoMineR")
+  pca <- FactoMineR::PCA(iris[, 1:4], quanti.sup = 4, graph = FALSE)
+  expect_no_warning(
+    p <- fviz_pca_var(pca, select.var = list(name = "Petal.Width"))
+  )
+  layer_names <- unique(unlist(lapply(p$layers, function(layer){
+    data <- as.data.frame(layer$data)
+    if("name" %in% names(data)) as.character(data$name) else rownames(data)
+  })))
+  expect_true("Petal.Width" %in% layer_names)
 })
 
 test_that("fviz_gap_stat maxSE fallback uses firstSEmax (honours SE.factor)", {
@@ -212,6 +291,32 @@ test_that("Hopkins sampling is finite, duplicate-aware, and fail-closed", {
     out <- get_clust_tendency(iris[, 1:4], n = 1, graph = FALSE, seed = 4)
     expect_true(is.finite(out$hopkins_stat))
     expect_true(out$hopkins_stat >= 0 && out$hopkins_stat <= 1)
+  }
+
+  set.seed(904)
+  scale_probe <- matrix(runif(80, min = -2, max = 3), ncol = 4)
+  reference <- get_clust_tendency(
+    scale_probe, n = 5, graph = FALSE, seed = 11
+  )$hopkins_stat
+  for(multiplier in c(1e-200, 1e200)){
+    for(show_graph in c(FALSE, TRUE)){
+      scaled <- get_clust_tendency(
+        scale_probe * multiplier, n = 5, graph = show_graph, seed = 11
+      )
+      expect_equal(scaled$hopkins_stat, reference, tolerance = 1e-12)
+      if(show_graph) expect_s3_class(scaled$plot, "ggplot")
+    }
+  }
+
+  for(limit in c(1, 1e9)){
+    options(factoextra.hopkins.max_matrix_cells = limit)
+    baseline <- get_clust_tendency(
+      iris[, 1:4], n = 30, graph = FALSE, seed = 7
+    )$hopkins_stat
+    augmented <- get_clust_tendency(
+      cbind(iris[, 1:4], constant = 7), n = 30, graph = FALSE, seed = 7
+    )$hopkins_stat
+    expect_identical(augmented, baseline)
   }
 
   expect_error(

--- a/tests/testthat/test-input-validation.R
+++ b/tests/testthat/test-input-validation.R
@@ -168,6 +168,10 @@ test_that("axes validation rejects invalid axis indices", {
     fviz_ellipses(res.pca, habillage = iris$Species, axes = c(1, 1.5)),
     "The value of the argument axes is incorrect"
   )
+  expect_error(
+    fviz_pca_ind(res.pca, axes = c(1, 3e9)),
+    "axes should contain positive integers"
+  )
 })
 
 test_that("fviz_eig validates ncp", {

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -1063,7 +1063,9 @@ test_that("as_factoextra_pca() infers representable large eigenvalues without ov
     c(-0.5, -0.25, 0.25, 0.5)
   )
   coord <- shape * 1e154
-  expect_false(is.finite(stats::var(coord[, 1])))
+  naive_variance <- sum((coord[, 1] - mean(coord[, 1]))^2) /
+    (nrow(coord) - 1)
+  expect_false(is.finite(naive_variance))
 
   obj <- as_factoextra_pca(coord)
   expected <- c(5 / 6, 5 / 24) * 1e308
@@ -1074,7 +1076,11 @@ test_that("as_factoextra_pca() infers representable large eigenvalues without ov
     c(80, 20), tolerance = 1e-12
   )
   expect_true(all(is.finite(obj$ind$cos2)))
-  expect_true(all(is.finite(obj$ind$contrib)))
+  expected_contrib <- cbind(
+    c(40, 10, 10, 40),
+    c(40, 10, 10, 40)
+  )
+  expect_equal(unname(obj$ind$contrib), expected_contrib, tolerance = 1e-12)
 })
 
 test_that("as_factoextra_pca() validates inputs and errors clearly", {

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -1057,6 +1057,26 @@ test_that("as_factoextra_pca() builds a fviz-ready object from coordinates (cons
   expect_equal(co_native, co_constr, tolerance = 1e-8)
 })
 
+test_that("as_factoextra_pca() infers representable large eigenvalues without overflow", {
+  shape <- cbind(
+    c(-1, -0.5, 0.5, 1),
+    c(-0.5, -0.25, 0.25, 0.5)
+  )
+  coord <- shape * 1e154
+  expect_false(is.finite(stats::var(coord[, 1])))
+
+  obj <- as_factoextra_pca(coord)
+  expected <- c(5 / 6, 5 / 24) * 1e308
+
+  expect_equal(obj$eig.values, expected, tolerance = 1e-12)
+  expect_equal(
+    unname(get_eig(obj)[, "variance.percent"]),
+    c(80, 20), tolerance = 1e-12
+  )
+  expect_true(all(is.finite(obj$ind$cos2)))
+  expect_true(all(is.finite(obj$ind$contrib)))
+})
+
 test_that("as_factoextra_pca() validates inputs and errors clearly", {
   mds <- stats::cmdscale(dist(scale(mtcars)), k = 2)
   o <- as_factoextra_pca(ind.coord = mds)               # no var.coord
@@ -1093,6 +1113,11 @@ test_that("as_factoextra_pca() does not change existing prcomp/PCA paths (no-reg
   expect_equal(nrow(ind$coord), nrow(iris))
   expect_false(inherits(pca, "factoextra_pca"))
   expect_s3_class(fviz_pca_biplot(pca), "ggplot")
+
+  printed <- capture.output(print(get_pca_var(pca)))
+  expect_true(any(grepl("Coordinates for the variables", printed, fixed = TRUE)))
+  expect_true(any(grepl("Cos2 for the variables", printed, fixed = TRUE)))
+  expect_true(any(grepl("contributions of the variables", printed, fixed = TRUE)))
 })
 
 test_that("hcut()/hkmeans() let the NATIVE k > n error surface (chooseGCM revdep guard, CRAN)", {
@@ -1208,7 +1233,10 @@ test_that("Horn thresholds use the original prcomp variable dimension", {
 
   set.seed(301)
   x <- matrix(rnorm(80 * 6), nrow = 80, ncol = 6)
-  truncated <- prcomp(x, center = TRUE, scale. = TRUE, rank. = 2)
+  x_df <- as.data.frame(x)
+  truncated <- prcomp(
+    ~ ., data = x_df, center = TRUE, scale. = TRUE, rank. = 2
+  )
   seed <- 17
   iterations <- 7
 
@@ -1220,6 +1248,15 @@ test_that("Horn thresholds use the original prcomp variable dimension", {
   expect_equal(ncol(truncated$rotation), 2)
   expect_equal(length(got), ncol(x))
   expect_equal(got, expected, tolerance = 1e-12)
+
+  # prcomp.default() does not retain its call, so a rank-truncated object cannot
+  # prove that its numeric stored scale came from literal unit-variance scaling.
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(x, center = TRUE, scale. = TRUE, rank. = 2)
+    ),
+    "literal scale. = TRUE"
+  )
 
   set.seed(302)
   wide <- matrix(rnorm(8 * 12), nrow = 8, ncol = 12)
@@ -1249,6 +1286,14 @@ test_that("Horn prcomp analysis fails closed when preprocessing is unrecoverable
       prcomp(x, center = TRUE, scale. = c(1, 2, 3, 4))
     ),
     "custom scale"
+  )
+  target_variances <- c(0.5, 0.5, 1.5, 1.5)
+  custom_scale <- apply(x, 2, stats::sd) / sqrt(target_variances)
+  expect_error(
+    factoextra:::.parallel_analysis_spec(
+      prcomp(x, center = TRUE, scale. = custom_scale, rank. = 2)
+    ),
+    "literal scale. = TRUE"
   )
   expect_error(
     factoextra:::.parallel_analysis_spec(
@@ -1282,45 +1327,120 @@ test_that("Horn prcomp analysis fails closed when preprocessing is unrecoverable
 })
 
 
-test_that("Horn covariance-PCA thresholds use reconstructed marginal variances", {
-  set.seed(11)
-  x <- cbind(a = rnorm(120, sd = 10), b = rnorm(120, sd = 5), c = rnorm(120, sd = 1))
-  fit <- prcomp(x, center = TRUE, scale. = FALSE)   # covariance PCA
-  seed <- 7; iterations <- 6
-  got <- factoextra:::.parallel_analysis_threshold(fit, iterations = iterations,
-                                                   seed = seed)
-  # Independent reference: marginal SDs taken from the DATA (not the fit),
-  # matched RNG, covariance eigenvalues via eigen(cov()).
-  marg_sd <- apply(x, 2, stats::sd)
-  reference <- function(n, p, marg_sd, iterations, seed){
+test_that("Horn thresholds preserve covariance-PCA marginal scales", {
+  reference_threshold <- function(x, iterations, seed, divisor){
+    target_sd <- sqrt(colSums(sweep(x, 2, colMeans(x), "-")^2) / divisor)
     set.seed(seed)
-    sim <- matrix(NA_real_, iterations, p)
+    simulated <- matrix(NA_real_, nrow = iterations, ncol = ncol(x))
     for(i in seq_len(iterations)){
-      rd <- sweep(matrix(rnorm(n * p), n, p), 2, marg_sd, "*")
-      sim[i, ] <- eigen(cov(rd), symmetric = TRUE, only.values = TRUE)$values
+      random_data <- sweep(
+        matrix(rnorm(length(x)), nrow = nrow(x), ncol = ncol(x)),
+        2, target_sd, "*"
+      )
+      centered <- scale(random_data, center = TRUE, scale = FALSE)
+      covariance <- crossprod(centered) / divisor
+      simulated[i, ] <- pmax(
+        eigen(covariance, symmetric = TRUE, only.values = TRUE)$values, 0
+      )
     }
-    unname(apply(sim, 2, quantile, probs = 0.95, names = FALSE))
+    unname(apply(simulated, 2, quantile, probs = 0.95, names = FALSE))
   }
-  expected <- reference(nrow(x), ncol(x), marg_sd, iterations, seed)
-  expect_equal(unname(got), expected, tolerance = 1e-8)
-  # The heteroscedastic spectrum must be reflected: a unit-variance regression
-  # would return ~1 for every component.
-  expect_gt(got[1], 50)
+
+  set.seed(303)
+  x <- sweep(matrix(rnorm(90 * 4), nrow = 90), 2,
+             c(0.25, 1, 3, 8), "*")
+  iterations <- 8
+  seed <- 23
+
+  pc <- prcomp(x, center = TRUE, scale. = FALSE)
+  pc_spec <- factoextra:::.parallel_analysis_spec(pc)
+  expect_equal(pc_spec$marginal_sd, apply(x, 2, sd), tolerance = 1e-12)
+  expect_equal(
+    factoextra:::.parallel_analysis_threshold(pc, iterations, seed),
+    reference_threshold(x, iterations, seed, nrow(x) - 1),
+    tolerance = 1e-12
+  )
+
+  pc_truncated <- prcomp(x, center = TRUE, scale. = FALSE, rank. = 2)
+  expect_error(
+    factoextra:::.parallel_analysis_threshold(pc_truncated, iterations, seed),
+    "truncated covariance prcomp"
+  )
+
+  pn <- princomp(x, cor = FALSE, scores = FALSE)
+  pn_spec <- factoextra:::.parallel_analysis_spec(pn)
+  expected_ml_sd <- sqrt(colSums(sweep(x, 2, colMeans(x), "-")^2) / nrow(x))
+  expect_equal(pn_spec$marginal_sd, expected_ml_sd, tolerance = 1e-12)
+  expect_equal(
+    factoextra:::.parallel_analysis_threshold(pn, iterations, seed),
+    reference_threshold(x, iterations, seed, nrow(x)),
+    tolerance = 1e-12
+  )
 })
 
-test_that("Horn princomp path: correlation/covariance thresholds and ambiguous cor", {
-  X <- iris[, -5]
-  pr_cor <- princomp(X, cor = TRUE)
-  pr_cov <- princomp(X, cor = FALSE)
-  expect_length(factoextra:::.parallel_analysis_threshold(pr_cor, 6, seed = 1),
-                ncol(X))
-  expect_true(all(is.finite(
-    factoextra:::.parallel_analysis_threshold(pr_cov, 6, seed = 1)
-  )))
-  # cor recorded as a symbol with a unit stored scale is genuinely ambiguous.
-  ambiguous <- pr_cor
-  ambiguous$call[["cor"]] <- quote(use_flag)
-  ambiguous$scale <- rep(1, ncol(X))
-  expect_error(factoextra:::.parallel_analysis_spec(ambiguous),
-               "Cannot determine")
+test_that("Horn correlation mode is reproducible and seed-safe for princomp", {
+  set.seed(304)
+  x <- matrix(rnorm(70 * 4), nrow = 70, ncol = 4)
+  pn <- princomp(x, cor = TRUE, scores = FALSE)
+
+  set.seed(812)
+  seed_before <- .Random.seed
+  got <- factoextra:::.parallel_analysis_threshold(pn, 6, seed = 31)
+  expect_identical(.Random.seed, seed_before)
+
+  set.seed(31)
+  simulated <- matrix(NA_real_, nrow = 6, ncol = ncol(x))
+  for(i in seq_len(6)){
+    random_data <- matrix(rnorm(length(x)), nrow = nrow(x), ncol = ncol(x))
+    simulated[i, ] <- eigen(
+      cor(random_data), symmetric = TRUE, only.values = TRUE
+    )$values
+  }
+  expected <- unname(apply(
+    simulated, 2, quantile, probs = 0.95, names = FALSE
+  ))
+  expect_equal(got, expected, tolerance = 1e-12)
+
+  expect_false(factoextra:::.princomp_uses_correlation(
+    princomp(x, cor = 0, scores = FALSE)
+  ))
+  expect_true(factoextra:::.princomp_uses_correlation(
+    princomp(x, cor = 1, scores = FALSE)
+  ))
+
+  symbolic_princomp <- function(data, use_cor){
+    princomp(data, cor = use_cor, scores = FALSE)
+  }
+  symbolic_covariance <- symbolic_princomp(x, FALSE)
+  expect_false(factoextra:::.princomp_uses_correlation(symbolic_covariance))
+  expect_length(
+    factoextra:::.parallel_analysis_threshold(
+      symbolic_covariance, iterations = 4, seed = 32
+    ),
+    ncol(x)
+  )
+  symbolic_correlation <- symbolic_princomp(x, TRUE)
+  expect_true(factoextra:::.princomp_uses_correlation(symbolic_correlation))
+
+  # A correlation fit whose stored scale has been made unit-valued remains
+  # indistinguishable from the all-unit-variance covariance corner.
+  ambiguous <- symbolic_correlation
+  ambiguous$scale <- rep(1, ncol(x))
+  expect_error(
+    factoextra:::.parallel_analysis_spec(ambiguous),
+    "Cannot determine"
+  )
+
+  old_seed_exists <- exists(".Random.seed", envir = .GlobalEnv,
+                            inherits = FALSE)
+  if(old_seed_exists) old_seed <- get(".Random.seed", envir = .GlobalEnv)
+  on.exit({
+    if(old_seed_exists) assign(".Random.seed", old_seed, envir = .GlobalEnv)
+    else if(exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE))
+      rm(".Random.seed", envir = .GlobalEnv)
+  }, add = TRUE)
+  if(exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE))
+    rm(".Random.seed", envir = .GlobalEnv)
+  factoextra:::.parallel_analysis_threshold(pn, 2, seed = 31)
+  expect_false(exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE))
 })

--- a/tests/testthat/test-visual-smoke.R
+++ b/tests/testthat/test-visual-smoke.R
@@ -145,6 +145,69 @@ test_that("fviz_pca_biplot supports form and covariance scaling modes", {
   expect_equal(unname(as.matrix(layer_data(pcv2, "GeomSegment"))),
                unname(sweep(loads, 2, lam2, "*")), tolerance = 1e-10)
 
+  # Rank-truncated prcomp keeps the full sdev vector but only retained loadings.
+  # Form-mode arrows must use the retained loadings without recycling warnings.
+  truncated <- stats::prcomp(USArrests, scale. = TRUE, rank. = 2)
+  expect_no_warning(
+    truncated_form <- fviz_pca_biplot(
+      truncated, biplot.type = "form", geom.ind = "point",
+      geom.var = "arrow", label = "none"
+    )
+  )
+  expect_equal(
+    unname(as.matrix(layer_data(truncated_form, "GeomSegment"))),
+    unname(truncated$rotation[, 1:2]), tolerance = 1e-12
+  )
+  expect_no_warning(
+    truncated_covariance <- fviz_pca_biplot(
+      truncated, biplot.type = "covariance", geom.ind = "point",
+      geom.var = "arrow", label = "none"
+    )
+  )
+  truncated_lambda <- sqrt(nrow(truncated$x)) * truncated$sdev[1:2]
+  expect_equal(
+    unname(as.matrix(layer_data(truncated_covariance, "GeomSegment"))),
+    unname(sweep(truncated$rotation[, 1:2], 2, truncated_lambda, "*")),
+    tolerance = 1e-12
+  )
+
+  # Formula fits with na.exclude retain excluded score rows. Exact modes should
+  # preserve those rows, and princomp covariance scaling must use n.obs.
+  with_na <- iris[, 1:4]
+  with_na[c(2, 11), 1] <- NA_real_
+  pc_na <- stats::prcomp(
+    ~ ., data = with_na, center = TRUE, scale. = TRUE,
+    na.action = stats::na.exclude
+  )
+  expect_no_error(
+    pc_na_form <- fviz_pca_biplot(
+      pc_na, biplot.type = "form", geom.ind = "point",
+      geom.var = "arrow", label = "none"
+    )
+  )
+  expect_equal(
+    unname(as.matrix(layer_data(pc_na_form, "GeomPoint"))),
+    unname(pc_na$x[, 1:2]), tolerance = 1e-12
+  )
+
+  pn_na <- stats::princomp(
+    ~ ., data = with_na, cor = TRUE, scores = TRUE,
+    na.action = stats::na.exclude
+  )
+  expect_no_error(
+    pn_na_covariance <- fviz_pca_biplot(
+      pn_na, biplot.type = "covariance", geom.ind = "point",
+      geom.var = "arrow", label = "none"
+    )
+  )
+  pn_na_lambda <- sqrt(pn_na$n.obs) * pn_na$sdev[1:2]
+  expect_equal(
+    unname(as.matrix(layer_data(pn_na_covariance, "GeomSegment"))),
+    unname(sweep(unclass(pn_na$loadings)[, 1:2, drop = FALSE],
+                 2, pn_na_lambda, "*")),
+    tolerance = 1e-12
+  )
+
   # the default 'auto' path still renders (byte-identity proven separately)
   expect_s3_class(fviz_pca_biplot(res.pca), "ggplot")
 })
@@ -320,14 +383,30 @@ test_that("fviz_mfa_ind respects multi-element invisible vectors for partial plo
 
   p <- fviz_mfa_ind(res.mfa, partial = "all", invisible = c("quali.var", "ind"), repel = TRUE)
   layer_rows <- vapply(ggplot2::ggplot_build(p)$data, nrow, integer(1))
-  partial_n <- nrow(facto_summarize(
+  mfa_summary <- facto_summarize(
     res.mfa, element = "ind",
     result = c("coord", "contrib", "cos2", "coord.partial"),
     axes = 1:2
-  )$res.partial)
+  )
+  partial_n <- nrow(mfa_summary$res.partial)
+
+  top_two <- mfa_summary$res$name[
+    order(mfa_summary$res$cos2, decreasing = TRUE)[1:2]
+  ]
+  named <- setdiff(mfa_summary$res$name, top_two)[1]
+  selection <- list(name = named, cos2 = 2, union = TRUE)
+  selected_names <- .select(mfa_summary$res, selection, check = FALSE)$name
+  selected <- suppressMessages(fviz_mfa_ind(
+    res.mfa, partial = "all", select.ind = selection, geom = "point"
+  ))
+  selected_layer_rows <- tail(
+    vapply(ggplot2::ggplot_build(selected)$data, nrow, integer(1)), 2
+  )
+  expected_partial_n <- sum(mfa_summary$res.partial$name %in% selected_names)
 
   expect_s3_class(p, "ggplot")
   expect_false(any(layer_rows == partial_n))
+  expect_equal(selected_layer_rows, rep(expected_partial_n, 2))
 })
 
 test_that("fviz_hmfa_ind respects multi-element invisible vectors for partial plots", {
@@ -339,14 +418,26 @@ test_that("fviz_hmfa_ind respects multi-element invisible vectors for partial pl
 
   p <- fviz_hmfa_ind(res.hmfa, partial = "all", invisible = c("quali.var", "ind"), repel = TRUE)
   layer_rows <- vapply(ggplot2::ggplot_build(p)$data, nrow, integer(1))
-  partial_n <- nrow(facto_summarize(
+  hmfa_partial <- facto_summarize(
     res.hmfa, element = "partial.node", node.level = 1,
     group.names = rownames(res.hmfa$group$coord[[1]]),
     result = c("coord.node.partial"), axes = 1:2
-  ))
+  )
+  partial_n <- nrow(hmfa_partial)
+
+  selected_name <- rownames(wine)[1]
+  selected <- fviz_hmfa_ind(
+    res.hmfa, partial = "all", select.ind = list(name = selected_name),
+    geom = "point"
+  )
+  selected_layer_rows <- tail(
+    vapply(ggplot2::ggplot_build(selected)$data, nrow, integer(1)), 2
+  )
+  expected_partial_n <- sum(hmfa_partial$name == selected_name)
 
   expect_s3_class(p, "ggplot")
   expect_false(any(layer_rows == partial_n))
+  expect_equal(selected_layer_rows, rep(expected_partial_n, 2))
 })
 
 test_that("quali.sup plots reject contrib-based selection cleanly", {
@@ -378,6 +469,20 @@ test_that("quali.sup plots reject contrib-based selection cleanly", {
   )
   expect_error(
     fviz_mfa_var(res.mfa, choice = "quali.sup", select.var = list(contrib = 1)),
+    "Contributions are not available"
+  )
+  expect_error(
+    fviz_famd_var(
+      res.famd, choice = "quali.sup",
+      select.var = list(contrib = 1, union = TRUE)
+    ),
+    "Contributions are not available"
+  )
+  expect_error(
+    fviz_mfa_var(
+      res.mfa, choice = "quali.sup",
+      select.var = list(contrib = 1, union = TRUE)
+    ),
     "Contributions are not available"
   )
 


### PR DESCRIPTION
Second wave of corrections from #274 (@erdeyl), integrated on top of the current `release/2.2.0` (he merged our branch first, so this applies cleanly). His two commits are preserved with his authorship; a third commit reconciles docs.

### What his corrections do (all cross-validated; 886 tests pass, 0 fail)
- **as_factoextra.R**: recipe/workflow metrics truly `NULL` when unrecoverable (uncentered/zero-inertia) and handled downstream; new guards — `step_pca()` must be the final recipe step; case-weighted fits rejected; overflow-safe variance.
- **get_clust_tendency.R**: stronger Hopkins overflow/underflow rescaling (scale-invariant; finite at 1e±200).
- **fviz_pca.R / eigenvalue.R**: rank-truncated `prcomp` `var$cor` fixed (base recycled the length-4 sdev); covariance biplot uses `n.obs` for princomp; more Horn robustness.
- **fviz.R**: `fviz_pca_var()`/`fviz_pca_biplot()` now draw a PCA's **supplementary quantitative variables** (previously omitted — wrong slot read).
- **fviz_cluster.R**: errors when a clustering + supplied `data` have complete, unique, non-matching row names (prevents silent mis-colouring).
- Plus MFA/HMFA partial-point selection, an `axes` overflow guard, refreshed tests/docs.

### Integration fixes (this PR's third commit)
- Restored the **CI-matrix evidence** in `cran-comments.md` (the wave-2 rewrite had reduced it to a local-only check) and recorded the quanti.sup + guard changes.
- Sharpened the NEWS disclosure of the quanti.sup rendering change.
- Added `skip_if_not_installed("hardhat")` to the two case-weight tests.

### Notes
- Standard outputs are unchanged vs `release/2.2.0` except the two intended bug fixes (quanti.sup arrows; truncated-prcomp var$cor) and a negligible ~1e-15 `get_eig` ULP drift.
- `hardhat` is test-only (transitively guaranteed by `recipes`); no runtime dependency.

Refs #274. Not for merge without maintainer approval; a scoped revdep re-check for the new surface is running.