### PR TITLE
fviz_dend(): make cex control leaf-label size (#281)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -199,6 +199,13 @@
 
 ## Bug fixes
 
+* `fviz_dend()`: the `cex` argument now scales the leaf-label size for the
+  `"rectangle"` and `"circular"` types. The label size was mapped through
+  ggplot2's default continuous size scale, which collapsed a single per-plot
+  `cex` value to a fixed size, so `cex` had no visible effect; leaf labels are
+  now sized directly from `cex` (and a per-leaf `labels_cex` set through
+  dendextend is honoured). At the default `cex = 0.8` the labels are marginally
+  smaller than before. Thanks to @dir21 (#281).
 * `fviz_ca_biplot()` / `fviz_ca()`: `invisible = "col.sup"` now hides
   supplementary columns (the column branch was keyed off the row-supplementary
   flag, so supplementary columns stayed visible). Thanks to @erdeyl (#274).

--- a/R/fviz_dend.R
+++ b/R/fviz_dend.R
@@ -456,6 +456,11 @@ fviz_dend <- function(x, k = NULL, h = NULL, k_colors = NULL, palette = NULL,  s
     p <- p + ggpubr::geom_exec(geom_text, data = data$labels,
                                x = "x", y = "y", label = "label", color = label_cols, size = "cex",
                                 angle = "angle", hjust = "hjust", vjust = "vjust")
+    # Map the label size through an identity scale so `cex` (stored per leaf in
+    # data$labels$cex) sets the text size directly. Without this, ggplot2's
+    # default continuous size scale rescales a single per-plot cex value to a
+    # fixed midpoint, so `cex` had no visible effect on the leaf labels (#281).
+    p <- p + scale_size_identity()
     # Apply a single font face to all leaf labels (e.g. "italic") as a fixed
     # layer parameter. Only when non-default, so the "plain" path is untouched (#121).
     if(!identical(labels_font, "plain"))

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -607,6 +607,44 @@ test_that("fviz_dend keeps leaf labels out of the legend (#14 sibling)", {
   }
 })
 
+test_that("fviz_dend leaf-label size responds to cex (#281)", {
+  skip_if_not_installed("dendextend")
+  hc <- hclust(dist(scale(USArrests)), method = "ward.D2")
+
+  leaf_size <- function(p) {
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))[1]
+    unique(ggplot2::ggplot_build(p)$data[[i]]$size)
+  }
+
+  # BITING: the rendered leaf-text size must scale linearly with cex (5 * cex),
+  # not collapse to a single value. Fails if scale_size_identity() is removed
+  # (the default continuous size scale would map every cex to a fixed midpoint).
+  for (type in c("rectangle", "circular")) {
+    expect_equal(leaf_size(fviz_dend(hc, k = 4, cex = 1.0, type = type)), 5)
+    expect_equal(leaf_size(fviz_dend(hc, k = 4, cex = 0.8, type = type)), 4)
+    expect_equal(leaf_size(fviz_dend(hc, k = 4, cex = 0.4, type = type)), 2)
+  }
+  # horizontal rectangle path too
+  expect_equal(leaf_size(fviz_dend(hc, k = 4, cex = 0.4, horiz = TRUE)), 2)
+
+  # per-leaf cex (a dendextend labels_cex vector) is preserved, not flattened
+  dend <- dendextend::set(as.dendrogram(hc), "labels_cex",
+                          rep(c(1, 0.4), length.out = nobs.hc <- length(hc$order)))
+  sizes <- leaf_size(fviz_dend(dend))
+  expect_setequal(round(sizes, 6), c(5, 2))
+
+  # NO-REGRESSION: the phylogenic path derives label size from font.label
+  # (ggpubr), a separate mechanism this fix does not touch; it still responds
+  # to cex and yields a single GeomText layer.
+  skip_if_not_installed("igraph")
+  psize <- function(cx) {
+    p <- fviz_dend(hc, k = 4, type = "phylogenic", cex = cx)
+    i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))[1]
+    p$layers[[i]]$aes_params$size
+  }
+  expect_gt(psize(1), psize(0.4))
+})
+
 test_that("fviz_dend rectangles match k even with tied heights (#154, #168)", {
   nrects <- function(p) {
     i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomRect"), logical(1)))[1]


### PR DESCRIPTION
## Summary

`fviz_dend()` ignored the `cex` argument for the default `"rectangle"` (and
`"circular"`) dendrogram: the leaf-label size looked the same no matter what
`cex` was set to.

The leaf-label `size` is a mapped aesthetic (`5 * cex`), but the plot had no
identity scale for it, so ggplot2's default continuous size scale rescaled the
single per-plot value to a fixed midpoint — the same rendered size for every
`cex`. This adds `scale_size_identity()` in the label layer so the size is used
directly. A per-leaf `labels_cex` set through dendextend is now honoured too.
The `"phylogenic"` type already sized labels via `font.label` and is unchanged.

## Example

```r
library(factoextra)
library(patchwork)

set.seed(123)
res.hk <- hkmeans(scale(USArrests), 4)

p1 <- fviz_dend(res.hk, cex = 1,   rect = TRUE, main = "cex = 1")
p2 <- fviz_dend(res.hk, cex = 0.8, rect = TRUE, main = "cex = 0.8 (default)")
p3 <- fviz_dend(res.hk, cex = 0.4, rect = TRUE, main = "cex = 0.4")
p1 + p2 + p3
```

![fviz_dend leaf labels now scale with cex](https://i.imgur.com/eCrLT42.png)

## Notes

The change is confined to leaf-label text size in the rectangle/circular
dendrograms; every other layer (branches, cluster rectangles, positions,
colours) is unchanged, as is the phylogenic type. At the default `cex = 0.8`
the leaf labels are marginally smaller than before (the previous fixed size was
a side effect of the collapsed size scale, not a chosen value).

Fixes #281. Reported by @dir21.
